### PR TITLE
feat: add microsoft docs plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Each plugin lives in `plugins/<slug>`. The directory name is the install keyword
 | `intercom-support-triage-slack` | Intercom conversation triage tools for support workflows. |
 | `linear` | Linear SDK scripting skill for issue, project, team, cycle, and comment workflows. |
 | `mac-notify` | macOS notifications when a Cline run completes. |
+| `microsoft-docs` | Official Microsoft Learn documentation and code samples through MCP. |
 | `nanobanana` | Image generation through OpenRouter and Gemini image models. |
 | `speak` | Speaks completed Cline replies with ElevenLabs text to speech. |
 | `typescript-lsp` | TypeScript language service `goto_definition` support. |

--- a/plugins/microsoft-docs/LICENSE-CODE.microsoft-docs
+++ b/plugins/microsoft-docs/LICENSE-CODE.microsoft-docs
@@ -1,0 +1,17 @@
+The MIT License (MIT)
+Copyright (c) Microsoft Corporation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and 
+associated documentation files (the "Software"), to deal in the Software without restriction, 
+including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, 
+and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, 
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial 
+portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT 
+NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. 
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, 
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE 
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/plugins/microsoft-docs/LICENSE.microsoft-docs
+++ b/plugins/microsoft-docs/LICENSE.microsoft-docs
@@ -1,0 +1,395 @@
+Attribution 4.0 International
+
+=======================================================================
+
+Creative Commons Corporation ("Creative Commons") is not a law firm and
+does not provide legal services or legal advice. Distribution of
+Creative Commons public licenses does not create a lawyer-client or
+other relationship. Creative Commons makes its licenses and related
+information available on an "as-is" basis. Creative Commons gives no
+warranties regarding its licenses, any material licensed under their
+terms and conditions, or any related information. Creative Commons
+disclaims all liability for damages resulting from their use to the
+fullest extent possible.
+
+Using Creative Commons Public Licenses
+
+Creative Commons public licenses provide a standard set of terms and
+conditions that creators and other rights holders may use to share
+original works of authorship and other material subject to copyright
+and certain other rights specified in the public license below. The
+following considerations are for informational purposes only, are not
+exhaustive, and do not form part of our licenses.
+
+     Considerations for licensors: Our public licenses are
+     intended for use by those authorized to give the public
+     permission to use material in ways otherwise restricted by
+     copyright and certain other rights. Our licenses are
+     irrevocable. Licensors should read and understand the terms
+     and conditions of the license they choose before applying it.
+     Licensors should also secure all rights necessary before
+     applying our licenses so that the public can reuse the
+     material as expected. Licensors should clearly mark any
+     material not subject to the license. This includes other CC-
+     licensed material, or material used under an exception or
+     limitation to copyright. More considerations for licensors:
+	wiki.creativecommons.org/Considerations_for_licensors
+
+     Considerations for the public: By using one of our public
+     licenses, a licensor grants the public permission to use the
+     licensed material under specified terms and conditions. If
+     the licensor's permission is not necessary for any reason--for
+     example, because of any applicable exception or limitation to
+     copyright--then that use is not regulated by the license. Our
+     licenses grant only permissions under copyright and certain
+     other rights that a licensor has authority to grant. Use of
+     the licensed material may still be restricted for other
+     reasons, including because others have copyright or other
+     rights in the material. A licensor may make special requests,
+     such as asking that all changes be marked or described.
+     Although not required by our licenses, you are encouraged to
+     respect those requests where reasonable. More_considerations
+     for the public: 
+	wiki.creativecommons.org/Considerations_for_licensees
+
+=======================================================================
+
+Creative Commons Attribution 4.0 International Public License
+
+By exercising the Licensed Rights (defined below), You accept and agree
+to be bound by the terms and conditions of this Creative Commons
+Attribution 4.0 International Public License ("Public License"). To the
+extent this Public License may be interpreted as a contract, You are
+granted the Licensed Rights in consideration of Your acceptance of
+these terms and conditions, and the Licensor grants You such rights in
+consideration of benefits the Licensor receives from making the
+Licensed Material available under these terms and conditions.
+
+
+Section 1 -- Definitions.
+
+  a. Adapted Material means material subject to Copyright and Similar
+     Rights that is derived from or based upon the Licensed Material
+     and in which the Licensed Material is translated, altered,
+     arranged, transformed, or otherwise modified in a manner requiring
+     permission under the Copyright and Similar Rights held by the
+     Licensor. For purposes of this Public License, where the Licensed
+     Material is a musical work, performance, or sound recording,
+     Adapted Material is always produced where the Licensed Material is
+     synched in timed relation with a moving image.
+
+  b. Adapter's License means the license You apply to Your Copyright
+     and Similar Rights in Your contributions to Adapted Material in
+     accordance with the terms and conditions of this Public License.
+
+  c. Copyright and Similar Rights means copyright and/or similar rights
+     closely related to copyright including, without limitation,
+     performance, broadcast, sound recording, and Sui Generis Database
+     Rights, without regard to how the rights are labeled or
+     categorized. For purposes of this Public License, the rights
+     specified in Section 2(b)(1)-(2) are not Copyright and Similar
+     Rights.
+
+  d. Effective Technological Measures means those measures that, in the
+     absence of proper authority, may not be circumvented under laws
+     fulfilling obligations under Article 11 of the WIPO Copyright
+     Treaty adopted on December 20, 1996, and/or similar international
+     agreements.
+
+  e. Exceptions and Limitations means fair use, fair dealing, and/or
+     any other exception or limitation to Copyright and Similar Rights
+     that applies to Your use of the Licensed Material.
+
+  f. Licensed Material means the artistic or literary work, database,
+     or other material to which the Licensor applied this Public
+     License.
+
+  g. Licensed Rights means the rights granted to You subject to the
+     terms and conditions of this Public License, which are limited to
+     all Copyright and Similar Rights that apply to Your use of the
+     Licensed Material and that the Licensor has authority to license.
+
+  h. Licensor means the individual(s) or entity(ies) granting rights
+     under this Public License.
+
+  i. Share means to provide material to the public by any means or
+     process that requires permission under the Licensed Rights, such
+     as reproduction, public display, public performance, distribution,
+     dissemination, communication, or importation, and to make material
+     available to the public including in ways that members of the
+     public may access the material from a place and at a time
+     individually chosen by them.
+
+  j. Sui Generis Database Rights means rights other than copyright
+     resulting from Directive 96/9/EC of the European Parliament and of
+     the Council of 11 March 1996 on the legal protection of databases,
+     as amended and/or succeeded, as well as other essentially
+     equivalent rights anywhere in the world.
+
+  k. You means the individual or entity exercising the Licensed Rights
+     under this Public License. Your has a corresponding meaning.
+
+
+Section 2 -- Scope.
+
+  a. License grant.
+
+       1. Subject to the terms and conditions of this Public License,
+          the Licensor hereby grants You a worldwide, royalty-free,
+          non-sublicensable, non-exclusive, irrevocable license to
+          exercise the Licensed Rights in the Licensed Material to:
+
+            a. reproduce and Share the Licensed Material, in whole or
+               in part; and
+
+            b. produce, reproduce, and Share Adapted Material.
+
+       2. Exceptions and Limitations. For the avoidance of doubt, where
+          Exceptions and Limitations apply to Your use, this Public
+          License does not apply, and You do not need to comply with
+          its terms and conditions.
+
+       3. Term. The term of this Public License is specified in Section
+          6(a).
+
+       4. Media and formats; technical modifications allowed. The
+          Licensor authorizes You to exercise the Licensed Rights in
+          all media and formats whether now known or hereafter created,
+          and to make technical modifications necessary to do so. The
+          Licensor waives and/or agrees not to assert any right or
+          authority to forbid You from making technical modifications
+          necessary to exercise the Licensed Rights, including
+          technical modifications necessary to circumvent Effective
+          Technological Measures. For purposes of this Public License,
+          simply making modifications authorized by this Section 2(a)
+          (4) never produces Adapted Material.
+
+       5. Downstream recipients.
+
+            a. Offer from the Licensor -- Licensed Material. Every
+               recipient of the Licensed Material automatically
+               receives an offer from the Licensor to exercise the
+               Licensed Rights under the terms and conditions of this
+               Public License.
+
+            b. No downstream restrictions. You may not offer or impose
+               any additional or different terms or conditions on, or
+               apply any Effective Technological Measures to, the
+               Licensed Material if doing so restricts exercise of the
+               Licensed Rights by any recipient of the Licensed
+               Material.
+
+       6. No endorsement. Nothing in this Public License constitutes or
+          may be construed as permission to assert or imply that You
+          are, or that Your use of the Licensed Material is, connected
+          with, or sponsored, endorsed, or granted official status by,
+          the Licensor or others designated to receive attribution as
+          provided in Section 3(a)(1)(A)(i).
+
+  b. Other rights.
+
+       1. Moral rights, such as the right of integrity, are not
+          licensed under this Public License, nor are publicity,
+          privacy, and/or other similar personality rights; however, to
+          the extent possible, the Licensor waives and/or agrees not to
+          assert any such rights held by the Licensor to the limited
+          extent necessary to allow You to exercise the Licensed
+          Rights, but not otherwise.
+
+       2. Patent and trademark rights are not licensed under this
+          Public License.
+
+       3. To the extent possible, the Licensor waives any right to
+          collect royalties from You for the exercise of the Licensed
+          Rights, whether directly or through a collecting society
+          under any voluntary or waivable statutory or compulsory
+          licensing scheme. In all other cases the Licensor expressly
+          reserves any right to collect such royalties.
+
+
+Section 3 -- License Conditions.
+
+Your exercise of the Licensed Rights is expressly made subject to the
+following conditions.
+
+  a. Attribution.
+
+       1. If You Share the Licensed Material (including in modified
+          form), You must:
+
+            a. retain the following if it is supplied by the Licensor
+               with the Licensed Material:
+
+                 i. identification of the creator(s) of the Licensed
+                    Material and any others designated to receive
+                    attribution, in any reasonable manner requested by
+                    the Licensor (including by pseudonym if
+                    designated);
+
+                ii. a copyright notice;
+
+               iii. a notice that refers to this Public License;
+
+                iv. a notice that refers to the disclaimer of
+                    warranties;
+
+                 v. a URI or hyperlink to the Licensed Material to the
+                    extent reasonably practicable;
+
+            b. indicate if You modified the Licensed Material and
+               retain an indication of any previous modifications; and
+
+            c. indicate the Licensed Material is licensed under this
+               Public License, and include the text of, or the URI or
+               hyperlink to, this Public License.
+
+       2. You may satisfy the conditions in Section 3(a)(1) in any
+          reasonable manner based on the medium, means, and context in
+          which You Share the Licensed Material. For example, it may be
+          reasonable to satisfy the conditions by providing a URI or
+          hyperlink to a resource that includes the required
+          information.
+
+       3. If requested by the Licensor, You must remove any of the
+          information required by Section 3(a)(1)(A) to the extent
+          reasonably practicable.
+
+       4. If You Share Adapted Material You produce, the Adapter's
+          License You apply must not prevent recipients of the Adapted
+          Material from complying with this Public License.
+
+
+Section 4 -- Sui Generis Database Rights.
+
+Where the Licensed Rights include Sui Generis Database Rights that
+apply to Your use of the Licensed Material:
+
+  a. for the avoidance of doubt, Section 2(a)(1) grants You the right
+     to extract, reuse, reproduce, and Share all or a substantial
+     portion of the contents of the database;
+
+  b. if You include all or a substantial portion of the database
+     contents in a database in which You have Sui Generis Database
+     Rights, then the database in which You have Sui Generis Database
+     Rights (but not its individual contents) is Adapted Material; and
+
+  c. You must comply with the conditions in Section 3(a) if You Share
+     all or a substantial portion of the contents of the database.
+
+For the avoidance of doubt, this Section 4 supplements and does not
+replace Your obligations under this Public License where the Licensed
+Rights include other Copyright and Similar Rights.
+
+
+Section 5 -- Disclaimer of Warranties and Limitation of Liability.
+
+  a. UNLESS OTHERWISE SEPARATELY UNDERTAKEN BY THE LICENSOR, TO THE
+     EXTENT POSSIBLE, THE LICENSOR OFFERS THE LICENSED MATERIAL AS-IS
+     AND AS-AVAILABLE, AND MAKES NO REPRESENTATIONS OR WARRANTIES OF
+     ANY KIND CONCERNING THE LICENSED MATERIAL, WHETHER EXPRESS,
+     IMPLIED, STATUTORY, OR OTHER. THIS INCLUDES, WITHOUT LIMITATION,
+     WARRANTIES OF TITLE, MERCHANTABILITY, FITNESS FOR A PARTICULAR
+     PURPOSE, NON-INFRINGEMENT, ABSENCE OF LATENT OR OTHER DEFECTS,
+     ACCURACY, OR THE PRESENCE OR ABSENCE OF ERRORS, WHETHER OR NOT
+     KNOWN OR DISCOVERABLE. WHERE DISCLAIMERS OF WARRANTIES ARE NOT
+     ALLOWED IN FULL OR IN PART, THIS DISCLAIMER MAY NOT APPLY TO YOU.
+
+  b. TO THE EXTENT POSSIBLE, IN NO EVENT WILL THE LICENSOR BE LIABLE
+     TO YOU ON ANY LEGAL THEORY (INCLUDING, WITHOUT LIMITATION,
+     NEGLIGENCE) OR OTHERWISE FOR ANY DIRECT, SPECIAL, INDIRECT,
+     INCIDENTAL, CONSEQUENTIAL, PUNITIVE, EXEMPLARY, OR OTHER LOSSES,
+     COSTS, EXPENSES, OR DAMAGES ARISING OUT OF THIS PUBLIC LICENSE OR
+     USE OF THE LICENSED MATERIAL, EVEN IF THE LICENSOR HAS BEEN
+     ADVISED OF THE POSSIBILITY OF SUCH LOSSES, COSTS, EXPENSES, OR
+     DAMAGES. WHERE A LIMITATION OF LIABILITY IS NOT ALLOWED IN FULL OR
+     IN PART, THIS LIMITATION MAY NOT APPLY TO YOU.
+
+  c. The disclaimer of warranties and limitation of liability provided
+     above shall be interpreted in a manner that, to the extent
+     possible, most closely approximates an absolute disclaimer and
+     waiver of all liability.
+
+
+Section 6 -- Term and Termination.
+
+  a. This Public License applies for the term of the Copyright and
+     Similar Rights licensed here. However, if You fail to comply with
+     this Public License, then Your rights under this Public License
+     terminate automatically.
+
+  b. Where Your right to use the Licensed Material has terminated under
+     Section 6(a), it reinstates:
+
+       1. automatically as of the date the violation is cured, provided
+          it is cured within 30 days of Your discovery of the
+          violation; or
+
+       2. upon express reinstatement by the Licensor.
+
+     For the avoidance of doubt, this Section 6(b) does not affect any
+     right the Licensor may have to seek remedies for Your violations
+     of this Public License.
+
+  c. For the avoidance of doubt, the Licensor may also offer the
+     Licensed Material under separate terms or conditions or stop
+     distributing the Licensed Material at any time; however, doing so
+     will not terminate this Public License.
+
+  d. Sections 1, 5, 6, 7, and 8 survive termination of this Public
+     License.
+
+
+Section 7 -- Other Terms and Conditions.
+
+  a. The Licensor shall not be bound by any additional or different
+     terms or conditions communicated by You unless expressly agreed.
+
+  b. Any arrangements, understandings, or agreements regarding the
+     Licensed Material not stated herein are separate from and
+     independent of the terms and conditions of this Public License.
+
+
+Section 8 -- Interpretation.
+
+  a. For the avoidance of doubt, this Public License does not, and
+     shall not be interpreted to, reduce, limit, restrict, or impose
+     conditions on any use of the Licensed Material that could lawfully
+     be made without permission under this Public License.
+
+  b. To the extent possible, if any provision of this Public License is
+     deemed unenforceable, it shall be automatically reformed to the
+     minimum extent necessary to make it enforceable. If the provision
+     cannot be reformed, it shall be severed from this Public License
+     without affecting the enforceability of the remaining terms and
+     conditions.
+
+  c. No term or condition of this Public License will be waived and no
+     failure to comply consented to unless expressly agreed to by the
+     Licensor.
+
+  d. Nothing in this Public License constitutes or may be interpreted
+     as a limitation upon, or waiver of, any privileges and immunities
+     that apply to the Licensor or You, including from the legal
+     processes of any jurisdiction or authority.
+
+
+=======================================================================
+
+Creative Commons is not a party to its public
+licenses. Notwithstanding, Creative Commons may elect to apply one of
+its public licenses to material it publishes and in those instances
+will be considered the “Licensor.” The text of the Creative Commons
+public licenses is dedicated to the public domain under the CC0 Public
+Domain Dedication. Except for the limited purpose of indicating that
+material is shared under a Creative Commons public license or as
+otherwise permitted by the Creative Commons policies published at
+creativecommons.org/policies, Creative Commons does not authorize the
+use of the trademark "Creative Commons" or any other trademark or logo
+of Creative Commons without its prior written consent including,
+without limitation, in connection with any unauthorized modifications
+to any of its public licenses or any other arrangements,
+understandings, or agreements concerning use of licensed material. For
+the avoidance of doubt, this paragraph does not form part of the
+public licenses.
+
+Creative Commons may be contacted at creativecommons.org.

--- a/plugins/microsoft-docs/NOTICE.microsoft-docs.md
+++ b/plugins/microsoft-docs/NOTICE.microsoft-docs.md
@@ -1,0 +1,15 @@
+# Microsoft Docs Skill Notice
+
+This plugin includes adapted skill content derived from the Microsoft Learn MCP Server repository:
+
+- Source: `https://github.com/microsoftdocs/mcp`
+- Source package metadata version: `0.3.1`
+- Original author: Microsoft
+- Source plugin homepage: `https://learn.microsoft.com`
+
+- Documentation and skill content are made available by Microsoft and contributors under the Creative Commons Attribution 4.0 International Public License. See `LICENSE.microsoft-docs`.
+- Code examples and helper snippets from that repository are made available under the MIT License. See `LICENSE-CODE.microsoft-docs`.
+- Original third-party and trademark notices are preserved in `ThirdPartyNotices.microsoft-docs.md`.
+- Microsoft, Windows, Microsoft Azure, and other Microsoft product names may be trademarks or registered trademarks of Microsoft in the United States and/or other countries. This plugin does not grant rights to use Microsoft names, logos, or trademarks.
+
+Local adaptations for Cline include plugin packaging, frontmatter cleanup, formatting normalization, and guidance for using the Cline-registered Microsoft Learn MCP server.

--- a/plugins/microsoft-docs/README.md
+++ b/plugins/microsoft-docs/README.md
@@ -1,0 +1,39 @@
+# microsoft-docs
+
+Adds the Microsoft Learn MCP server to Cline.
+
+## What It Does
+
+Registers a `microsoft-learn` MCP server at `https://learn.microsoft.com/api/mcp`. The Microsoft Learn MCP server helps Cline search official Microsoft documentation, fetch Microsoft Learn pages, and find official Microsoft and Azure code samples.
+
+## Install
+
+```bash
+cline plugin install microsoft-docs
+```
+
+For local development from this repository:
+
+```bash
+cline plugin install ./plugins/microsoft-docs --cwd .
+```
+
+## Example Usage
+
+After installation, ask Cline:
+
+```text
+Use Microsoft Learn to find the official Azure Functions timeout limits and cite the relevant page.
+```
+
+Cline can use the registered Microsoft Learn MCP server when it is available in the MCP runtime.
+
+## Requirements
+
+- Network access to `https://learn.microsoft.com/api/mcp`.
+- No Microsoft account or API key is required for the public Microsoft Learn MCP server.
+- No existing manual MCP server named `microsoft-learn`. If one already exists, Cline leaves the manual entry alone and the plugin does not replace it.
+
+## Security Notes
+
+Microsoft Learn MCP tools send documentation searches, page URLs, code-sample queries, and surrounding task context to Microsoft Learn. Avoid including secrets, customer data, or private code in queries unless you are comfortable with Microsoft Learn handling that content.

--- a/plugins/microsoft-docs/README.md
+++ b/plugins/microsoft-docs/README.md
@@ -1,10 +1,16 @@
 # microsoft-docs
 
-Adds the Microsoft Learn MCP server to Cline.
+Adds the Microsoft Learn MCP server and bundled Microsoft documentation skills to Cline.
 
 ## What It Does
 
 Registers a `microsoft-learn` MCP server at `https://learn.microsoft.com/api/mcp`. The Microsoft Learn MCP server helps Cline search official Microsoft documentation, fetch Microsoft Learn pages, and find official Microsoft and Azure code samples.
+
+The plugin also bundles three skills:
+
+- `microsoft-docs` for concepts, tutorials, configuration, limits, quotas, and best practices across Microsoft technologies.
+- `microsoft-code-reference` for verifying Microsoft SDK/API signatures and finding official code samples before writing or fixing code.
+- `microsoft-skill-creator` for creating Cline skills about Microsoft technologies with Microsoft Learn as the source of truth.
 
 ## Install
 
@@ -33,7 +39,10 @@ Cline can use the registered Microsoft Learn MCP server when it is available in 
 - Network access to `https://learn.microsoft.com/api/mcp`.
 - No Microsoft account or API key is required for the public Microsoft Learn MCP server.
 - No existing manual MCP server named `microsoft-learn`. If one already exists, Cline leaves the manual entry alone and the plugin does not replace it.
+- Optional `@microsoft/learn-cli` use requires user approval before `npx` downloads or global npm installs.
 
 ## Security Notes
 
 Microsoft Learn MCP tools send documentation searches, page URLs, code-sample queries, and surrounding task context to Microsoft Learn. Avoid including secrets, customer data, or private code in queries unless you are comfortable with Microsoft Learn handling that content.
+
+Bundled skill content includes adapted Microsoft Learn MCP Server material. See `NOTICE.microsoft-docs.md`, `LICENSE.microsoft-docs`, `LICENSE-CODE.microsoft-docs`, and `ThirdPartyNotices.microsoft-docs.md`.

--- a/plugins/microsoft-docs/ThirdPartyNotices.microsoft-docs.md
+++ b/plugins/microsoft-docs/ThirdPartyNotices.microsoft-docs.md
@@ -1,0 +1,15 @@
+## Legal Notices
+Microsoft and any contributors grant you a license to the Microsoft documentation and other content
+in this repository under the [Creative Commons Attribution 4.0 International Public License](https://creativecommons.org/licenses/by/4.0/legalcode),
+see the [LICENSE](LICENSE) file, and grant you a license to any code in the repository under the [MIT License](https://opensource.org/licenses/MIT), see the
+[LICENSE-CODE](LICENSE-CODE) file.
+
+Microsoft, Windows, Microsoft Azure and/or other Microsoft products and services referenced in the documentation
+may be either trademarks or registered trademarks of Microsoft in the United States and/or other countries.
+The licenses for this project do not grant you rights to use any Microsoft names, logos, or trademarks.
+You can find Microsoft general trademark guidelines at [Microsoft Trademark and Brand Guidelines](https://www.microsoft.com/legal/intellectualproperty/trademarks).
+
+For privacy information, see [privacy at Microsoft](https://privacy.microsoft.com/).
+
+Microsoft and any contributors reserve all others rights, whether under their respective copyrights, patents,
+or trademarks, whether by implication, estoppel or otherwise.

--- a/plugins/microsoft-docs/index.ts
+++ b/plugins/microsoft-docs/index.ts
@@ -1,0 +1,19 @@
+import type { AgentPlugin } from "@cline/sdk"
+
+const plugin: AgentPlugin = {
+	name: "microsoft-docs",
+	manifest: {
+		capabilities: ["mcp"],
+	},
+	setup(api) {
+		api.registerMcpServer({
+			name: "microsoft-learn",
+			transport: {
+				type: "streamableHttp",
+				url: "https://learn.microsoft.com/api/mcp",
+			},
+		})
+	},
+}
+
+export default plugin

--- a/plugins/microsoft-docs/index.ts
+++ b/plugins/microsoft-docs/index.ts
@@ -3,7 +3,7 @@ import type { AgentPlugin } from "@cline/sdk"
 const plugin: AgentPlugin = {
 	name: "microsoft-docs",
 	manifest: {
-		capabilities: ["mcp"],
+		capabilities: ["mcp", "skills"],
 	},
 	setup(api) {
 		api.registerMcpServer({

--- a/plugins/microsoft-docs/package.json
+++ b/plugins/microsoft-docs/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "microsoft-docs",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Cline plugin that registers Microsoft Learn MCP and bundles Microsoft documentation skills.",
+  "cline": {
+    "plugins": [
+      {
+        "paths": [
+          "./index.ts"
+        ],
+        "capabilities": [
+          "mcp",
+          "skills"
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/microsoft-docs/skills/microsoft-code-reference/SKILL.md
+++ b/plugins/microsoft-docs/skills/microsoft-code-reference/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: microsoft-code-reference
+description: Find working code samples, verify API signatures, and fix Microsoft SDK errors using official docs. Use whenever the user is writing, debugging, or reviewing code that touches any Microsoft SDK, .NET library, Azure client library, or Microsoft API-even if they don't ask for a "reference." Catches hallucinated methods, wrong signatures, and deprecated patterns. If the task involves producing or fixing Microsoft-related code, this is the right skill.
+---
+
+# Microsoft Code Reference
+
+## Tools
+
+| Need | Tool | Example |
+|------|------|---------|
+| API method/class lookup | `microsoft_docs_search` | `"BlobClient UploadAsync Azure.Storage.Blobs"` |
+| Working code sample | `microsoft_code_sample_search` | `query: "upload blob managed identity", language: "python"` |
+| Full API reference | `microsoft_docs_fetch` | Fetch URL from `microsoft_docs_search` (for overloads, full signatures) |
+
+## Finding Code Samples
+
+Use `microsoft_code_sample_search` to get official, working examples:
+
+```
+microsoft_code_sample_search(query: "upload file to blob storage", language: "csharp")
+microsoft_code_sample_search(query: "authenticate with managed identity", language: "python")
+microsoft_code_sample_search(query: "send message service bus", language: "javascript")
+```
+
+When to use:
+- Before writing code-find a working pattern to follow
+- After errors-compare your code against a known-good sample
+- Unsure of initialization/setup-samples show complete context
+
+## API Lookups
+
+```
+# Verify method exists (include namespace for precision)
+"BlobClient UploadAsync Azure.Storage.Blobs"
+"GraphServiceClient Users Microsoft.Graph"
+
+# Find class/interface
+"DefaultAzureCredential class Azure.Identity"
+
+# Find correct package
+"Azure Blob Storage NuGet package"
+"azure-storage-blob pip package"
+```
+
+Fetch full page when method has multiple overloads or you need complete parameter details.
+
+## Error Troubleshooting
+
+Use `microsoft_code_sample_search` to find working code samples and compare with your implementation. For specific errors, use `microsoft_docs_search` and `microsoft_docs_fetch`:
+
+| Error Type | Query |
+|------------|-------|
+| Method not found | `"[ClassName] methods [Namespace]"` |
+| Type not found | `"[TypeName] NuGet package namespace"` |
+| Wrong signature | `"[ClassName] [MethodName] overloads"` -> fetch full page |
+| Deprecated warning | `"[OldType] migration v12"` |
+| Auth failure | `"DefaultAzureCredential troubleshooting"` |
+| 403 Forbidden | `"[ServiceName] RBAC permissions"` |
+
+## When to Verify
+
+Always verify when:
+- Method name seems "too convenient" (`UploadFile` vs actual `Upload`)
+- Mixing SDK versions (v11 `CloudBlobClient` vs v12 `BlobServiceClient`)
+- Package name doesn't follow conventions (`Azure.*` for .NET, `azure-*` for Python)
+- Using an API for the first time
+
+## Validation Workflow
+
+Before generating code using Microsoft SDKs, verify it's correct:
+
+1. Confirm method or package exists - `microsoft_docs_search(query: "[ClassName] [MethodName] [Namespace]")`
+2. Fetch full details (for overloads/complex params) - `microsoft_docs_fetch(url: "...")`
+3. Find working sample - `microsoft_code_sample_search(query: "[task]", language: "[lang]")`
+
+For simple lookups, step 1 alone may suffice. For complex API usage, complete all three steps.
+
+## CLI Alternative
+
+Prefer the Cline-registered Microsoft Learn MCP tools. If the Learn MCP server is not available and the user approves a terminal fallback, use the `mslearn` CLI from the command line instead:
+
+```sh
+# Downloads and runs the package through npx; ask first.
+npx @microsoft/learn-cli search "BlobClient UploadAsync Azure.Storage.Blobs"
+
+# Or, with explicit approval, install globally, then run
+npm install -g @microsoft/learn-cli
+mslearn search "BlobClient UploadAsync Azure.Storage.Blobs"
+```
+
+| MCP Tool | CLI Command |
+|----------|-------------|
+| `microsoft_docs_search(query: "...")` | `mslearn search "..."` |
+| `microsoft_code_sample_search(query: "...", language: "...")` | `mslearn code-search "..." --language ...` |
+| `microsoft_docs_fetch(url: "...")` | `mslearn fetch "..."` |
+
+Pass `--json` to `search` or `code-search` to get raw JSON output for further processing. Do not include secrets, private customer data, or proprietary code in Microsoft Learn search queries unless the user explicitly asks.

--- a/plugins/microsoft-docs/skills/microsoft-docs/SKILL.md
+++ b/plugins/microsoft-docs/skills/microsoft-docs/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: microsoft-docs
+description: Understand Microsoft technologies by querying official documentation. Use whenever the user asks how something works, wants tutorials, needs configuration options, limits, quotas, or best practices for any Microsoft technology (Azure, .NET, M365, Windows, Power Platform, etc.)-even if they don't mention "docs." If the question is about understanding a concept rather than writing code, this is the right skill.
+---
+
+# Microsoft Docs
+
+## Tools
+
+| Tool | Use For |
+|------|---------|
+| `microsoft_docs_search` | Find documentation-concepts, guides, tutorials, configuration |
+| `microsoft_docs_fetch` | Get full page content (when search excerpts aren't enough) |
+
+## When to Use
+
+- Understanding concepts - "How does Cosmos DB partitioning work?"
+- Learning a service - "Azure Functions overview", "Container Apps architecture"
+- Finding tutorials - "quickstart", "getting started", "step-by-step"
+- Configuration options - "App Service configuration settings"
+- Limits & quotas - "Azure OpenAI rate limits", "Service Bus quotas"
+- Best practices - "Azure security best practices"
+
+## Query Effectiveness
+
+Good queries are specific:
+
+```
+# [no] Too broad
+"Azure Functions"
+
+# [yes] Specific
+"Azure Functions Python v2 programming model"
+"Cosmos DB partition key design best practices"
+"Container Apps scaling rules KEDA"
+```
+
+Include context:
+- Version when relevant (`.NET 8`, `EF Core 8`)
+- Task intent (`quickstart`, `tutorial`, `overview`, `limits`)
+- Platform for multi-platform docs (`Linux`, `Windows`)
+
+## When to Fetch Full Page
+
+Fetch after search when:
+- Tutorials - need complete step-by-step instructions
+- Configuration guides - need all options listed
+- Deep dives - user wants comprehensive coverage
+- Search excerpt is cut off - full context needed
+
+## Why Use This
+
+- Accuracy - live docs, not training data that may be outdated
+- Completeness - tutorials have all steps, not fragments
+- Authority - official Microsoft documentation
+
+## CLI Alternative
+
+Prefer the Cline-registered Microsoft Learn MCP tools. If the Learn MCP server is not available and the user approves a terminal fallback, use the `mslearn` CLI from the command line instead:
+
+```sh
+# Downloads and runs the package through npx; ask first.
+npx @microsoft/learn-cli search "azure functions timeout"
+
+# Or, with explicit approval, install globally, then run
+npm install -g @microsoft/learn-cli
+mslearn search "azure functions timeout"
+```
+
+| MCP Tool | CLI Command |
+|----------|-------------|
+| `microsoft_docs_search(query: "...")` | `mslearn search "..."` |
+| `microsoft_docs_fetch(url: "...")` | `mslearn fetch "..."` |
+
+The `fetch` command also supports `--section <heading>` to extract a single section and `--max-chars <number>` to truncate output. Do not include secrets, private customer data, or proprietary code in Microsoft Learn search queries unless the user explicitly asks.

--- a/plugins/microsoft-docs/skills/microsoft-skill-creator/SKILL.md
+++ b/plugins/microsoft-docs/skills/microsoft-skill-creator/SKILL.md
@@ -1,0 +1,258 @@
+---
+name: microsoft-skill-creator
+description: Create agent skills for Microsoft technologies using official documentation. Use whenever the user wants to build, generate, or scaffold a skill for any Microsoft technology (Azure, .NET, M365, VS Code, Bicep, etc.)-even phrased casually like "make a skill for Cosmos DB." Investigates the topic via official docs, then generates a hybrid skill with essential knowledge stored locally and dynamic lookups for depth.
+---
+
+# Microsoft Skill Creator
+
+Create hybrid skills for Microsoft technologies that store essential knowledge locally while enabling dynamic Learn MCP lookups for deeper details.
+
+## About Skills
+
+Skills are modular packages that extend agent capabilities with specialized knowledge and workflows. A skill transforms a general-purpose agent into a specialized one for a specific domain.
+
+### Cline Skill Destinations
+
+Before generating files, decide where the skill should live:
+
+- Project-local skill: `.cline/skills/{skill-name}/SKILL.md` when the skill is specific to the current repository.
+- User-local skill: ask the user where their Cline user skills directory lives before writing; do not guess.
+- Plugin-bundled skill: `plugins/{plugin-slug}/skills/{skill-name}/SKILL.md` when contributing to this plugin collection.
+
+Always state the destination and ask before creating or modifying skill files.
+
+### Skill Structure
+
+```
+skill-name/
+├── SKILL.md (required)     # Frontmatter (name, description) + instructions
+├── references/             # Documentation loaded into context as needed
+├── sample_codes/           # Working code examples
+└── assets/                 # Files used in output (templates, etc.)
+```
+
+### Key Principles
+
+- Frontmatter is critical: `name` and `description` determine when the skill triggers-be clear and comprehensive
+- Concise is key: Only include what agents don't already know; context window is shared
+- No duplication: Information lives in SKILL.md OR reference files, not both
+
+## Learn MCP Tools
+
+| Tool | Purpose | When to Use |
+|------|---------|-------------|
+| `microsoft_docs_search` | Search official docs | First pass discovery, finding topics |
+| `microsoft_docs_fetch` | Get full page content | Deep dive into important pages |
+| `microsoft_code_sample_search` | Find code examples | Get implementation patterns |
+
+### CLI Alternative
+
+Prefer the Cline-registered Microsoft Learn MCP tools. If the Learn MCP server is not available and the user approves a terminal fallback, use the `mslearn` CLI from the command line instead:
+
+```sh
+# Downloads and runs the package through npx; ask first.
+npx @microsoft/learn-cli search "semantic kernel overview"
+
+# Or, with explicit approval, install globally, then run
+npm install -g @microsoft/learn-cli
+mslearn search "semantic kernel overview"
+```
+
+| MCP Tool | CLI Command |
+|----------|-------------|
+| `microsoft_docs_search(query: "...")` | `mslearn search "..."` |
+| `microsoft_code_sample_search(query: "...", language: "...")` | `mslearn code-search "..." --language ...` |
+| `microsoft_docs_fetch(url: "...")` | `mslearn fetch "..."` |
+
+Generated skills should include this same CLI fallback table so agents can use either path, with explicit approval before any `npx` package download or global npm install.
+
+## Creation Process
+
+### Step 1: Investigate the Topic
+
+Build deep understanding using Learn MCP tools in three phases:
+
+Phase 1 - Scope Discovery:
+```
+microsoft_docs_search(query="{technology} overview what is")
+microsoft_docs_search(query="{technology} concepts architecture")
+microsoft_docs_search(query="{technology} getting started tutorial")
+```
+
+Phase 2 - Core Content:
+```
+microsoft_docs_fetch(url="...")  # Fetch pages from Phase 1
+microsoft_code_sample_search(query="{technology}", language="{lang}")
+```
+
+Phase 3 - Depth:
+```
+microsoft_docs_search(query="{technology} best practices")
+microsoft_docs_search(query="{technology} troubleshooting errors")
+```
+
+#### Investigation Checklist
+
+After investigating, verify:
+- [ ] Can explain what the technology does in one paragraph
+- [ ] Identified 3-5 key concepts
+- [ ] Have working code for basic usage
+- [ ] Know the most common API patterns
+- [ ] Have search queries for deeper topics
+
+### Step 2: Clarify with User
+
+Present findings and ask:
+1. "I found these key areas: [list]. Which are most important?"
+2. "What tasks will agents primarily perform with this skill?"
+3. "Which programming language should code samples prioritize?"
+
+### Step 3: Generate the Skill
+
+Use the appropriate template from [skill-templates.md](references/skill-templates.md):
+
+| Technology Type | Template |
+|-----------------|----------|
+| Client library, NuGet/npm package | SDK/Library |
+| Azure resource | Azure Service |
+| App development framework | Framework/Platform |
+| REST API, protocol | API/Protocol |
+
+#### Generated Skill Structure
+
+```
+plugins/{plugin-slug}/skills/{skill-name}/
+├── SKILL.md                    # Core knowledge + Learn MCP guidance
+├── references/                 # Detailed local documentation (if needed)
+└── sample_codes/               # Working code examples
+    ├── getting-started/
+    └── common-patterns/
+```
+
+### Step 4: Balance Local vs Dynamic Content
+
+Store locally when:
+- Foundational (needed for any task)
+- Frequently accessed
+- Stable (won't change)
+- Hard to find via search
+
+Keep dynamic when:
+- Exhaustive reference (too large)
+- Version-specific
+- Situational (specific tasks only)
+- Well-indexed (easy to search)
+
+#### Content Guidelines
+
+| Content Type | Local | Dynamic |
+|--------------|-------|---------|
+| Core concepts (3-5) | [yes] Full | |
+| Hello world code | [yes] Full | |
+| Common patterns (3-5) | [yes] Full | |
+| Top API methods | Signature + example | Full docs via fetch |
+| Best practices | Top 5 bullets | Search for more |
+| Troubleshooting | | Search queries |
+| Full API reference | | Doc links |
+
+### Step 5: Validate
+
+1. Review: Is local content sufficient for common tasks?
+2. Test: Do suggested search queries return useful results?
+3. Verify: Do code samples run without errors?
+
+## Common Investigation Patterns
+
+### For SDKs/Libraries
+```
+"{name} overview" -> purpose, architecture
+"{name} getting started quickstart" -> setup steps
+"{name} API reference" -> core classes/methods
+"{name} samples examples" -> code patterns
+"{name} best practices performance" -> optimization
+```
+
+### For Azure Services
+```
+"{service} overview features" -> capabilities
+"{service} quickstart {language}" -> setup code
+"{service} REST API reference" -> endpoints
+"{service} SDK {language}" -> client library
+"{service} pricing limits quotas" -> constraints
+```
+
+### For Frameworks/Platforms
+```
+"{framework} architecture concepts" -> mental model
+"{framework} project structure" -> conventions
+"{framework} tutorial walkthrough" -> end-to-end flow
+"{framework} configuration options" -> customization
+```
+
+## Example: Creating a "Semantic Kernel" Skill
+
+### Investigation
+
+```
+microsoft_docs_search(query="semantic kernel overview")
+microsoft_docs_search(query="semantic kernel plugins functions")
+microsoft_code_sample_search(query="semantic kernel", language="csharp")
+microsoft_docs_fetch(url="https://learn.microsoft.com/semantic-kernel/overview/")
+```
+
+### Generated Skill
+
+```
+semantic-kernel/
+├── SKILL.md
+└── sample_codes/
+    ├── getting-started/
+    │   └── hello-kernel.cs
+    └── common-patterns/
+        ├── chat-completion.cs
+        └── function-calling.cs
+```
+
+### Generated SKILL.md
+
+```markdown
+---
+name: semantic-kernel
+description: Build AI agents with Microsoft Semantic Kernel. Use for LLM-powered apps with plugins, planners, and memory in .NET or Python.
+---
+
+# Semantic Kernel
+
+Orchestration SDK for integrating LLMs into applications with plugins, planners, and memory.
+
+## Key Concepts
+
+- Kernel: Central orchestrator managing AI services and plugins
+- Plugins: Collections of functions the AI can call
+- Planner: Sequences plugin functions to achieve goals
+- Memory: Vector store integration for RAG patterns
+
+## Quick Start
+
+See [getting-started/hello-kernel.cs](sample_codes/getting-started/hello-kernel.cs)
+
+## Learn More
+
+| Topic | How to Find |
+|-------|-------------|
+| Plugin development | `microsoft_docs_search(query="semantic kernel plugins custom functions")` |
+| Planners | `microsoft_docs_search(query="semantic kernel planner")` |
+| Memory | `microsoft_docs_fetch(url="https://learn.microsoft.com/en-us/semantic-kernel/frameworks/agent/agent-memory")` |
+
+## CLI Alternative
+
+If the Learn MCP server is not available and the user approves a terminal fallback, use the `mslearn` CLI instead:
+
+| MCP Tool | CLI Command |
+|----------|-------------|
+| `microsoft_docs_search(query: "...")` | `mslearn search "..."` |
+| `microsoft_code_sample_search(query: "...", language: "...")` | `mslearn code-search "..." --language ...` |
+| `microsoft_docs_fetch(url: "...")` | `mslearn fetch "..."` |
+
+Run directly with `npx @microsoft/learn-cli <command>` or install globally with `npm install -g @microsoft/learn-cli` only after explicit approval.
+```

--- a/plugins/microsoft-docs/skills/microsoft-skill-creator/references/skill-templates.md
+++ b/plugins/microsoft-docs/skills/microsoft-skill-creator/references/skill-templates.md
@@ -1,0 +1,355 @@
+# Skill Templates
+
+Ready-to-use templates for different types of Microsoft technologies.
+
+## CLI Alternative for MCP Tools
+
+All templates below use MCP tool calls (e.g., `microsoft_docs_search`, `microsoft_docs_fetch`, `microsoft_code_sample_search`). If the Learn MCP server is not available and the user approves a terminal fallback, replace them with CLI equivalents:
+
+| MCP Tool | CLI Command |
+|----------|-------------|
+| `microsoft_docs_search(query: "...")` | `mslearn search "..."` |
+| `microsoft_code_sample_search(query: "...", language: "...")` | `mslearn code-search "..." --language ...` |
+| `microsoft_docs_fetch(url: "...")` | `mslearn fetch "..."` |
+
+Run directly with `npx @microsoft/learn-cli <command>` or install globally with `npm install -g @microsoft/learn-cli` only after explicit approval.
+
+## Cline Skill Destinations
+
+Before writing generated files, choose and state the destination:
+
+- Project-local skill: `.cline/skills/{skill-name}/SKILL.md`.
+- User-local skill: ask the user for the Cline user skills directory before writing.
+- Plugin-bundled skill: `plugins/{plugin-slug}/skills/{skill-name}/SKILL.md`.
+
+Ask before creating or modifying skill files.
+
+## Template 1: SDK/Library Skill
+
+For client libraries, SDKs, and programming frameworks.
+
+```markdown
+---
+name: {sdk-name}
+description: {What it does}. Use when agents need to {primary task} with {technology context}. Supports {languages/platforms}.
+---
+
+# {SDK Name}
+
+{One paragraph: what it is, why it exists, when to use it}
+
+## Installation
+
+{Package manager commands for supported languages}
+
+## Key Concepts
+
+{3-5 essential concepts, one paragraph each max}
+
+### {Concept 1}
+{Brief explanation}
+
+### {Concept 2}
+{Brief explanation}
+
+## Quick Start
+
+{Minimal working example - inline if <30 lines, otherwise reference sample_codes/}
+
+## Common Patterns
+
+### {Pattern 1: e.g., "Basic CRUD"}
+```{language}
+{code}
+```
+
+### {Pattern 2: e.g., "Error Handling"}
+```{language}
+{code}
+```
+
+## API Quick Reference
+
+| Class/Method | Purpose | Example |
+|--------------|---------|---------|
+| {name} | {what it does} | `{usage}` |
+
+For full API documentation:
+- `microsoft_docs_search(query="{sdk} {class} API reference")`
+- `microsoft_docs_fetch(url="{url}")`
+
+## Best Practices
+
+- Do: {recommendation}
+- Do: {recommendation}
+- Avoid: {anti-pattern}
+
+See [best-practices.md](references/best-practices.md) for detailed guidance.
+
+## Learn More
+
+| Topic | How to Find |
+|-------|-------------|
+| {Advanced topic 1} | `microsoft_docs_search(query="{sdk} {topic}")` |
+| {Advanced topic 2} | `microsoft_docs_fetch(url="{url}")` |
+| {Code examples} | `microsoft_code_sample_search(query="{sdk} {scenario}", language="{lang}")` |
+```
+
+---
+
+## Template 2: Azure Service Skill
+
+For Azure services and cloud resources.
+
+```markdown
+---
+name: {service-name}
+description: Work with {Azure Service}. Use when agents need to {primary capabilities}. Covers provisioning, configuration, and SDK usage.
+---
+
+# {Azure Service Name}
+
+{One paragraph: what the service does, primary use cases}
+
+## Overview
+
+- Category: {Compute/Storage/AI/Networking/etc.}
+- Key capability: {main value proposition}
+- When to use: {scenarios}
+
+## Getting Started
+
+### Prerequisites
+- Azure subscription
+- {Other requirements}
+
+### Provisioning
+{CLI/Portal/Bicep snippet for creating the resource}
+
+## SDK Usage ({Language})
+
+### Installation
+```
+{package install command}
+```
+
+### Authentication
+```{language}
+{auth code pattern}
+```
+
+### Basic Operations
+```{language}
+{CRUD or primary operations}
+```
+
+## Key Configurations
+
+| Setting | Purpose | Default |
+|---------|---------|---------|
+| {setting} | {what it controls} | {value} |
+
+## Pricing & Limits
+
+- Pricing model: {consumption/tier-based/etc.}
+- Key limits: {important quotas}
+
+For current pricing: `microsoft_docs_search(query="{service} pricing")`
+
+## Common Patterns
+
+### {Pattern 1}
+{Code or configuration}
+
+### {Pattern 2}
+{Code or configuration}
+
+## Troubleshooting
+
+| Issue | Solution |
+|-------|----------|
+| {Common error} | {Fix} |
+
+For more issues: `microsoft_docs_search(query="{service} troubleshoot {symptom}")`
+
+## Learn More
+
+| Topic | How to Find |
+|-------|-------------|
+| REST API | `microsoft_docs_fetch(url="{url}")` |
+| ARM/Bicep | `microsoft_docs_search(query="{service} bicep template")` |
+| Security | `microsoft_docs_search(query="{service} security best practices")` |
+```
+
+---
+
+## Template 3: Framework/Platform Skill
+
+For development frameworks and platforms (e.g., ASP.NET, MAUI, Blazor).
+
+```markdown
+---
+name: {framework-name}
+description: Build {type of apps} with {Framework}. Use when agents need to create, modify, or debug {framework} applications.
+---
+
+# {Framework Name}
+
+{One paragraph: what it is, what you build with it, why choose it}
+
+## Project Structure
+
+```
+{typical-project}/
+├── {folder}/     # {purpose}
+├── {file}        # {purpose}
+└── {file}        # {purpose}
+```
+
+## Getting Started
+
+### Create New Project
+```bash
+{CLI command to scaffold}
+```
+
+### Project Configuration
+{Key files to configure and what they control}
+
+## Core Concepts
+
+### {Concept 1: e.g., "Components"}
+{Explanation with minimal code example}
+
+### {Concept 2: e.g., "Routing"}
+{Explanation with minimal code example}
+
+### {Concept 3: e.g., "State Management"}
+{Explanation with minimal code example}
+
+## Common Patterns
+
+### {Pattern 1}
+```{language}
+{code}
+```
+
+### {Pattern 2}
+```{language}
+{code}
+```
+
+## Configuration Options
+
+| Setting | File | Purpose |
+|---------|------|---------|
+| {setting} | {file} | {what it does} |
+
+## Deployment
+
+{Brief deployment guidance or reference}
+
+For detailed deployment: `microsoft_docs_search(query="{framework} deploy {target}")`
+
+## Learn More
+
+| Topic | How to Find |
+|-------|-------------|
+| {Advanced feature} | `microsoft_docs_search(query="{framework} {feature}")` |
+| {Integration} | `microsoft_docs_fetch(url="{url}")` |
+| {Samples} | `microsoft_code_sample_search(query="{framework} {scenario}")` |
+```
+
+---
+
+## Template 4: API/Protocol Skill
+
+For APIs, protocols, and specifications (e.g., Microsoft Graph, OOXML).
+
+```markdown
+---
+name: {api-name}
+description: Interact with {API/Protocol}. Use when agents need to {primary operations}. Covers authentication, endpoints, and common operations.
+---
+
+# {API/Protocol Name}
+
+{One paragraph: what it provides access to, primary use cases}
+
+## Authentication
+
+{Auth method and code pattern}
+
+## Base Configuration
+
+- Base URL: `{url}`
+- Version: `{version}`
+- Format: {JSON/XML/etc.}
+
+## Common Endpoints/Operations
+
+### {Operation 1: e.g., "List Items"}
+```
+{HTTP method} {endpoint}
+```
+```{language}
+{SDK code}
+```
+
+### {Operation 2: e.g., "Create Item"}
+```
+{HTTP method} {endpoint}
+```
+```{language}
+{SDK code}
+```
+
+## Request/Response Patterns
+
+### Pagination
+{How to handle pagination}
+
+### Error Handling
+{Error format and common codes}
+
+## Quick Reference
+
+| Operation | Endpoint/Method | Notes |
+|-----------|-----------------|-------|
+| {op} | `{endpoint}` | {note} |
+
+## Permissions/Scopes
+
+| Operation | Required Permission |
+|-----------|---------------------|
+| {op} | `{permission}` |
+
+## Learn More
+
+| Topic | How to Find |
+|-------|-------------|
+| Full endpoint reference | `microsoft_docs_fetch(url="{url}")` |
+| Permissions | `microsoft_docs_search(query="{api} permissions {resource}")` |
+| SDKs | `microsoft_docs_search(query="{api} SDK {language}")` |
+```
+
+---
+
+## Choosing a Template
+
+| Technology Type | Template | Examples |
+|-----------------|----------|----------|
+| Client library, NuGet/npm package | SDK/Library | Semantic Kernel, Azure SDK, MSAL |
+| Azure resource | Azure Service | Cosmos DB, Azure Functions, App Service |
+| App development framework | Framework/Platform | ASP.NET Core, Blazor, MAUI |
+| REST API, protocol, specification | API/Protocol | Microsoft Graph, OOXML, FHIR |
+
+## Customization Guidelines
+
+Templates are starting points. Customize by:
+
+1. Adding sections for unique aspects of the technology
+2. Removing sections that don't apply
+3. Adjusting depth based on complexity (more concepts for complex tech)
+4. Adding reference files for detailed content that doesn't fit in SKILL.md
+5. Adding sample_codes/ for working examples beyond inline snippets


### PR DESCRIPTION
## Microsoft Docs

This adds a Cline plugin for Microsoft Learn. It registers the public Microsoft Learn MCP server and bundles focused skills for using official Microsoft documentation, API references, and code samples when working with Azure, .NET, Microsoft 365, Windows, Power Platform, and related Microsoft technologies.

## Cline Primitives

- `mcp`: registers the `microsoft-learn` Streamable HTTP MCP server at `https://learn.microsoft.com/api/mcp`. The server exposes Microsoft Learn search, page fetch, and official code-sample lookup tools.
- `skills`: bundles three Microsoft-focused workflows: `microsoft-docs` for conceptual docs, tutorials, configuration, limits, and best practices; `microsoft-code-reference` for validating SDK/API signatures and finding official samples before writing or fixing code; and `microsoft-skill-creator` for building Cline skills about Microsoft technologies using Microsoft Learn as the source of truth.

## Requirements

- Network access to `https://learn.microsoft.com/api/mcp`.
- No Microsoft account or API key is required for the public Microsoft Learn MCP server.
- Optional `@microsoft/learn-cli` fallback only when the user approves an `npx` package download or global npm install.
- No existing manual MCP server named `microsoft-learn`; if one already exists, Cline preserves the user-managed entry.

## Trust Boundaries

Microsoft Learn MCP searches send documentation queries, page URLs, code-sample queries, and relevant task context to Microsoft Learn. The skills tell Cline not to include secrets, private customer data, proprietary code, or sensitive incident details in queries unless the user explicitly asks. Bundled Microsoft skill material is attributed with local notice and license files.