### PR TITLE
feat: add firebase plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Each plugin lives in `plugins/<slug>`. The directory name is the install keyword
 | `custom-compaction` | Provider message compaction through a plugin message builder. |
 | `clickhouse-data-analyst` | ClickHouse data analyst skill with supporting analysis and ClickHouse sub-skills. |
 | `env-blocker` | A hook that blocks reads of secret `.env` files. |
+| `firebase` | Firebase MCP server for supported Firebase project and backend workflows. |
 | `gitignore-read-files-guard` | A hook that blocks file access to `.gitignore` ignored paths. |
 | `goal` | Completion nudges for active goals with a slash command and completion tool. |
 | `intercom-support-triage-slack` | Intercom conversation triage tools for support workflows. |

--- a/plugins/firebase/README.md
+++ b/plugins/firebase/README.md
@@ -1,0 +1,47 @@
+# firebase
+
+Register the Firebase MCP server in Cline.
+
+## What It Does
+
+Adds the `firebase` MCP server through the pinned `firebase-tools` package bundled with this plugin.
+
+The server lets Cline use Firebase tools for supported project workflows such as inspecting and managing Firebase resources from the Firebase CLI MCP runtime.
+
+When Cline provides a workspace path, the plugin runs Firebase from that workspace and passes it to Firebase with `--dir` so Firebase discovers project configuration from the user's workspace rather than the plugin install directory.
+
+## Install
+
+From your Firebase project root:
+
+```bash
+cline plugin install firebase --cwd .
+```
+
+For local development from this repository:
+
+```bash
+cline plugin install ./plugins/firebase --cwd /path/to/firebase/project
+```
+
+## Example Usage
+
+After installation, ask Cline:
+
+```text
+Use Firebase to inspect this project's configured services and summarize the available backend resources.
+```
+
+Cline can use the registered Firebase MCP server when it is available in the MCP runtime.
+
+## Requirements
+
+- Node.js 20 or newer.
+- Firebase project configuration in the workspace for project-aware tools.
+- Firebase project access for the resources you want Cline to inspect or modify.
+- Firebase authentication through the Firebase CLI environment.
+- Installing the plugin installs the full `firebase-tools` package and its dependencies.
+
+## Security Notes
+
+Firebase MCP tools can inspect or change cloud resources depending on your account, project permissions, and selected action. It runs the bundled `firebase-tools` package installed with this plugin. Review requested tool calls before allowing changes to production projects.

--- a/plugins/firebase/index.ts
+++ b/plugins/firebase/index.ts
@@ -1,0 +1,45 @@
+import { dirname, join } from "node:path"
+import { fileURLToPath } from "node:url"
+import type { AgentPlugin } from "@cline/sdk"
+
+const pluginDir = dirname(fileURLToPath(import.meta.url))
+const firebaseCliPath = join(
+	pluginDir,
+	"node_modules",
+	"firebase-tools",
+	"lib",
+	"bin",
+	"firebase.js",
+)
+
+function workspaceRootFromContext(ctx: unknown): string | undefined {
+	const workspaceInfo = (ctx as { workspaceInfo?: { rootPath?: unknown } })
+		.workspaceInfo
+	const rootPath = workspaceInfo?.rootPath
+	return typeof rootPath === "string" && rootPath.trim() ? rootPath : undefined
+}
+
+const plugin: AgentPlugin = {
+	name: "firebase",
+	manifest: {
+		capabilities: ["mcp"],
+	},
+	setup(api, ctx) {
+		const workspaceRoot = workspaceRootFromContext(ctx)
+		api.registerMcpServer({
+			name: "firebase",
+			transport: {
+				type: "stdio",
+				command: "node",
+				args: [
+					firebaseCliPath,
+					"mcp",
+					...(workspaceRoot ? ["--dir", workspaceRoot] : []),
+				],
+				cwd: workspaceRoot ?? pluginDir,
+			},
+		})
+	},
+}
+
+export default plugin

--- a/plugins/firebase/package.json
+++ b/plugins/firebase/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "firebase",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Cline plugin that registers the Firebase MCP server.",
+  "dependencies": {
+    "firebase-tools": "15.20.0"
+  },
+  "cline": {
+    "plugins": [
+      {
+        "paths": [
+          "./index.ts"
+        ],
+        "capabilities": [
+          "mcp"
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Firebase Plugin

Adds `firebase`, a Cline plugin that registers the Firebase MCP server for Firebase project and backend workflows.

## Cline Primitives

This plugin uses the MCP primitive. It registers one MCP server named `firebase` and runs it from the pinned `firebase-tools` package installed with the plugin.

The Firebase MCP server exposes Firebase CLI MCP tools for supported workflows such as Firebase project discovery, developer documentation search, app/project management, deploy status, and Firebase service operations available through the Firebase CLI runtime.

When Cline provides a workspace path, the plugin runs Firebase from that workspace and passes it to Firebase with `--dir` so Firebase discovers project configuration from the user's project instead of the plugin install directory.

## Requirements

- Node.js 20 or newer.
- Firebase project configuration in the workspace for project-aware tools.
- Firebase authentication through the Firebase CLI environment.
- Firebase project permissions for the resources the user asks Cline to inspect or modify.
- The plugin installs the full `firebase-tools` package and its dependencies.

Firebase MCP tools can inspect or change cloud resources depending on the selected action and account permissions. Users should review tool calls carefully before allowing changes to production projects.
