### PR TITLE
feat: add circleback plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Each plugin lives in `plugins/<slug>`. The directory name is the install keyword
 | `background-terminal` | Long-running shell jobs with polling and cleanup tools. |
 | `branch-protector` | A hook that blocks protected branch pushes unless explicitly allowed. |
 | `bundled-skills-demo` | A package plugin that proves bundled skill discovery works. |
+| `circleback` | Meeting, email, calendar, and conversational context through MCP. |
 | `custom-compaction` | Provider message compaction through a plugin message builder. |
 | `clickhouse-data-analyst` | ClickHouse data analyst skill with supporting analysis and ClickHouse sub-skills. |
 | `env-blocker` | A hook that blocks reads of secret `.env` files. |

--- a/plugins/circleback/README.md
+++ b/plugins/circleback/README.md
@@ -1,0 +1,40 @@
+# circleback
+
+Adds the Circleback MCP server to Cline.
+
+## What It Does
+
+Registers a `circleback` MCP server at `https://app.circleback.ai/api/mcp`. The Circleback MCP server helps Cline search and use meeting notes, emails, calendar events, and other conversational context available to the authenticated Circleback account.
+
+## Install
+
+```bash
+cline plugin install circleback
+```
+
+For local development from this repository:
+
+```bash
+cline plugin install ./plugins/circleback --cwd .
+```
+
+## Example Usage
+
+After installation and any required Circleback authorization, ask Cline:
+
+```text
+Use Circleback to find the last meeting about this launch plan and summarize the decisions.
+```
+
+Cline can use the registered Circleback MCP server when it is available in the MCP runtime.
+
+## Requirements
+
+- Network access to `https://app.circleback.ai/api/mcp`.
+- A Circleback account with access to the meetings, emails, calendar events, and conversational context you want Cline to inspect.
+- OAuth authorization through Cline's MCP auth flow when required by the Circleback MCP server.
+- No existing manual MCP server named `circleback`. If one already exists, Cline leaves the manual entry alone and the plugin does not replace it.
+
+## Security Notes
+
+Circleback MCP tools can read meeting notes, email metadata or content, calendar events, and related workspace context depending on your account permissions and selected tool call. Avoid sending or approving access to private conversations unless you are comfortable with Circleback and Cline using that context.

--- a/plugins/circleback/index.ts
+++ b/plugins/circleback/index.ts
@@ -1,0 +1,19 @@
+import type { AgentPlugin } from "@cline/sdk"
+
+const plugin: AgentPlugin = {
+	name: "circleback",
+	manifest: {
+		capabilities: ["mcp"],
+	},
+	setup(api) {
+		api.registerMcpServer({
+			name: "circleback",
+			transport: {
+				type: "streamableHttp",
+				url: "https://app.circleback.ai/api/mcp",
+			},
+		})
+	},
+}
+
+export default plugin


### PR DESCRIPTION
## Circleback Plugin

Adds `circleback`, a Cline plugin for using meeting notes, email, calendar events, and conversational context from Circleback.

## Cline Primitives

This plugin uses the MCP primitive. It registers one remote MCP server named `circleback` at `https://app.circleback.ai/api/mcp` using Streamable HTTP.

The Circleback MCP server exposes tools for searching and accessing the authenticated account's meetings, emails, calendar events, and related conversational context.

## Requirements

- Network access to `https://app.circleback.ai/api/mcp`.
- A Circleback account with access to the meetings, emails, calendar events, and workspace context the user wants Cline to inspect.
- OAuth authorization through Cline's MCP auth flow when required by the Circleback MCP server.
- No existing manual MCP server named `circleback`; Cline leaves existing manual MCP entries alone instead of replacing them from a plugin install.

Circleback MCP tools can read meeting notes, email metadata or content, calendar events, and related context depending on account permissions and selected tool calls. Users should avoid approving access to private conversations unless they are comfortable with Circleback and Cline using that context.
