### PR TITLE
feat: add shopify plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Each plugin lives in `plugins/<slug>`. The directory name is the install keyword
 | `linear` | Linear SDK scripting skill for issue, project, team, cycle, and comment workflows. |
 | `mac-notify` | macOS notifications when a Cline run completes. |
 | `nanobanana` | Image generation through OpenRouter and Gemini image models. |
+| `shopify` | Shopify developer docs, API schemas, and validation through the Shopify Dev MCP server. |
 | `speak` | Speaks completed Cline replies with ElevenLabs text to speech. |
 | `typescript-lsp` | TypeScript language service `goto_definition` support. |
 | `weather-metrics` | Demo weather tool plus runtime metrics hooks. |

--- a/plugins/shopify/README.md
+++ b/plugins/shopify/README.md
@@ -1,0 +1,39 @@
+# shopify
+
+Adds the Shopify Dev MCP server to Cline.
+
+## What It Does
+
+Registers a `shopify-mcp` MCP server backed by the pinned `@shopify/dev-mcp` package. The Shopify Dev MCP server helps Cline work with Shopify developer docs, GraphQL APIs, Liquid, Functions, themes, and UI extension guidance.
+
+## Install
+
+```bash
+cline plugin install shopify
+```
+
+For local development from this repository:
+
+```bash
+cline plugin install ./plugins/shopify --cwd .
+```
+
+## Example Usage
+
+After installation, ask Cline:
+
+```text
+Use Shopify docs to validate this Admin API mutation and explain the required fields.
+```
+
+Cline can use the registered Shopify MCP server when it needs Shopify documentation, API schemas, or validation help.
+
+## Requirements
+
+- Node.js 20.10 or newer available on PATH.
+- Network access during installation to download `@shopify/dev-mcp` and its dependencies.
+- Network access during use for Shopify documentation lookups when the MCP server needs remote docs.
+
+## Security Notes
+
+This plugin starts a local MCP server through the bundled `@shopify/dev-mcp` package. The server may receive prompts, code snippets, GraphQL operations, Liquid/theme snippets, and surrounding task context that Cline sends to its MCP tools. Avoid sending secrets, customer data, or private store data unless you are comfortable with the Shopify MCP server handling that content.

--- a/plugins/shopify/index.ts
+++ b/plugins/shopify/index.ts
@@ -1,0 +1,32 @@
+import { dirname, join } from "node:path"
+import { fileURLToPath } from "node:url"
+import type { AgentPlugin } from "@cline/sdk"
+
+const pluginDir = dirname(fileURLToPath(import.meta.url))
+const shopifyServerPath = join(
+	pluginDir,
+	"node_modules",
+	"@shopify",
+	"dev-mcp",
+	"dist",
+	"index.js",
+)
+
+const plugin: AgentPlugin = {
+	name: "shopify",
+	manifest: {
+		capabilities: ["mcp"],
+	},
+	setup(api) {
+		api.registerMcpServer({
+			name: "shopify-mcp",
+			transport: {
+				type: "stdio",
+				command: "node",
+				args: [shopifyServerPath],
+			},
+		})
+	},
+}
+
+export default plugin

--- a/plugins/shopify/package.json
+++ b/plugins/shopify/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "shopify",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Cline plugin that registers the Shopify Dev MCP server.",
+  "dependencies": {
+    "@shopify/dev-mcp": "1.14.0"
+  },
+  "overrides": {
+    "@shopify/cli": "3.93.1"
+  },
+  "cline": {
+    "plugins": [
+      {
+        "paths": [
+          "./index.ts"
+        ],
+        "capabilities": [
+          "mcp"
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
## Shopify Plugin

Adds `shopify`, a Cline plugin for Shopify app, theme, and API development workflows.

## Cline Primitives

This plugin uses the MCP primitive. It registers one local stdio MCP server named `shopify-mcp`, backed by the pinned `@shopify/dev-mcp` package.

The Shopify Dev MCP server exposes tools for Shopify developer documentation and API work, including learning Shopify APIs, searching docs chunks, validating GraphQL code blocks, validating component code blocks, and validating themes.

## Requirements

- Node.js 20.10 or newer available on PATH.
- Network access during installation to download `@shopify/dev-mcp` and its dependencies.
- Network access during use for Shopify documentation lookups when the MCP server needs remote docs.

The plugin pins `@shopify/dev-mcp` and overrides Shopify CLI to a known compatible version so installs do not float to a newer major Shopify CLI release.

The MCP server may receive prompts, code snippets, GraphQL operations, Liquid/theme snippets, and surrounding task context that Cline sends to its tools. Users should avoid sending secrets, customer data, or private store data unless they are comfortable with the Shopify MCP server handling that content.
