### PR TITLE
feat: add atlan plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Each plugin lives in `plugins/<slug>`. The directory name is the install keyword
 | --- | --- |
 | `agent-browser` | Web and Electron browser automation via the agent-browser CLI skill. |
 | `agents-squad` | Background subagents with presets, skills, and shared handoffs. |
+| `atlan` | Atlan data catalog, lineage, glossary, and governance workflows through MCP. |
 | `background-terminal` | Long-running shell jobs with polling and cleanup tools. |
 | `branch-protector` | A hook that blocks protected branch pushes unless explicitly allowed. |
 | `bundled-skills-demo` | A package plugin that proves bundled skill discovery works. |

--- a/plugins/atlan/README.md
+++ b/plugins/atlan/README.md
@@ -1,0 +1,39 @@
+# atlan
+
+Adds the Atlan MCP server to Cline.
+
+## What It Does
+
+Registers an `atlan` MCP server at `https://mcp.atlan.com/mcp`. The Atlan MCP server helps Cline work with data catalog, metadata, lineage, glossary, data quality, and governance workflows available to the authenticated Atlan account.
+
+## Install
+
+```bash
+cline plugin install atlan
+```
+
+For local development from this repository:
+
+```bash
+cline plugin install ./plugins/atlan --cwd .
+```
+
+## Example Usage
+
+After installation, ask Cline:
+
+```text
+Use Atlan to find customer-related tables and summarize their upstream lineage.
+```
+
+Cline can use the registered Atlan MCP server when it is available in the MCP runtime.
+
+## Requirements
+
+- Network access to `https://mcp.atlan.com/mcp`.
+- An Atlan account with access to the assets, glossaries, and metadata you want Cline to inspect or update.
+- OAuth authorization through Cline's MCP auth flow when required by the Atlan MCP server.
+
+## Security Notes
+
+Atlan MCP tools can read or change metadata depending on your Atlan permissions and the selected tool call. Review requested actions before allowing updates to catalog assets, glossary terms, data quality rules, or related governance data.

--- a/plugins/atlan/index.ts
+++ b/plugins/atlan/index.ts
@@ -1,0 +1,19 @@
+import type { AgentPlugin } from "@cline/sdk"
+
+const plugin: AgentPlugin = {
+	name: "atlan",
+	manifest: {
+		capabilities: ["mcp"],
+	},
+	setup(api) {
+		api.registerMcpServer({
+			name: "atlan",
+			transport: {
+				type: "streamableHttp",
+				url: "https://mcp.atlan.com/mcp",
+			},
+		})
+	},
+}
+
+export default plugin


### PR DESCRIPTION
## Atlan Plugin

Adds `atlan`, a Cline plugin for data catalog, lineage, glossary, and governance workflows through Atlan.

## Cline Primitives

This plugin uses the MCP primitive. It registers one remote MCP server named `atlan` at `https://mcp.atlan.com/mcp` using Streamable HTTP.

The Atlan MCP server exposes tools for working with an authenticated Atlan context layer, including asset discovery, metadata, lineage traversal, glossary/data domain workflows, data quality, and catalog governance actions available to the user.

## Requirements

- Network access to `https://mcp.atlan.com/mcp`.
- An Atlan account with access to the assets, glossaries, and metadata the user wants Cline to inspect or update.
- OAuth authorization through Cline's MCP auth flow when required by the Atlan MCP server.

Atlan MCP tools can read or change metadata depending on account permissions and selected tool calls. Users should review requested updates before allowing changes to catalog assets, glossary terms, data quality rules, or related governance data.
