### PR TITLE
feat: add playwright plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Each plugin lives in `plugins/<slug>`. The directory name is the install keyword
 | `linear` | Linear SDK scripting skill for issue, project, team, cycle, and comment workflows. |
 | `mac-notify` | macOS notifications when a Cline run completes. |
 | `nanobanana` | Image generation through OpenRouter and Gemini image models. |
+| `playwright` | Playwright MCP server for browser automation and end-to-end testing workflows. |
 | `speak` | Speaks completed Cline replies with ElevenLabs text to speech. |
 | `typescript-lsp` | TypeScript language service `goto_definition` support. |
 | `weather-metrics` | Demo weather tool plus runtime metrics hooks. |

--- a/plugins/playwright/README.md
+++ b/plugins/playwright/README.md
@@ -1,0 +1,41 @@
+# playwright
+
+Register the Playwright MCP server in Cline.
+
+## What It Does
+
+Adds the `playwright` MCP server through the pinned `@playwright/mcp` package bundled with this plugin.
+
+The server lets Cline use Playwright browser automation tools for page navigation, screenshots, form interaction, and end-to-end testing workflows when the Playwright runtime can launch a browser on the current machine.
+
+## Install
+
+```bash
+cline plugin install playwright
+```
+
+For local development from this repository:
+
+```bash
+cline plugin install ./plugins/playwright --cwd .
+```
+
+## Example Usage
+
+After installation, ask Cline:
+
+```text
+Open the local app, click through the login flow, and report any console errors.
+```
+
+Cline can use the registered Playwright MCP server when it is available in the MCP runtime.
+
+## Requirements
+
+- Node.js.
+- Browser support depends on the Playwright MCP package and the current machine.
+- Installing the plugin installs `@playwright/mcp` and its Playwright dependencies.
+
+## Security Notes
+
+The Playwright MCP server can open browser windows, interact with pages, capture screenshots, and access page content. It runs the bundled `@playwright/mcp` package installed with this plugin. Review requested tool calls before using it on sensitive sites or logged-in sessions.

--- a/plugins/playwright/index.ts
+++ b/plugins/playwright/index.ts
@@ -1,0 +1,20 @@
+import type { AgentPlugin } from "@cline/sdk"
+
+const plugin: AgentPlugin = {
+	name: "playwright",
+	manifest: {
+		capabilities: ["mcp"],
+	},
+	setup(api) {
+		api.registerMcpServer({
+			name: "playwright",
+			transport: {
+				type: "stdio",
+				command: "node",
+				args: ["./node_modules/@playwright/mcp/cli.js"],
+			},
+		})
+	},
+}
+
+export default plugin

--- a/plugins/playwright/package.json
+++ b/plugins/playwright/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "playwright",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Cline plugin that registers the Playwright MCP server.",
+  "dependencies": {
+    "@playwright/mcp": "0.0.76"
+  },
+  "cline": {
+    "plugins": [
+      {
+        "paths": [
+          "./index.ts"
+        ],
+        "capabilities": [
+          "mcp"
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Playwright Plugin

Adds `playwright`, a Cline plugin that registers the Playwright MCP server for browser automation and end-to-end testing workflows.

## Cline Primitives

This plugin uses the MCP primitive. It registers one MCP server named `playwright` and runs it from the pinned `@playwright/mcp` package installed with the plugin.

The Playwright MCP server exposes browser automation tools for actions such as navigating pages, clicking and filling UI, reading console output, evaluating page state, uploading files, and capturing screenshots.

## Requirements

- Node.js.
- The plugin installs `@playwright/mcp` and its Playwright dependencies.
- Browser support depends on the current machine and the Playwright runtime.
- The MCP server can interact with pages and read page content, screenshots, console messages, and logged-in browser state. Users should be careful when using it on sensitive sites or authenticated sessions.
