### PR TITLE
feat: add planetscale plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Each plugin lives in `plugins/<slug>`. The directory name is the install keyword
 | `linear` | Linear SDK scripting skill for issue, project, team, cycle, and comment workflows. |
 | `mac-notify` | macOS notifications when a Cline run completes. |
 | `nanobanana` | Image generation through OpenRouter and Gemini image models. |
+| `planetscale` | PlanetScale organizations, databases, branches, schema, and Insights through MCP. |
 | `speak` | Speaks completed Cline replies with ElevenLabs text to speech. |
 | `typescript-lsp` | TypeScript language service `goto_definition` support. |
 | `weather-metrics` | Demo weather tool plus runtime metrics hooks. |

--- a/plugins/planetscale/README.md
+++ b/plugins/planetscale/README.md
@@ -1,0 +1,40 @@
+# planetscale
+
+Adds the PlanetScale MCP server to Cline.
+
+## What It Does
+
+Registers a `planetscale` MCP server at `https://mcp.pscale.dev/mcp/planetscale`. The PlanetScale MCP server helps Cline work with PlanetScale organizations, databases, branches, schema, and Insights data available to the authenticated PlanetScale account.
+
+## Install
+
+```bash
+cline plugin install planetscale
+```
+
+For local development from this repository:
+
+```bash
+cline plugin install ./plugins/planetscale --cwd .
+```
+
+## Example Usage
+
+After installation and any required PlanetScale authorization, ask Cline:
+
+```text
+Use PlanetScale to inspect this database schema and explain which tables are related to billing.
+```
+
+Cline can use the registered PlanetScale MCP server when it is available in the MCP runtime.
+
+## Requirements
+
+- Network access to `https://mcp.pscale.dev/mcp/planetscale`.
+- A PlanetScale account with access to the organizations, databases, branches, schema, and Insights data you want Cline to inspect.
+- OAuth authorization through Cline's MCP auth flow when required by the PlanetScale MCP server.
+- No existing manual MCP server named `planetscale`. If one already exists, Cline leaves the manual entry alone and the plugin does not replace it.
+
+## Security Notes
+
+PlanetScale MCP tools can read database metadata and operational data depending on your account permissions and the selected tool call. Review requested actions before allowing changes to databases, branches, schema, or other PlanetScale resources.

--- a/plugins/planetscale/index.ts
+++ b/plugins/planetscale/index.ts
@@ -1,0 +1,19 @@
+import type { AgentPlugin } from "@cline/sdk"
+
+const plugin: AgentPlugin = {
+	name: "planetscale",
+	manifest: {
+		capabilities: ["mcp"],
+	},
+	setup(api) {
+		api.registerMcpServer({
+			name: "planetscale",
+			transport: {
+				type: "streamableHttp",
+				url: "https://mcp.pscale.dev/mcp/planetscale",
+			},
+		})
+	},
+}
+
+export default plugin


### PR DESCRIPTION
## PlanetScale Plugin

Adds `planetscale`, a Cline plugin for PlanetScale database and operational workflows.

## Cline Primitives

This plugin uses the MCP primitive. It registers one remote MCP server named `planetscale` at `https://mcp.pscale.dev/mcp/planetscale` using Streamable HTTP.

The PlanetScale MCP server exposes tools for working with an authenticated PlanetScale account, including organizations, databases, branches, schema, and Insights data available to the user.

## Requirements

- Network access to `https://mcp.pscale.dev/mcp/planetscale`.
- A PlanetScale account with access to the organizations, databases, branches, schema, and Insights data the user wants Cline to inspect.
- OAuth authorization through Cline's MCP auth flow when required by the PlanetScale MCP server.
- No existing manual MCP server named `planetscale`; Cline leaves existing manual MCP entries alone instead of replacing them from a plugin install.

PlanetScale MCP tools can read database metadata and operational data depending on account permissions and selected tool calls. Users should review requested actions before allowing changes to databases, branches, schema, or other PlanetScale resources.
