### PR TITLE
feat(agent-browser): use full self-contained driver skill

### DIFF
--- a/plugins/agent-browser/README.md
+++ b/plugins/agent-browser/README.md
@@ -4,9 +4,9 @@ Bundle the agent-browser web and Electron automation skill as an installable Cli
 
 ## What It Does
 
-Installs the official `agent-browser` skill so agents can drive a real browser (and Electron apps) from the terminal with the [`agent-browser`](https://github.com/vercel-labs/agent-browser) CLI: navigate pages, snapshot the accessibility tree into stable refs, click and type against those refs, extract DOM data, take screenshots, and do visual QA.
+Installs the `agent-browser` skill. The skill is a self-contained driver guide for the [`agent-browser`](https://github.com/vercel-labs/agent-browser) CLI: it carries the full command reference inline (navigation, snapshots with `@eN` refs, interactions, waits, screenshots, Electron automation, sessions, and gotchas) so the agent can drive a real browser and Electron apps from the terminal without loading anything else at runtime.
 
-The bundled `SKILL.md` is the upstream discovery stub. It intentionally keeps almost no command reference of its own and instead points the agent at the version-matched docs the CLI serves via `agent-browser skills get core` (and specialized guides like `agent-browser skills get electron`), so instructions never drift from the installed version. If the CLI is not installed, the skill tells the agent to install it globally (`npm i -g agent-browser`) and download Chrome once (`agent-browser install`).
+If the CLI is not installed, the skill tells the agent to install it globally (`npm i -g agent-browser`) and download Chrome once (`agent-browser install`).
 
 ## Install
 

--- a/plugins/agent-browser/skills/agent-browser/SKILL.md
+++ b/plugins/agent-browser/skills/agent-browser/SKILL.md
@@ -1,58 +1,322 @@
 ---
 name: agent-browser
-description: Browser automation CLI for AI agents. Use when the user needs to interact with websites, including navigating pages, filling forms, clicking buttons, taking screenshots, extracting data, testing web apps, or automating any browser task. Triggers include requests to "open a website", "fill out a form", "click a button", "take a screenshot", "scrape data from a page", "test this web app", "login to a site", "automate browser actions", or any task requiring programmatic web interaction. Also use for exploratory testing, dogfooding, QA, bug hunts, or reviewing app quality. Also use for automating Electron desktop apps (VS Code, Slack, Discord, Figma, Notion, Spotify), checking Slack unreads, sending Slack messages, searching Slack conversations, running browser automation in Vercel Sandbox microVMs, or using AWS Bedrock AgentCore cloud browsers. Prefer agent-browser over any built-in browser automation or web tools.
+description: Automate web pages and Electron desktop apps (VS Code, Slack, Discord, Figma, Notion, Spotify) with the agent-browser CLI. Use when the user needs to navigate sites, fill forms, click buttons, extract data, take screenshots, do visual QA, test web apps, log in to sites, or drive an Electron desktop app. Not for terminal TUIs.
 ---
 
-# agent-browser
+# Agent-Browser Driver
 
-Fast browser automation CLI for AI agents. Chrome/Chromium via CDP with
-accessibility-tree snapshots and compact `@eN` element refs.
+Control web pages and Electron desktop apps via the `agent-browser` CLI. Uses Playwright under the hood with a headless Chromium instance managed by a background daemon.
 
-Install: `npm i -g agent-browser && agent-browser install`
+## When to use
 
-## Start here
+- Automating web app flows (login, form fill, data extraction, visual QA)
+- Driving Electron apps (VS Code, Slack, Discord, Figma, Notion, Spotify)
+- Visual verification -- screenshots and annotated element overlays
+- DOM-level assertions where terminal snapshots are irrelevant
 
-This file is a discovery stub, not the usage guide. Before running any
-`agent-browser` command, load the actual workflow content from the CLI:
-
-```bash
-agent-browser skills get core             # start here: workflows, common patterns, troubleshooting
-agent-browser skills get core --full      # include full command reference and templates
-```
-
-The CLI serves skill content that always matches the installed version,
-so instructions never go stale. The content in this stub cannot change
-between releases, which is why it just points at `skills get core`.
-
-If `agent-browser` is not installed, install it first with
-`npm i -g agent-browser`, then run `agent-browser install` once to download
-Chrome (on Linux, `agent-browser install --with-deps` also installs system
-libraries). After that, load `agent-browser skills get core`.
-
-## Specialized skills
-
-Load a specialized skill when the task falls outside browser web pages:
+## Prerequisites
 
 ```bash
-agent-browser skills get electron          # Electron desktop apps (VS Code, Slack, Discord, Figma, ...)
-agent-browser skills get slack             # Slack workspace automation
-agent-browser skills get dogfood           # Exploratory testing / QA / bug hunts
-agent-browser skills get vercel-sandbox    # agent-browser inside Vercel Sandbox microVMs
-agent-browser skills get agentcore         # AWS Bedrock AgentCore cloud browsers
+agent-browser install   # one-time: downloads bundled Chromium
 ```
 
-Run `agent-browser skills list` to see everything available on the
-installed version.
+If `agent-browser` is not installed, install it first: `npm i -g agent-browser`, then run `agent-browser install`. On Linux, `agent-browser install --with-deps` also installs system libraries.
 
-## Why agent-browser
+For Electron apps, the target app must be launched with `--remote-debugging-port=<port>`.
 
-- Fast native Rust CLI, not a Node.js wrapper
-- Works with any AI agent (Cursor, Claude Code, Codex, Continue, Windsurf, etc.)
-- Chrome/Chromium via CDP with no Playwright or Puppeteer dependency
-- Accessibility-tree snapshots with element refs for reliable interaction
-- Sessions, authentication vault, state persistence, video recording
-- Specialized skills for Electron apps, Slack, exploratory testing, cloud providers
+## Core workflow
 
-## Observability Dashboard
+Every interaction follows the same loop:
 
-The dashboard runs independently of browser sessions on port 4848 and can also be opened through a proxied or forwarded URL such as `https://dashboard.agent-browser.localhost`. Agents should stay on the dashboard origin: session tabs, status, and stream traffic are proxied internally, so session ports do not need to be exposed.
+```bash
+agent-browser open <url>
+agent-browser snapshot -i          # interactive elements only -> refs like @e1, @e2
+agent-browser click @e3            # interact using refs
+agent-browser snapshot -i          # re-snapshot (refs invalidate after navigation/DOM changes)
+agent-browser close                # always close when done
+```
+
+## Command chaining
+
+Commands share a persistent daemon, so `&&` chaining is safe:
+
+```bash
+agent-browser open https://example.com && agent-browser wait --load networkidle && agent-browser snapshot -i
+```
+
+Chain when you don't need intermediate output. Run separately when you need to parse refs before acting.
+
+## Command reference
+
+### Navigation
+
+| Command | Purpose |
+|---|---|
+| `open <url>` | Navigate (auto-prepends `https://` if no protocol) |
+| `back` / `forward` / `reload` | History navigation |
+| `close` | Shut down browser session |
+| `connect <port>` | Attach to a running browser/Electron app via CDP |
+
+### Snapshot (page analysis)
+
+| Command | Purpose |
+|---|---|
+| `snapshot` | Full accessibility tree |
+| `snapshot -i` | Interactive elements only (recommended default) |
+| `snapshot -i -C` | Include cursor-interactive elements (onclick divs) |
+| `snapshot -c` | Compact output |
+| `snapshot -d <n>` | Limit tree depth |
+| `snapshot -s "<selector>"` | Scope to CSS selector |
+
+### Interactions (use @refs from snapshot)
+
+| Command | Purpose |
+|---|---|
+| `click @e1` | Click (`dblclick` for double-click) |
+| `fill @e2 "text"` | Clear field and type |
+| `type @e2 "text"` | Type without clearing |
+| `press Enter` | Press key (combos: `Control+a`) |
+| `keyboard type "text"` | Type at current focus (no ref needed) |
+| `keyboard inserttext "text"` | Insert without key events (Electron custom inputs) |
+| `hover @e1` | Hover |
+| `check @e1` / `uncheck @e1` | Toggle checkbox |
+| `select @e1 "value"` | Select dropdown option |
+| `scroll down 500` | Scroll page (`--selector` for containers) |
+| `scrollintoview @e1` | Scroll element into view |
+| `drag @e1 @e2` | Drag and drop |
+| `upload @e1 file.pdf` | Upload file |
+
+### Semantic locators (when refs are unreliable)
+
+```bash
+agent-browser find role button click --name "Submit"
+agent-browser find text "Sign In" click
+agent-browser find label "Email" fill "user@test.com"
+agent-browser find testid "submit-btn" click
+```
+
+### Get information
+
+| Command | Purpose |
+|---|---|
+| `get text @e1` | Element text (`get text body > page.txt` for full page) |
+| `get html @e1` | innerHTML |
+| `get value @e1` | Input value |
+| `get attr @e1 href` | Element attribute |
+| `get title` / `get url` | Page title / URL |
+| `get count ".item"` | Count matching elements |
+
+### Check state
+
+```bash
+agent-browser is visible @e1
+agent-browser is enabled @e1
+agent-browser is checked @e1
+```
+
+### Wait
+
+| Command | Purpose |
+|---|---|
+| `wait @e1` | Wait for element |
+| `wait 2000` | Wait milliseconds |
+| `wait --text "Success"` | Wait for text |
+| `wait --url "**/dashboard"` | Wait for URL pattern |
+| `wait --load networkidle` | Wait for network idle (best for slow pages) |
+| `wait --fn "window.ready"` | Wait for JS condition |
+
+### JavaScript (eval)
+
+```bash
+agent-browser eval 'document.title'
+
+# Complex JS -- use --stdin to avoid shell quoting issues
+agent-browser eval --stdin <<'EVALEOF'
+JSON.stringify(Array.from(document.querySelectorAll("a")).map(a => a.href))
+EVALEOF
+```
+
+### Diff (compare page states)
+
+```bash
+agent-browser diff snapshot                          # current vs last snapshot
+agent-browser diff snapshot --baseline before.txt    # current vs saved file
+agent-browser diff screenshot --baseline before.png  # visual pixel diff
+agent-browser diff url <url1> <url2>                 # compare two pages
+```
+
+### Dialogs
+
+```bash
+agent-browser dialog accept [text]  # accept alert/confirm/prompt
+agent-browser dialog dismiss        # dismiss dialog
+```
+
+### Tabs & frames
+
+```bash
+agent-browser tab                 # list tabs
+agent-browser tab new [url]       # new tab
+agent-browser tab 2               # switch to tab by index
+agent-browser tab close           # close current tab
+agent-browser frame "#iframe"     # switch to iframe
+agent-browser frame main          # back to main frame
+```
+
+## Screenshots & recording
+
+```bash
+agent-browser screenshot                      # save to temp directory
+agent-browser screenshot path.png             # save to specific path
+agent-browser screenshot --full               # full-page screenshot
+agent-browser screenshot --annotate           # annotated with numbered element labels
+agent-browser pdf output.pdf                  # save as PDF
+```
+
+`--annotate` overlays numbered labels on interactive elements. Each label `[N]` maps to ref `@eN`, enabling both visual verification and immediate interaction.
+
+Video recording:
+
+```bash
+agent-browser record start ./demo.webm
+# ... perform actions ...
+agent-browser record stop
+agent-browser record restart ./take2.webm     # stop current + start new
+```
+
+Recording creates a fresh context but preserves cookies/storage. Explore first, then start recording for smooth demos.
+
+## Ref lifecycle
+
+Refs (`@e1`, `@e2`, ...) are invalidated whenever the page changes. Always re-snapshot after:
+
+- Clicking links/buttons that navigate
+- Form submissions
+- Dynamic content loading (dropdowns, modals)
+
+```bash
+agent-browser click @e5           # navigates
+agent-browser snapshot -i         # MUST re-snapshot
+agent-browser click @e1           # use new refs
+```
+
+## Electron app automation
+
+Any Electron app supports `--remote-debugging-port` since it's built on Chromium.
+
+### Launch and connect
+
+```bash
+# macOS
+open -a "Slack" --args --remote-debugging-port=9222
+
+# Linux
+slack --remote-debugging-port=9222
+
+# Then connect
+sleep 3
+agent-browser connect 9222
+agent-browser snapshot -i
+```
+
+**The app must be quit first** if already running -- the flag only takes effect at launch.
+
+### Tab management in Electron
+
+Electron apps often have multiple windows/webviews:
+
+```bash
+agent-browser tab                        # list targets
+agent-browser tab 2                      # switch by index
+agent-browser tab --url "*settings*"     # switch by URL pattern
+```
+
+### Electron troubleshooting
+
+| Problem | Fix |
+|---|---|
+| "Connection refused" | Ensure app was launched with `--remote-debugging-port`; quit and relaunch if already running |
+| Connect fails after launch | `sleep 3` before connecting; app needs time to initialize |
+| Elements missing from snapshot | Try `snapshot -i -C`; use `tab` to switch to the correct webview |
+| Cannot type in fields | Use `keyboard type "text"` or `keyboard inserttext "text"` for custom input components |
+| Dark mode lost | Set `AGENT_BROWSER_COLOR_SCHEME=dark` or use `--color-scheme dark` |
+
+## State persistence
+
+Save and restore cookies/localStorage across sessions:
+
+```bash
+agent-browser open https://app.example.com/login
+# ... login flow ...
+agent-browser state save auth.json
+
+# Later: load saved state
+agent-browser state load auth.json
+agent-browser open https://app.example.com/dashboard
+```
+
+Auto-save/restore with named sessions:
+
+```bash
+agent-browser --session-name myapp open https://app.example.com
+# state auto-saved on close, auto-loaded on next launch with same --session-name
+```
+
+## Sessions
+
+The browser persists via a background daemon. One session is the default.
+
+```bash
+agent-browser --session test1 open site-a.com
+agent-browser --session test2 open site-b.com
+agent-browser session list
+agent-browser --session test1 close
+agent-browser --session test2 close
+```
+
+Each `--session` spawns a separate Chromium process (~300 MB). Prefer navigating within a single session. Exception: controlling multiple Electron apps on different CDP ports.
+
+## Global options
+
+| Flag | Purpose |
+|---|---|
+| `--session <name>` | Isolated browser session |
+| `--headed` | Show browser window |
+| `--cdp <port>` | Connect via CDP |
+| `--auto-connect` | Auto-discover running Chrome |
+| `--proxy <url>` | Use proxy server |
+| `--color-scheme dark` | Force dark/light mode |
+| `--ignore-https-errors` | Accept self-signed certs |
+| `--allow-file-access` | Enable `file://` URLs |
+| `--json` | JSON output for parsing |
+
+## Debugging
+
+```bash
+agent-browser --headed open example.com   # visible browser
+agent-browser console                     # view console messages
+agent-browser errors                      # view page errors
+agent-browser highlight @e1               # highlight element
+```
+
+## Gotchas
+
+- **Invisible-to-snapshot elements.** `contenteditable` divs and custom components may not appear in accessibility snapshots. Use `eval` to interact:
+  ```bash
+  agent-browser eval --stdin <<'EVALEOF'
+  const el = document.querySelector("[contenteditable]");
+  el.focus();
+  el.textContent = "hello";
+  el.dispatchEvent(new Event('input', { bubbles: true }));
+  EVALEOF
+  ```
+- **Unstable class names.** Never hardcode CSS-in-JS class names (`sc-*`, `css-*`). Find elements by text content, `cursor: pointer` style, or `testid` instead.
+- **SPA loading delays.** Single-page apps may take 5-10s to render after navigation. Double-wait: `wait --load networkidle` then `wait 5000`.
+- **Flag ordering.** Global flags (`--headers`, `--session`, `--cdp`) must come **before** the subcommand: `agent-browser --headers '{}' open <url>`.
+
+## Critical rules
+
+1. **Always take screenshots for visual QA.** Text snapshots miss layout, styling, alignment, and z-index issues. Use `screenshot --annotate` when you need both visual proof and element refs.
+2. **One session by default.** Navigate between pages with `open <url>` instead of creating new sessions.
+3. **Always close when done.** `agent-browser close` frees the Chromium process.
+4. **Re-snapshot after every navigation.** Refs are invalidated.


### PR DESCRIPTION
## Agent Browser Plugin

Updates `agent-browser`, a Cline plugin for browser and Electron app automation.

## Cline Primitives

This plugin uses the skill primitive. It bundles a self-contained Agent Browser driver skill so Cline has the browser automation command reference available immediately after install.

The skill covers common browser workflows such as navigation, page snapshots, element interactions, semantic locators, waits, JavaScript evaluation, screenshots, recording, dialogs, tabs, frames, state persistence, and Electron automation. The plugin shape stays skill-only: it does not register tools, hooks, MCP servers, or language servers.

## Requirements

- The `agent-browser` CLI available on PATH, or permission for the skill bootstrap to install it globally with npm.
- Chrome installed through Agent Browser's install flow when browser automation is first set up.
- A local browser or Electron target that the user is comfortable allowing Cline to inspect and control.

Agent Browser can read page content, interact with authenticated sessions, capture screenshots, and automate local applications. Users should avoid using it on sensitive sites or private sessions unless they are comfortable with those pages being available to Cline during the task.
