### PR TITLE
fix: avoid speak hook timeout during playback

### DIFF
--- a/plugins/speak/README.md
+++ b/plugins/speak/README.md
@@ -4,7 +4,9 @@ Speaks Cline replies out loud with ElevenLabs text to speech.
 
 ## What It Does
 
-Registers a conversational response rule and an `afterRun` hook. When a Cline turn completes successfully, the plugin sends the final assistant reply to ElevenLabs, saves the returned MP3 to a temporary file, plays it with a local audio player, then removes the temporary file.
+Registers a conversational response rule and an `afterRun` hook. When a Cline turn completes successfully, the plugin queues the final assistant reply for ElevenLabs speech generation, saves the returned MP3 to a temporary file, plays it with a local audio player, then removes the temporary file.
+
+Speech work runs in the background after the hook returns so Cline does not wait for audio generation or playback before accepting the next message.
 
 The only required configuration is `ELEVENLABS_API_KEY`. Voice, model, output format, playback detection, and reply length limits have defaults.
 

--- a/plugins/speak/index.ts
+++ b/plugins/speak/index.ts
@@ -228,7 +228,7 @@ async function speakText(text: string): Promise<void> {
 	}
 }
 
-function enqueueSpeech(text: string): Promise<void> {
+function enqueueSpeech(text: string): void {
 	const next = playbackQueue
 		.catch(() => undefined)
 		.then(() => speakText(text))
@@ -237,7 +237,6 @@ function enqueueSpeech(text: string): Promise<void> {
 			log(message);
 		});
 	playbackQueue = next;
-	return next;
 }
 
 const plugin: AgentPlugin = {
@@ -270,7 +269,8 @@ const plugin: AgentPlugin = {
 				return undefined;
 			}
 
-			return enqueueSpeech(text);
+			enqueueSpeech(text);
+			return undefined;
 		},
 	},
 };


### PR DESCRIPTION
## Summary

Fixes `speak` so its `afterRun` hook queues speech generation and returns immediately instead of returning the playback promise.

## Problem

A teammate reported this flow:

1. Send a message with the Speak plugin enabled.
2. Cline replies and audio plays.
3. Send another message.
4. Cline shows `Error: plugin-sandbox process exited (code=null, signal=SIGTERM)`.

The likely cause is the plugin hook lifecycle. Cline plugin hooks run through the plugin sandbox RPC path, and sandbox hook calls have a short timeout. The Speak plugin was returning `enqueueSpeech(text)` from `afterRun`, which made Cline wait for ElevenLabs synthesis, MP3 file writing, local player startup, full audio playback, and cleanup before the hook resolved.

That can easily exceed the hook timeout, especially for longer replies or slower network calls. When the call times out, Cline terminates the plugin sandbox process, which surfaces later as the SIGTERM error.

## Approach

The hook now schedules speech work and returns `undefined` immediately. The existing module-level `playbackQueue` still serializes audio generation and playback, so follow-up turns should not overlap with currently playing speech. Errors inside background speech work are still caught and logged through the queue.

This keeps the plugin best-effort, which matches the intended behavior: speech should enrich the run, but it should never block the agent turn or break the next user message.

The README now calls out that speech work runs in the background after the hook returns.

## Testing

Validated the plugin collection with:

```bash
npm run validate
```

I also inspected the Cline plugin sandbox path while debugging. The hook timeout defaults to 3000 ms in the sandbox loader, and the sandbox shutdown path sends SIGTERM to the plugin process. That matches the reported failure mode when Speak returned a long-running playback promise.

## Notes

This PR intentionally keeps the serialized playback queue. It only changes the hook contract so `afterRun` does not wait for the queue item to finish.