### PR TITLE
feat: add cds mcp plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Each plugin lives in `plugins/<slug>`. The directory name is the install keyword
 | `background-terminal` | Long-running shell jobs with polling and cleanup tools. |
 | `branch-protector` | A hook that blocks protected branch pushes unless explicitly allowed. |
 | `bundled-skills-demo` | A package plugin that proves bundled skill discovery works. |
+| `cds-mcp` | SAP CAP model and documentation search through MCP. |
 | `custom-compaction` | Provider message compaction through a plugin message builder. |
 | `clickhouse-data-analyst` | ClickHouse data analyst skill with supporting analysis and ClickHouse sub-skills. |
 | `env-blocker` | A hook that blocks reads of secret `.env` files. |

--- a/plugins/cds-mcp/README.md
+++ b/plugins/cds-mcp/README.md
@@ -1,0 +1,40 @@
+# cds-mcp
+
+Adds the SAP CAP MCP server to Cline.
+
+## What It Does
+
+Registers a `cds-mcp` MCP server backed by the pinned `@cap-js/mcp-server` package. The CAP MCP server helps Cline search CDS model definitions in the current workspace and search SAP Cloud Application Programming Model documentation.
+
+## Install
+
+```bash
+cline plugin install cds-mcp
+```
+
+For local development from this repository:
+
+```bash
+cline plugin install ./plugins/cds-mcp --cwd .
+```
+
+## Example Usage
+
+After installation in a CAP project workspace, ask Cline:
+
+```text
+Use cds-mcp to find the services and entities in this CAP project before changing the model.
+```
+
+Cline can use the registered CAP MCP server when it is available in the MCP runtime.
+
+## Requirements
+
+- Node.js available on PATH.
+- Network access during installation to download `@cap-js/mcp-server` and its dependencies.
+- A SAP CAP project workspace when using model-search tools.
+- No existing manual MCP server named `cds-mcp`. If one already exists, Cline leaves the manual entry alone and the plugin does not replace it.
+
+## Security Notes
+
+The CAP MCP server runs locally and can inspect CDS model files in the workspace where the plugin was installed. Documentation search uses local package data and model search reads project files. Review requested actions before allowing changes to CAP models, services, or project configuration.

--- a/plugins/cds-mcp/index.ts
+++ b/plugins/cds-mcp/index.ts
@@ -1,0 +1,25 @@
+import { createRequire } from "node:module"
+import type { AgentPlugin } from "@cline/sdk"
+
+const require = createRequire(import.meta.url)
+const serverPath = require.resolve("@cap-js/mcp-server")
+
+const plugin: AgentPlugin = {
+	name: "cds-mcp",
+	manifest: {
+		capabilities: ["mcp"],
+	},
+	setup(api, ctx) {
+		api.registerMcpServer({
+			name: "cds-mcp",
+			transport: {
+				type: "stdio",
+				command: "node",
+				args: [serverPath],
+				cwd: ctx.workspaceInfo?.rootPath ?? process.cwd(),
+			},
+		})
+	},
+}
+
+export default plugin

--- a/plugins/cds-mcp/package.json
+++ b/plugins/cds-mcp/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "cds-mcp",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Cline plugin that registers the SAP CAP MCP server.",
+  "cline": {
+    "plugins": [
+      {
+        "paths": [
+          "./index.ts"
+        ],
+        "capabilities": [
+          "mcp"
+        ]
+      }
+    ]
+  },
+  "dependencies": {
+    "@cap-js/mcp-server": "0.0.5"
+  }
+}


### PR DESCRIPTION
## CDS MCP Plugin

Adds `cds-mcp`, a Cline plugin for SAP Cloud Application Programming Model development workflows.

## Cline Primitives

This plugin uses the MCP primitive. It registers one local stdio MCP server named `cds-mcp`, backed by the pinned `@cap-js/mcp-server` package installed with the plugin.

The CAP MCP server exposes tools for searching CDS model definitions in the current workspace and searching SAP CAP documentation. The plugin runs the server from the user workspace so model-search tools inspect the CAP project rather than the plugin install directory.

## Requirements

- Node.js available on PATH.
- Network access during installation to download `@cap-js/mcp-server` and its dependencies.
- A SAP CAP project workspace when using model-search tools.
- No existing manual MCP server named `cds-mcp`; Cline leaves existing manual MCP entries alone instead of replacing them from a plugin install.

The CAP MCP server runs locally and can inspect CDS model files in the workspace where the plugin was installed. Users should review requested actions before allowing changes to CAP models, services, or project configuration.
