### PR TITLE
fix: run speak playback outside plugin sandbox

### DIFF
--- a/plugins/speak/README.md
+++ b/plugins/speak/README.md
@@ -4,9 +4,9 @@ Speaks Cline replies out loud with ElevenLabs text to speech.
 
 ## What It Does
 
-Registers a conversational response rule and an `afterRun` hook. When a Cline turn completes successfully, the plugin queues the final assistant reply for ElevenLabs speech generation, saves the returned MP3 to a temporary file, plays it with a local audio player, then removes the temporary file.
+Registers a conversational response rule and an `afterRun` hook. When a Cline turn completes successfully, the plugin starts a detached local worker that sends the final assistant reply to ElevenLabs, saves the returned MP3 to a temporary file, plays it with a local audio player, then removes the temporary file.
 
-Speech work runs in the background after the hook returns so Cline does not wait for audio generation or playback before accepting the next message.
+Speech work runs outside the plugin sandbox after the hook returns, so Cline does not wait for audio generation or playback before accepting the next message. The worker uses a temporary lock to avoid overlapping playback from back-to-back replies.
 
 The only required configuration is `ELEVENLABS_API_KEY`. Voice, model, output format, playback detection, and reply length limits have defaults.
 

--- a/plugins/speak/index.ts
+++ b/plugins/speak/index.ts
@@ -1,7 +1,12 @@
-import { constants } from "node:fs";
-import { access, mkdtemp, rm, writeFile } from "node:fs/promises";
+import {
+	accessSync,
+	constants,
+	mkdtempSync,
+	rmSync,
+	writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
-import { basename, delimiter, join } from "node:path";
+import { delimiter, join } from "node:path";
 import { spawn } from "node:child_process";
 import type { AgentPlugin } from "@cline/sdk";
 
@@ -14,8 +19,147 @@ const DEFAULT_MAX_CHARS = 3000;
 const DEFAULT_PLAYERS = ["afplay", "ffplay", "mpg123", "mpg321", "play"];
 const CONTINUATION_NOTICE = "Response continues in the terminal.";
 
-let playbackQueue: Promise<void> = Promise.resolve();
 let missingApiKeyWarningShown = false;
+
+const SPEECH_WORKER_SCRIPT = String.raw`
+const { mkdir, readFile, rm, stat, writeFile } = require("node:fs/promises");
+const { tmpdir } = require("node:os");
+const { basename, dirname, join } = require("node:path");
+const { spawn } = require("node:child_process");
+
+const LOCK_STALE_MS = 10 * 60 * 1000;
+const LOCK_RETRY_MS = 200;
+
+function delay(ms) {
+	return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function acquireLock() {
+	const lockDir = join(tmpdir(), "cline-speak-audio.lock");
+	while (true) {
+		try {
+			await mkdir(lockDir);
+			return async () => {
+				await rm(lockDir, { recursive: true, force: true });
+			};
+		} catch (error) {
+			if (!error || error.code !== "EEXIST") {
+				throw error;
+			}
+			try {
+				const info = await stat(lockDir);
+				if (Date.now() - info.mtimeMs > LOCK_STALE_MS) {
+					await rm(lockDir, { recursive: true, force: true });
+					continue;
+				}
+			} catch {
+				// Ignore stale lock cleanup races.
+			}
+			await delay(LOCK_RETRY_MS);
+		}
+	}
+}
+
+function playerArgs(player, filePath) {
+	const command = basename(player).toLowerCase();
+	if (command === "ffplay") {
+		return ["-nodisp", "-autoexit", "-loglevel", "quiet", filePath];
+	}
+	return [filePath];
+}
+
+function playFile(player, filePath) {
+	return new Promise((resolve, reject) => {
+		const child = spawn(player, playerArgs(player, filePath), {
+			stdio: "ignore",
+		});
+		child.on("error", reject);
+		child.on("close", (code) => {
+			if (code === 0) {
+				resolve();
+				return;
+			}
+			reject(new Error("audio player exited with code " + (code ?? "unknown")));
+		});
+	});
+}
+
+async function synthesizeSpeech(payload) {
+	const apiKey = process.env.ELEVENLABS_API_KEY;
+	if (!apiKey) {
+		return Buffer.alloc(0);
+	}
+
+	const url = payload.ttsUrl + "/" + encodeURIComponent(payload.voiceId) + "?output_format=" + encodeURIComponent(payload.outputFormat);
+	const response = await fetch(url, {
+		method: "POST",
+		headers: {
+			"Content-Type": "application/json",
+			Accept: "audio/mpeg",
+			"xi-api-key": apiKey,
+		},
+		body: JSON.stringify({
+			text: payload.text,
+			model_id: payload.modelId,
+			voice_settings: {
+				stability: 0.45,
+				similarity_boost: 0.8,
+				style: 0.2,
+				use_speaker_boost: true,
+				speed: 1.03,
+			},
+		}),
+	});
+
+	if (!response.ok) {
+		const body = (await response.text()).replace(/\s+/g, " ").trim();
+		const detail = body ? ": " + body.slice(0, 300) : "";
+		throw new Error("ElevenLabs returned HTTP " + response.status + detail);
+	}
+
+	return Buffer.from(await response.arrayBuffer());
+}
+
+async function main() {
+	const payloadPath = process.argv[2];
+	if (!payloadPath) {
+		return;
+	}
+
+	const workerDir = dirname(payloadPath);
+	let releaseLock = async () => {};
+	try {
+		const payload = JSON.parse(await readFile(payloadPath, "utf8"));
+		if (
+			typeof payload.text !== "string" ||
+			typeof payload.player !== "string" ||
+			typeof payload.voiceId !== "string" ||
+			typeof payload.modelId !== "string" ||
+			typeof payload.outputFormat !== "string" ||
+			typeof payload.ttsUrl !== "string"
+		) {
+			return;
+		}
+
+		releaseLock = await acquireLock();
+		const audio = await synthesizeSpeech(payload);
+		if (audio.length === 0) {
+			return;
+		}
+
+		const audioPath = join(workerDir, "response.mp3");
+		await writeFile(audioPath, audio);
+		await playFile(payload.player, audioPath);
+	} finally {
+		await releaseLock().catch(() => undefined);
+		await rm(workerDir, { recursive: true, force: true }).catch(() => undefined);
+	}
+}
+
+main().catch(() => {
+	process.exitCode = 1;
+});
+`;
 
 function env(name: string): string | undefined {
 	const value = process.env[name]?.trim();
@@ -80,16 +224,16 @@ function isExplicitPath(command: string): boolean {
 	return command.includes("/") || command.includes("\\");
 }
 
-async function canExecute(path: string): Promise<boolean> {
+function canExecute(path: string): boolean {
 	try {
-		await access(path, constants.X_OK);
+		accessSync(path, constants.X_OK);
 		return true;
 	} catch {
 		return false;
 	}
 }
 
-async function commandExists(command: string): Promise<boolean> {
+function commandExists(command: string): boolean {
 	if (isExplicitPath(command)) {
 		return canExecute(command);
 	}
@@ -109,7 +253,7 @@ async function commandExists(command: string): Promise<boolean> {
 			continue;
 		}
 		for (const extension of extensions) {
-			if (await canExecute(join(directory, `${command}${extension}`))) {
+			if (canExecute(join(directory, `${command}${extension}`))) {
 				return true;
 			}
 		}
@@ -118,17 +262,17 @@ async function commandExists(command: string): Promise<boolean> {
 	return false;
 }
 
-async function resolvePlayer(): Promise<string | undefined> {
+function resolvePlayer(): string | undefined {
 	const configured = env("ELEVENLABS_TTS_PLAYER");
 	if (configured) {
-		if (await commandExists(configured)) {
+		if (commandExists(configured)) {
 			return configured;
 		}
 		log(`configured player was not found or is not executable: ${configured}`);
 	}
 
 	for (const player of DEFAULT_PLAYERS) {
-		if (await commandExists(player)) {
+		if (commandExists(player)) {
 			return player;
 		}
 	}
@@ -136,77 +280,17 @@ async function resolvePlayer(): Promise<string | undefined> {
 	return undefined;
 }
 
-function playerArgs(player: string, filePath: string): string[] {
-	const command = basename(player).toLowerCase();
-	if (command === "ffplay") {
-		return ["-nodisp", "-autoexit", "-loglevel", "quiet", filePath];
-	}
-	return [filePath];
+function cleanupWorkerDir(workerDir: string): void {
+	rmSync(workerDir, { recursive: true, force: true });
 }
 
-function playFile(player: string, filePath: string): Promise<void> {
-	return new Promise((resolve, reject) => {
-		const child = spawn(player, playerArgs(player, filePath), {
-			stdio: "ignore",
-		});
-
-		child.on("error", reject);
-		child.on("close", (code) => {
-			if (code === 0) {
-				resolve();
-				return;
-			}
-			reject(new Error(`audio player exited with code ${code ?? "unknown"}`));
-		});
-	});
-}
-
-async function synthesizeSpeech(text: string): Promise<Buffer> {
-	const apiKey = env("ELEVENLABS_API_KEY");
-	if (!apiKey) {
-		warnMissingApiKeyOnce();
-		return Buffer.alloc(0);
-	}
-
-	const voiceId = env("ELEVENLABS_VOICE_ID") ?? DEFAULT_VOICE_ID;
-	const modelId = env("ELEVENLABS_MODEL_ID") ?? DEFAULT_MODEL_ID;
-	const url = `${ELEVENLABS_TTS_URL}/${encodeURIComponent(voiceId)}?output_format=${encodeURIComponent(DEFAULT_OUTPUT_FORMAT)}`;
-	const response = await fetch(url, {
-		method: "POST",
-		headers: {
-			"Content-Type": "application/json",
-			Accept: "audio/mpeg",
-			"xi-api-key": apiKey,
-		},
-		body: JSON.stringify({
-			text,
-			model_id: modelId,
-			voice_settings: {
-				stability: 0.45,
-				similarity_boost: 0.8,
-				style: 0.2,
-				use_speaker_boost: true,
-				speed: 1.03,
-			},
-		}),
-	});
-
-	if (!response.ok) {
-		const body = (await response.text()).replace(/\s+/g, " ").trim();
-		const detail = body ? `: ${body.slice(0, 300)}` : "";
-		throw new Error(`ElevenLabs returned HTTP ${response.status}${detail}`);
-	}
-
-	return Buffer.from(await response.arrayBuffer());
-}
-
-async function speakText(text: string): Promise<void> {
+function launchSpeechWorker(text: string): void {
 	if (!env("ELEVENLABS_API_KEY")) {
 		warnMissingApiKeyOnce();
 		return;
 	}
 
-	const player = await resolvePlayer();
+	const player = resolvePlayer();
 	if (!player) {
 		log(
 			"no supported audio player found. Install afplay, ffplay, mpg123, mpg321, or play, or set ELEVENLABS_TTS_PLAYER.",
@@ -214,29 +298,41 @@ async function speakText(text: string): Promise<void> {
 		return;
 	}
 
-	const audio = await synthesizeSpeech(text);
-	if (audio.length === 0) {
-		return;
-	}
-	const tempDir = await mkdtemp(join(tmpdir(), "cline-elevenlabs-"));
-	const audioPath = join(tempDir, "response.mp3");
-	try {
-		await writeFile(audioPath, audio);
-		await playFile(player, audioPath);
-	} finally {
-		await rm(tempDir, { recursive: true, force: true });
-	}
-}
+	const workerDir = mkdtempSync(join(tmpdir(), "cline-speak-worker-"));
+	const workerPath = join(workerDir, "worker.cjs");
+	const payloadPath = join(workerDir, "payload.json");
 
-function enqueueSpeech(text: string): void {
-	const next = playbackQueue
-		.catch(() => undefined)
-		.then(() => speakText(text))
-		.catch((error: unknown) => {
-			const message = error instanceof Error ? error.message : String(error);
-			log(message);
+	try {
+		writeFileSync(workerPath, SPEECH_WORKER_SCRIPT, { mode: 0o700 });
+		writeFileSync(
+			payloadPath,
+			JSON.stringify({
+				text,
+				player,
+				voiceId: env("ELEVENLABS_VOICE_ID") ?? DEFAULT_VOICE_ID,
+				modelId: env("ELEVENLABS_MODEL_ID") ?? DEFAULT_MODEL_ID,
+				outputFormat: DEFAULT_OUTPUT_FORMAT,
+				ttsUrl: ELEVENLABS_TTS_URL,
+			}),
+			{ mode: 0o600 },
+		);
+
+		const child = spawn(process.execPath, [workerPath, payloadPath], {
+			detached: true,
+			stdio: "ignore",
+			env: process.env,
 		});
-	playbackQueue = next;
+		child.on("error", (error: unknown) => {
+			cleanupWorkerDir(workerDir);
+			const message = error instanceof Error ? error.message : String(error);
+			log(`failed to start speech worker: ${message}`);
+		});
+		child.unref();
+	} catch (error) {
+		cleanupWorkerDir(workerDir);
+		const message = error instanceof Error ? error.message : String(error);
+		log(`failed to prepare speech worker: ${message}`);
+	}
 }
 
 const plugin: AgentPlugin = {
@@ -269,7 +365,7 @@ const plugin: AgentPlugin = {
 				return undefined;
 			}
 
-			enqueueSpeech(text);
+			launchSpeechWorker(text);
 			return undefined;
 		},
 	},


### PR DESCRIPTION
## Summary

Fixes Speak playback after the hook-timeout fix by moving ElevenLabs synthesis and local audio playback into a detached local worker process.

## Problem

PR #5 changed `afterRun` so it no longer awaited the whole TTS and playback promise. That avoided Cline plugin hook timeouts, but it left the actual speech work running inside the plugin sandbox after the hook returned.

In testing, that meant audio could stop playing entirely. The likely lifecycle is:

1. `afterRun` queues async speech work inside the sandbox.
2. The hook returns immediately.
3. Cline considers the plugin hook finished and may shut down or restart the sandbox.
4. The queued TTS/playback job is killed before it can call ElevenLabs or invoke the audio player.

So the old version played audio but risked `plugin-sandbox process exited (code=null, signal=SIGTERM)` after long playback. The first fix avoided the timeout but made playback unreliable because the background work still depended on the sandbox staying alive.

## Approach

This PR keeps the fast hook return, but starts a detached Node worker before returning from `afterRun`.

The plugin now does lightweight synchronous setup in the hook:

```text
resolve player -> write worker.cjs and payload.json to a temp directory -> spawn detached worker -> return
```

The detached worker then:

```text
reads payload -> takes a temp lock -> calls ElevenLabs -> writes response.mp3 -> invokes the configured player -> cleans up temp files
```

The temp lock preserves the intended no-overlap behavior for back-to-back replies without requiring an in-memory queue inside the plugin sandbox. If multiple replies spawn workers, each worker waits on the same temp lock before generating and playing audio.

This keeps speech best-effort and avoids making Cline wait on network latency or audio playback. It also lets the audio continue after the plugin hook returns and after the sandbox is cleaned up.

## Testing

Validated the plugin collection:

```bash
npm run validate
```

Checked the embedded worker script parses as JavaScript:

```bash
node --input-type=commonjs - <<EOF
// extracts SPEECH_WORKER_SCRIPT from plugins/speak/index.ts and runs new Function(script)
EOF
```

Ran a local smoke test with a fake ElevenLabs HTTP server and a fake audio player. The worker:

- posted the expected text to the fake TTS endpoint
- received fake MP3 bytes
- invoked the fake player with `response.mp3`
- removed its temporary worker directory after playback

## Notes

This PR intentionally does not add plugin-level dependencies. The detached worker uses Node built-ins and inherits the current environment so `ELEVENLABS_API_KEY`, voice overrides, and player configuration keep working the same way.