### PR TITLE
feat: add gitlab plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Each plugin lives in `plugins/<slug>`. The directory name is the install keyword
 | `clickhouse-data-analyst` | ClickHouse data analyst skill with supporting analysis and ClickHouse sub-skills. |
 | `env-blocker` | A hook that blocks reads of secret `.env` files. |
 | `gitignore-read-files-guard` | A hook that blocks file access to `.gitignore` ignored paths. |
+| `gitlab` | GitLab.com repositories, issues, merge requests, CI/CD, and DevOps workflows through MCP. |
 | `goal` | Completion nudges for active goals with a slash command and completion tool. |
 | `intercom-support-triage-slack` | Intercom conversation triage tools for support workflows. |
 | `linear` | Linear SDK scripting skill for issue, project, team, cycle, and comment workflows. |

--- a/plugins/gitlab/README.md
+++ b/plugins/gitlab/README.md
@@ -1,0 +1,41 @@
+# gitlab
+
+Adds the GitLab.com MCP server to Cline.
+
+## What It Does
+
+Registers a `gitlab` MCP server at `https://gitlab.com/api/v4/mcp`. The GitLab.com MCP server helps Cline work with repositories, issues, merge requests, CI/CD pipelines, wikis, and other GitLab.com DevOps workflows available to the authenticated GitLab.com account.
+
+## Install
+
+```bash
+cline plugin install gitlab
+```
+
+For local development from this repository:
+
+```bash
+cline plugin install ./plugins/gitlab --cwd .
+```
+
+## Example Usage
+
+After installation and any required GitLab authorization, ask Cline:
+
+```text
+Use GitLab to summarize the open merge requests for this project and highlight failed pipelines.
+```
+
+Cline can use the registered GitLab MCP server when it is available in the MCP runtime.
+
+## Requirements
+
+- Network access to `https://gitlab.com/api/v4/mcp`.
+- A GitLab.com account with access to the projects, issues, merge requests, pipelines, and wiki pages you want Cline to inspect or update.
+- OAuth authorization through Cline's MCP auth flow when required by the GitLab MCP server.
+- No existing manual MCP server named `gitlab`. If one already exists, Cline leaves the manual entry alone and the plugin does not replace it.
+- This plugin targets GitLab.com. For self-managed GitLab instances, configure that instance's MCP endpoint manually.
+
+## Security Notes
+
+GitLab MCP tools can read or change repository, issue, merge request, pipeline, and wiki data depending on your account permissions and selected tool call. Review requested actions before allowing changes to source code, CI/CD settings, issues, merge requests, or other GitLab resources.

--- a/plugins/gitlab/index.ts
+++ b/plugins/gitlab/index.ts
@@ -1,0 +1,19 @@
+import type { AgentPlugin } from "@cline/sdk"
+
+const plugin: AgentPlugin = {
+	name: "gitlab",
+	manifest: {
+		capabilities: ["mcp"],
+	},
+	setup(api) {
+		api.registerMcpServer({
+			name: "gitlab",
+			transport: {
+				type: "streamableHttp",
+				url: "https://gitlab.com/api/v4/mcp",
+			},
+		})
+	},
+}
+
+export default plugin


### PR DESCRIPTION
## GitLab Plugin

Adds `gitlab`, a Cline plugin for GitLab.com repository and DevOps workflows.

## Cline Primitives

This plugin uses the MCP primitive. It registers one remote MCP server named `gitlab` at `https://gitlab.com/api/v4/mcp` using Streamable HTTP.

The GitLab.com MCP server exposes tools for working with an authenticated GitLab.com account, including projects, repositories, issues, merge requests, CI/CD pipelines, wikis, and related DevOps resources available to the user.

## Requirements

- Network access to `https://gitlab.com/api/v4/mcp`.
- A GitLab.com account with access to the projects, issues, merge requests, pipelines, and wiki pages the user wants Cline to inspect or update.
- OAuth authorization through Cline's MCP auth flow when required by the GitLab MCP server.
- No existing manual MCP server named `gitlab`; Cline leaves existing manual MCP entries alone instead of replacing them from a plugin install.

This plugin targets GitLab.com. Self-managed GitLab instances should continue using manual MCP settings with their instance-specific MCP endpoint.

GitLab MCP tools can read or change repository, issue, merge request, pipeline, and wiki data depending on account permissions and selected tool calls. Users should review requested actions before allowing changes to source code, CI/CD settings, issues, merge requests, or other GitLab resources.
