### PR TITLE
fix: simplify plugin names and add usage examples

### DIFF
--- a/plugins/agents-squad/README.md
+++ b/plugins/agents-squad/README.md
@@ -18,6 +18,16 @@ For local development from this repository:
 cline plugin install ./plugins/agents-squad --cwd .
 ```
 
+## Example Usage
+
+After installation, ask Cline:
+
+```text
+Start a code review subagent for this branch, have it focus on correctness and missing tests, then report back with findings.
+```
+
+Cline can use the `start_subagent`, `get_subagent`, and handoff tools from `agents-squad` to run the subagent in the background and bring the result back into the parent session.
+
 ## Requirements
 
 - A Cline host with plugin package support.
@@ -26,4 +36,3 @@ cline plugin install ./plugins/agents-squad --cwd .
 ## Security Notes
 
 Subagents run normal Cline SDK sessions and can use whatever tools the host exposes to them. Review presets before using this in a sensitive workspace.
-

--- a/plugins/agents-squad/package.json
+++ b/plugins/agents-squad/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "cline-agent-squad-plugin",
+	"name": "agents-squad",
 	"version": "0.1.0",
 	"private": true,
 	"description": "Background Subagents Plugin for Cline",

--- a/plugins/automation-events/README.md
+++ b/plugins/automation-events/README.md
@@ -18,6 +18,16 @@ For local development from this repository:
 cline plugin install ./plugins/automation-events --cwd .
 ```
 
+## Example Usage
+
+After installation, run Cline with `CLINE_LOCAL_EVENT_INTERVAL_MS` set and ask:
+
+```text
+Wait for the local automation event and summarize the payload when it arrives.
+```
+
+Cline receives the event through the automation bridge registered by `automation-events` and can react to it in the session.
+
 ## Requirements
 
 - Optional `CLINE_LOCAL_EVENT_INTERVAL_MS` for periodic demo events.
@@ -25,4 +35,3 @@ cline plugin install ./plugins/automation-events --cwd .
 ## Security Notes
 
 This is a demo event source. Keep the interval unset unless you are testing automation ingestion.
-

--- a/plugins/background-terminal/README.md
+++ b/plugins/background-terminal/README.md
@@ -18,6 +18,16 @@ For local development from this repository:
 cline plugin install ./plugins/background-terminal --cwd .
 ```
 
+## Example Usage
+
+After installation, ask Cline:
+
+```text
+Run npm test in the background, keep working while it runs, and check the result before you finish.
+```
+
+Cline can use `start_background_command` to launch the process, `get_background_command` to poll logs, and `delete_background_command` to clean up stored job metadata.
+
 ## Requirements
 
 - A shell environment.
@@ -26,4 +36,3 @@ cline plugin install ./plugins/background-terminal --cwd .
 ## Security Notes
 
 This plugin runs shell commands. Review requested commands carefully and use host tool approval policies in sensitive workspaces.
-

--- a/plugins/branch-protector/README.md
+++ b/plugins/branch-protector/README.md
@@ -18,6 +18,16 @@ For local development from this repository:
 cline plugin install ./plugins/branch-protector --cwd .
 ```
 
+## Example Usage
+
+After installation, use Cline normally:
+
+```text
+Commit this change and push the feature branch.
+```
+
+If Cline attempts a protected-branch `git push`, `branch-protector` blocks the command before it runs unless the command explicitly includes `--force-allow`.
+
 ## Requirements
 
 - A git workspace.
@@ -26,4 +36,3 @@ cline plugin install ./plugins/branch-protector --cwd .
 ## Security Notes
 
 This is a guardrail, not a replacement for protected branches in your git host. It only applies to shell commands executed through Cline tools.
-

--- a/plugins/bundled-skills-demo/README.md
+++ b/plugins/bundled-skills-demo/README.md
@@ -19,6 +19,16 @@ For local development from this repository:
 cline plugin install ./plugins/bundled-skills-demo --cwd .
 ```
 
+## Example Usage
+
+After installation, ask Cline:
+
+```text
+Verify that the bundled skills demo plugin loaded and that its bundled skill is discoverable.
+```
+
+Cline can call `bundled_skills_info` and use the bundled `plugin-skill-smoke-test` skill to confirm package plugin skill discovery works.
+
 ## Requirements
 
 - A Cline host with plugin package and bundled skill discovery support.
@@ -27,4 +37,3 @@ cline plugin install ./plugins/bundled-skills-demo --cwd .
 ## Security Notes
 
 This is a smoke test plugin. It should not be promoted as an end-user feature.
-

--- a/plugins/bundled-skills-demo/package.json
+++ b/plugins/bundled-skills-demo/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "cline-internal-bundled-skills-demo",
+  "name": "bundled-skills-demo",
   "version": "0.0.0",
   "private": true,
   "type": "module",

--- a/plugins/custom-compaction/README.md
+++ b/plugins/custom-compaction/README.md
@@ -18,6 +18,16 @@ For local development from this repository:
 cline plugin install ./plugins/custom-compaction --cwd .
 ```
 
+## Example Usage
+
+After installation, continue a long Cline session and ask:
+
+```text
+Summarize where we landed, keep the current implementation constraints in mind, and continue with the next change.
+```
+
+Before provider requests, `custom-compaction` rewrites older middle history into a compact summary while preserving the first user message and recent context.
+
 ## Requirements
 
 - A Cline host with plugin message builder support.
@@ -25,4 +35,3 @@ cline plugin install ./plugins/custom-compaction --cwd .
 ## Security Notes
 
 The plugin rewrites model-bound context. Test it before using it in workflows where exact full-history preservation matters.
-

--- a/plugins/data-analyst/README.md
+++ b/plugins/data-analyst/README.md
@@ -20,6 +20,16 @@ For local development from this repository:
 cline plugin install ./plugins/data-analyst --cwd .
 ```
 
+## Example Usage
+
+After installation, ask Cline:
+
+```text
+Analyze last week's signup funnel in ClickHouse, show drop-off by step, and create a chart of the result.
+```
+
+Cline automatically uses the `data-analyst` skill and its supporting ClickHouse sub-skills to gather connection details, inspect the data dictionary, run safe queries, and produce analysis artifacts.
+
 ## Requirements
 
 - `clickhousectl` for ClickHouse server and Cloud workflows.
@@ -33,4 +43,3 @@ The bundled skill instructs agents to use `clickhousectl` instead of ClickHouse 
 ## Attribution
 
 Several bundled ClickHouse sub-skills are derived from `ClickHouse/agent-skills`, licensed under Apache-2.0. See `LICENSE.clickhouse-agent-skills` and `NOTICE.clickhouse-agent-skills`.
-

--- a/plugins/data-analyst/package.json
+++ b/plugins/data-analyst/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "cline-data-analyst-plugin",
+  "name": "data-analyst",
   "version": "0.0.0",
   "private": true,
   "type": "module",
@@ -17,4 +17,3 @@
     ]
   }
 }
-

--- a/plugins/env-blocker/README.md
+++ b/plugins/env-blocker/README.md
@@ -18,6 +18,16 @@ For local development from this repository:
 cline plugin install ./plugins/env-blocker --cwd .
 ```
 
+## Example Usage
+
+After installation, ask Cline:
+
+```text
+Review the app configuration and tell me whether the required environment variables are documented.
+```
+
+If Cline tries to read a secret `.env` file during that work, `env-blocker` skips the tool call while still allowing safe template files such as `.env.example`.
+
 ## Requirements
 
 - No API keys or external services.
@@ -25,4 +35,3 @@ cline plugin install ./plugins/env-blocker --cwd .
 ## Security Notes
 
 This is a deterministic local guard for common secret file names. It does not detect every possible secret path or prevent access outside Cline.
-

--- a/plugins/gitignore-read-files-guard/README.md
+++ b/plugins/gitignore-read-files-guard/README.md
@@ -18,6 +18,16 @@ For local development from this repository:
 cline plugin install ./plugins/gitignore-read-files-guard --cwd .
 ```
 
+## Example Usage
+
+After installation, ask Cline:
+
+```text
+Review this repository for build and test setup issues without inspecting ignored artifacts.
+```
+
+If Cline tries to read or edit a path ignored by `.gitignore`, `gitignore-read-files-guard` blocks that file tool call.
+
 ## Requirements
 
 - A git workspace with `.gitignore` rules.
@@ -25,4 +35,3 @@ cline plugin install ./plugins/gitignore-read-files-guard --cwd .
 ## Security Notes
 
 This only applies to Cline tool calls. It does not change filesystem permissions or git behavior.
-

--- a/plugins/intercom-support-triage/README.md
+++ b/plugins/intercom-support-triage/README.md
@@ -18,6 +18,16 @@ For local development from this repository:
 cline plugin install ./plugins/intercom-support-triage --cwd .
 ```
 
+## Example Usage
+
+After installation, ask Cline:
+
+```text
+Fetch today's open Intercom conversations, group them by refund, account deletion, product support, and spam, then post the summary to Slack.
+```
+
+Cline can use `fetch_intercom_conversations` to retrieve support threads and `post_slack_summary` to publish the grouped triage summary.
+
 ## Requirements
 
 - `INTERCOM_API_TOKEN`
@@ -27,4 +37,3 @@ cline plugin install ./plugins/intercom-support-triage --cwd .
 ## Security Notes
 
 This plugin reads support content from Intercom and posts summaries to Slack. Only enable it in workspaces authorized for customer support data.
-

--- a/plugins/linear/README.md
+++ b/plugins/linear/README.md
@@ -18,6 +18,16 @@ For local development from this repository:
 cline plugin install ./plugins/linear --cwd .
 ```
 
+## Example Usage
+
+After installation, ask Cline:
+
+```text
+Find my open Linear issues, summarize the blockers, and add a comment to the highest-priority issue with the next step.
+```
+
+Cline automatically uses the `linear-sdk-scripting` skill to write and run small Node scripts against `@linear/sdk`, then returns the Linear result in the conversation.
+
 ## Requirements
 
 - Node 18 or newer for the scripts the skill creates.

--- a/plugins/linear/package.json
+++ b/plugins/linear/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "cline-linear-plugin",
+  "name": "linear",
   "version": "0.0.0",
   "private": true,
   "type": "module",

--- a/plugins/mac-notify/README.md
+++ b/plugins/mac-notify/README.md
@@ -18,6 +18,16 @@ For local development from this repository:
 cline plugin install ./plugins/mac-notify --cwd .
 ```
 
+## Example Usage
+
+After installation, ask Cline:
+
+```text
+Run the test suite and let me know when the task is complete.
+```
+
+When the Cline run completes on macOS, `mac-notify` sends a native notification with a short completion summary.
+
 ## Requirements
 
 - macOS for notifications.
@@ -26,4 +36,3 @@ cline plugin install ./plugins/mac-notify --cwd .
 ## Security Notes
 
 Notification text can include task output. Avoid enabling it if completion summaries may contain sensitive information.
-

--- a/plugins/nanobanana/README.md
+++ b/plugins/nanobanana/README.md
@@ -18,6 +18,16 @@ For local development from this repository:
 cline plugin install ./plugins/nanobanana --cwd .
 ```
 
+## Example Usage
+
+After installation, ask Cline:
+
+```text
+Generate a 16:9 product mockup image for our release notes and save it to assets/release-hero.png.
+```
+
+Cline can call `generate_image` with the requested prompt, aspect ratio, output path, and image size, then save the generated image inside the workspace.
+
 ## Requirements
 
 - `OPENROUTER_API_KEY`
@@ -26,4 +36,3 @@ cline plugin install ./plugins/nanobanana --cwd .
 ## Security Notes
 
 Output paths are resolved inside the workspace root. The plugin refuses paths that escape the workspace.
-

--- a/plugins/typescript-lsp/README.md
+++ b/plugins/typescript-lsp/README.md
@@ -18,6 +18,16 @@ For local development from this repository:
 cline plugin install ./plugins/typescript-lsp --cwd .
 ```
 
+## Example Usage
+
+After installation, ask Cline:
+
+```text
+Find the implementation behind this TypeScript symbol and explain how it is used.
+```
+
+Cline can call `goto_definition` when it needs precise TypeScript definition lookup instead of relying only on text search.
+
 ## Requirements
 
 - A JavaScript or TypeScript workspace.
@@ -26,4 +36,3 @@ cline plugin install ./plugins/typescript-lsp --cwd .
 ## Security Notes
 
 The tool reads project files through the language service. Use normal workspace trust rules before enabling it on untrusted projects.
-

--- a/plugins/weather-metrics/README.md
+++ b/plugins/weather-metrics/README.md
@@ -18,6 +18,16 @@ For local development from this repository:
 cline plugin install ./plugins/weather-metrics --cwd .
 ```
 
+## Example Usage
+
+After installation, ask Cline:
+
+```text
+Get the weather for San Francisco while I test plugin tool calls and runtime metrics.
+```
+
+Cline can call the demo `get_weather` tool and the plugin logs run, tool, token, and cost metrics through lifecycle hooks.
+
 ## Requirements
 
 - No API keys or external services.
@@ -25,4 +35,3 @@ cline plugin install ./plugins/weather-metrics --cwd .
 ## Security Notes
 
 This is an example plugin. It logs runtime metadata, so review logs before using it in private workflows.
-

--- a/plugins/web-search/README.md
+++ b/plugins/web-search/README.md
@@ -18,6 +18,16 @@ For local development from this repository:
 cline plugin install ./plugins/web-search --cwd .
 ```
 
+## Example Usage
+
+After installation, ask Cline:
+
+```text
+Search the web for current Cline plugin package manifest examples and summarize the most relevant results.
+```
+
+Cline can call `web_search` to retrieve Exa-backed web results before deciding which public pages to inspect.
+
 ## Requirements
 
 - `EXA_API_KEY`
@@ -25,4 +35,3 @@ cline plugin install ./plugins/web-search --cwd .
 ## Security Notes
 
 Queries are sent to Exa. Do not include private code, secrets, customer data, or other confidential text in search queries.
-

--- a/scripts/validate-plugins.mjs
+++ b/scripts/validate-plugins.mjs
@@ -92,6 +92,9 @@ if (!existsSync(pluginsRoot)) {
       if (!hasPluginManifest(packageJson)) {
         errors.push(`plugins/${entry.name}/package.json needs cline.plugins`);
       }
+      if (packageJson?.name !== entry.name) {
+        errors.push(`plugins/${entry.name}/package.json name must be ${entry.name}`);
+      }
     }
     if (statSync(pluginRoot).isDirectory()) {
       walk(pluginRoot);


### PR DESCRIPTION
## Problem

Some package-style plugins used npm package names like `cline-linear-plugin`, `cline-data-analyst-plugin`, and `cline-agent-squad-plugin`. The install surface for this repository is already slug based, so those names add noise and make the manifest metadata less consistent with how users think about the plugins. For example, users install `linear`, and the plugin itself is already named `linear`, so the package name should match that simple slug too.

The plugin READMEs also explained installation and requirements, but they did not show the natural prompt a user would give Cline after installing each plugin. That made it harder to understand the actual workflow, especially for bundled skill plugins where the right behavior is not a direct tool call from the user but a normal Cline task that causes the installed skill to activate.

## Technical approach

This PR renames the package plugin manifests so their `name` fields match the plugin directory slugs. The updated names are intentionally plain: `linear`, `data-analyst`, `bundled-skills-demo`, and `agents-squad`.

It also extends plugin validation so any plugin with a `package.json` must use a package name that exactly matches its directory slug. That turns the naming convention into an enforced repository invariant instead of a convention reviewers have to catch manually.

Each plugin README now includes an `Example Usage` section after the install instructions. The examples are phrased as prompts a user would give Cline, not as implementation details. For the Linear plugin specifically, the example shows a normal Linear task and explains that Cline can use the bundled `linear-sdk-scripting` skill to write and run small Node scripts against `@linear/sdk`.

## Debugging journey

I started by checking the repo structure, plugin manifests, and the existing validation script. Most source plugin runtime names were already short and slug-like, so the mismatch was isolated to package plugin `package.json` metadata rather than every `index.ts` plugin name.

The README structure was already consistent across plugins: title, what it does, install, requirements, and security notes. That made the least disruptive documentation change to insert `Example Usage` between `Install` and `Requirements` for each plugin. This keeps install instructions first, then immediately answers what a user should ask Cline to do next.

Validation already walked plugin files, checked slug format, required README files, and validated package plugin manifests. I added the package name check there because it is the same place that already owns plugin collection rules.

## Gotchas and decisions

The package names are not scoped npm publish names. These package manifests are private plugin manifests for the collection, so matching the install slug is clearer and avoids redundant `cline` and `plugin` wording.

The examples avoid pretending users need to call internal tools by hand. For tool plugins, the examples describe tasks that naturally cause tool use. For bundled skill plugins, the examples describe the workflow the skill enables.

The validation rule only applies when a plugin has a `package.json`. Simple `index.ts` plugins without package manifests continue to rely on their directory slug and runtime plugin name.

## How to test

Run:

```bash
npm run validate
```

Expected result:

```text
Plugin collection validation passed.
```

I ran this after the manifest changes and again after the README updates.
