### PR TITLE
feat: add context7 plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Each plugin lives in `plugins/<slug>`. The directory name is the install keyword
 | `bundled-skills-demo` | A package plugin that proves bundled skill discovery works. |
 | `custom-compaction` | Provider message compaction through a plugin message builder. |
 | `clickhouse-data-analyst` | ClickHouse data analyst skill with supporting analysis and ClickHouse sub-skills. |
+| `context7` | Version-specific library documentation lookup through the Context7 MCP server. |
 | `env-blocker` | A hook that blocks reads of secret `.env` files. |
 | `gitignore-read-files-guard` | A hook that blocks file access to `.gitignore` ignored paths. |
 | `goal` | Completion nudges for active goals with a slash command and completion tool. |

--- a/plugins/context7/README.md
+++ b/plugins/context7/README.md
@@ -4,7 +4,7 @@ Adds the Context7 documentation MCP server to Cline.
 
 ## What It Does
 
-Registers a `context7` MCP server backed by `@upstash/context7-mcp`. Context7 helps Cline look up version-specific library documentation and code examples while working on implementation tasks.
+Registers a `context7` MCP server backed by the pinned `@upstash/context7-mcp` package. Context7 helps Cline look up version-specific library documentation and code examples while working on implementation tasks.
 
 ## Install
 
@@ -30,9 +30,10 @@ Cline can use the MCP tools contributed by Context7 when it needs package docume
 
 ## Requirements
 
-- Node.js and `npx` available on PATH.
-- Network access to download and run `@upstash/context7-mcp` on first use.
+- Node.js available on PATH.
+- Network access during installation to download `@upstash/context7-mcp` and its dependencies.
+- Network access during use for Context7 documentation lookups.
 
 ## Security Notes
 
-This plugin starts a local MCP server through `npx -y @upstash/context7-mcp`. The server may receive package names, documentation queries, and surrounding task context that Cline sends to its MCP tools. Avoid sending private code, secrets, or customer data unless you are comfortable with the Context7 server handling that content.
+This plugin starts a local MCP server through the bundled `@upstash/context7-mcp` package. The server may receive package names, documentation queries, and surrounding task context that Cline sends to its MCP tools. Avoid sending private code, secrets, or customer data unless you are comfortable with Context7 handling that content.

--- a/plugins/context7/README.md
+++ b/plugins/context7/README.md
@@ -1,0 +1,38 @@
+# context7
+
+Adds the Context7 documentation MCP server to Cline.
+
+## What It Does
+
+Registers a `context7` MCP server backed by `@upstash/context7-mcp`. Context7 helps Cline look up version-specific library documentation and code examples while working on implementation tasks.
+
+## Install
+
+```bash
+cline plugin install context7
+```
+
+For local development from this repository:
+
+```bash
+cline plugin install ./plugins/context7 --cwd .
+```
+
+## Example Usage
+
+After installation, ask Cline:
+
+```text
+Use Context7 to check the current TanStack Query mutation API, then update this component without guessing.
+```
+
+Cline can use the MCP tools contributed by Context7 when it needs package documentation or examples.
+
+## Requirements
+
+- Node.js and `npx` available on PATH.
+- Network access to download and run `@upstash/context7-mcp` on first use.
+
+## Security Notes
+
+This plugin starts a local MCP server through `npx -y @upstash/context7-mcp`. The server may receive package names, documentation queries, and surrounding task context that Cline sends to its MCP tools. Avoid sending private code, secrets, or customer data unless you are comfortable with the Context7 server handling that content.

--- a/plugins/context7/index.ts
+++ b/plugins/context7/index.ts
@@ -1,4 +1,16 @@
-import type { AgentPlugin } from "@cline/core";
+import { dirname, join } from "node:path"
+import { fileURLToPath } from "node:url"
+import type { AgentPlugin } from "@cline/sdk"
+
+const pluginDir = dirname(fileURLToPath(import.meta.url))
+const context7ServerPath = join(
+	pluginDir,
+	"node_modules",
+	"@upstash",
+	"context7-mcp",
+	"dist",
+	"index.js",
+)
 
 const plugin: AgentPlugin = {
 	name: "context7",
@@ -10,11 +22,11 @@ const plugin: AgentPlugin = {
 			name: "context7",
 			transport: {
 				type: "stdio",
-				command: "npx",
-				args: ["-y", "@upstash/context7-mcp"],
+				command: "node",
+				args: [context7ServerPath],
 			},
-		});
+		})
 	},
-};
+}
 
-export default plugin;
+export default plugin

--- a/plugins/context7/index.ts
+++ b/plugins/context7/index.ts
@@ -1,0 +1,20 @@
+import type { AgentPlugin } from "@cline/core";
+
+const plugin: AgentPlugin = {
+	name: "context7",
+	manifest: {
+		capabilities: ["mcp"],
+	},
+	setup(api) {
+		api.registerMcpServer({
+			name: "context7",
+			transport: {
+				type: "stdio",
+				command: "npx",
+				args: ["-y", "@upstash/context7-mcp"],
+			},
+		});
+	},
+};
+
+export default plugin;

--- a/plugins/context7/package.json
+++ b/plugins/context7/package.json
@@ -4,6 +4,9 @@
   "private": true,
   "type": "module",
   "description": "Cline plugin that registers the Context7 documentation MCP server.",
+  "dependencies": {
+    "@upstash/context7-mcp": "3.1.0"
+  },
   "cline": {
     "plugins": [
       {

--- a/plugins/context7/package.json
+++ b/plugins/context7/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "context7",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Cline plugin that registers the Context7 documentation MCP server.",
+  "cline": {
+    "plugins": [
+      {
+        "paths": [
+          "./index.ts"
+        ],
+        "capabilities": [
+          "mcp"
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Context7 Plugin

Adds `context7`, a Cline plugin for pulling current library documentation and examples into implementation work without relying on stale model memory.

## Cline Primitives

This plugin uses the MCP primitive. It registers one local stdio MCP server named `context7`, backed by the pinned `@upstash/context7-mcp` package.

The Context7 MCP server exposes documentation lookup tools, including resolving a package or library name to a Context7 library id and querying docs for version-specific examples and API details.

## Requirements

- Node.js available on PATH.
- Network access during installation to download `@upstash/context7-mcp` and its dependencies.
- Network access during use for Context7 documentation lookups.

The MCP server may receive package names, documentation queries, and surrounding task context that Cline sends to its tools. Users should avoid sending private code, secrets, or customer data unless they are comfortable with Context7 handling that content.
