### PR TITLE
feat: add codspeed plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Each plugin lives in `plugins/<slug>`. The directory name is the install keyword
 | `bundled-skills-demo` | A package plugin that proves bundled skill discovery works. |
 | `custom-compaction` | Provider message compaction through a plugin message builder. |
 | `clickhouse-data-analyst` | ClickHouse data analyst skill with supporting analysis and ClickHouse sub-skills. |
+| `codspeed` | CodSpeed performance runs, comparisons, and flamegraph analysis through MCP. |
 | `env-blocker` | A hook that blocks reads of secret `.env` files. |
 | `gitignore-read-files-guard` | A hook that blocks file access to `.gitignore` ignored paths. |
 | `goal` | Completion nudges for active goals with a slash command and completion tool. |

--- a/plugins/codspeed/README.md
+++ b/plugins/codspeed/README.md
@@ -1,0 +1,40 @@
+# codspeed
+
+Adds the CodSpeed MCP server to Cline.
+
+## What It Does
+
+Registers a `codspeed` MCP server at `https://mcp.codspeed.io/mcp`. The CodSpeed MCP server helps Cline inspect CodSpeed benchmark runs, compare performance changes, and analyze flamegraph data available to the authenticated CodSpeed account.
+
+## Install
+
+```bash
+cline plugin install codspeed
+```
+
+For local development from this repository:
+
+```bash
+cline plugin install ./plugins/codspeed --cwd .
+```
+
+## Example Usage
+
+After installation and any required CodSpeed authorization, ask Cline:
+
+```text
+Use CodSpeed to compare the latest benchmark run against main and identify the hottest regression.
+```
+
+Cline can use the registered CodSpeed MCP server when it is available in the MCP runtime.
+
+## Requirements
+
+- Network access to `https://mcp.codspeed.io/mcp`.
+- A CodSpeed account with access to the projects and benchmark runs you want Cline to inspect.
+- OAuth authorization through Cline's MCP auth flow when required by the CodSpeed MCP server.
+- No existing manual MCP server named `codspeed`. If one already exists, Cline leaves the manual entry alone and the plugin does not replace it.
+
+## Security Notes
+
+CodSpeed MCP tools can read benchmark metadata, run comparisons, flamegraph details, and related project performance data depending on your account permissions and selected tool call. Review requested actions before allowing changes to benchmark configuration, CI setup, or project performance workflows.

--- a/plugins/codspeed/index.ts
+++ b/plugins/codspeed/index.ts
@@ -1,0 +1,19 @@
+import type { AgentPlugin } from "@cline/sdk"
+
+const plugin: AgentPlugin = {
+	name: "codspeed",
+	manifest: {
+		capabilities: ["mcp"],
+	},
+	setup(api) {
+		api.registerMcpServer({
+			name: "codspeed",
+			transport: {
+				type: "streamableHttp",
+				url: "https://mcp.codspeed.io/mcp",
+			},
+		})
+	},
+}
+
+export default plugin


### PR DESCRIPTION
## CodSpeed Plugin

Adds `codspeed`, a Cline plugin for CodSpeed performance analysis workflows.

## Cline Primitives

This plugin uses the MCP primitive. It registers one remote MCP server named `codspeed` at `https://mcp.codspeed.io/mcp` using Streamable HTTP.

The CodSpeed MCP server exposes tools for working with an authenticated CodSpeed account, including benchmark runs, performance comparisons, and flamegraph analysis available to the user. The plugin intentionally stays MCP-only so the live CodSpeed server remains the integration surface without bundling a heavier performance workflow skill.

## Requirements

- Network access to `https://mcp.codspeed.io/mcp`.
- A CodSpeed account with access to the projects and benchmark runs the user wants Cline to inspect.
- OAuth authorization through Cline's MCP auth flow when required by the CodSpeed MCP server.
- No existing manual MCP server named `codspeed`; Cline leaves existing manual MCP entries alone instead of replacing them from a plugin install.

CodSpeed MCP tools can read benchmark metadata, run comparisons, flamegraph details, and related project performance data depending on account permissions and selected tool calls. Users should review requested actions before allowing changes to benchmark configuration, CI setup, or project performance workflows.
