### PR TITLE
feat: add endor labs plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Each plugin lives in `plugins/<slug>`. The directory name is the install keyword
 | Plugin | What it adds |
 | --- | --- |
 | `agent-browser` | Web and Electron browser automation via the agent-browser CLI skill. |
+| `ai-plugins` | Endor Labs MCP tools and setup guidance for software supply-chain security scans. |
 | `agents-squad` | Background subagents with presets, skills, and shared handoffs. |
 | `background-terminal` | Long-running shell jobs with polling and cleanup tools. |
 | `branch-protector` | A hook that blocks protected branch pushes unless explicitly allowed. |

--- a/plugins/ai-plugins/README.md
+++ b/plugins/ai-plugins/README.md
@@ -1,0 +1,54 @@
+# ai-plugins
+
+Endor Labs supply-chain security support for Cline.
+
+## What It Adds
+
+This plugin adds the `endor-cli-tools` MCP server and an `endor-setup` skill.
+
+The MCP server starts with:
+
+```bash
+endorctl ai-tools mcp-server
+```
+
+That server exposes Endor Labs CLI-backed tools for scanning and analyzing software supply-chain risk when the user has `endorctl` access configured.
+
+The bundled `endor-setup` skill helps Cline install or verify `endorctl`, choose an Endor namespace, authenticate safely, and run scans with explicit user approval.
+
+## Install
+
+```bash
+cline plugin install ai-plugins
+cline config mcp
+cline config skills
+```
+
+For local development from this repository:
+
+```bash
+cline plugin install ./plugins/ai-plugins --cwd .
+```
+
+## Example Usage
+
+After installation, ask Cline:
+
+```text
+Use the endor-setup skill to check whether this repository is ready for an Endor Labs scan.
+```
+
+```text
+Use Endor Labs to scan this project for dependency and supply-chain risk.
+```
+
+## Requirements
+
+- `endorctl` installed and available on `PATH`.
+- Endor Labs access and a namespace for the project or tenant to scan.
+- Browser authentication or API credentials configured through environment variables.
+- User approval before installing `endorctl`, starting authentication, reading existing Endor config, or running a scan.
+
+## Security Notes
+
+Do not paste Endor API keys or secrets into chat. Use environment variables such as `ENDOR_API_CREDENTIALS_KEY` and `ENDOR_API_CREDENTIALS_SECRET` for non-browser authentication. Review scan scope before running commands, especially in repositories with private dependencies or production release artifacts.

--- a/plugins/ai-plugins/index.ts
+++ b/plugins/ai-plugins/index.ts
@@ -1,0 +1,21 @@
+import type { AgentPlugin } from "@cline/sdk"
+
+const plugin: AgentPlugin = {
+	name: "ai-plugins",
+	manifest: {
+		capabilities: ["mcp", "skills"],
+	},
+
+	setup(api) {
+		api.registerMcpServer({
+			name: "endor-cli-tools",
+			transport: {
+				type: "stdio",
+				command: "endorctl",
+				args: ["ai-tools", "mcp-server"],
+			},
+		})
+	},
+}
+
+export default plugin

--- a/plugins/ai-plugins/package.json
+++ b/plugins/ai-plugins/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "ai-plugins",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Cline plugin that registers Endor Labs MCP tools and bundles an endorctl setup skill.",
+  "cline": {
+    "plugins": [
+      {
+        "paths": [
+          "./index.ts"
+        ],
+        "capabilities": [
+          "mcp",
+          "skills"
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/ai-plugins/skills/endor-setup/SKILL.md
+++ b/plugins/ai-plugins/skills/endor-setup/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: endor-setup
+description: Use this skill when setting up endorctl, authenticating Endor Labs, choosing a namespace, or running Endor Labs software supply-chain scans.
+---
+
+# Endor Setup
+
+Use this skill to help Cline prepare and run Endor Labs `endorctl` scans.
+
+## Guardrails
+
+- Ask before installing or downloading `endorctl`.
+- Ask before starting browser authentication.
+- Ask before reading `~/.endorctl/config.yaml`, and never print the full config file.
+- Never ask the user to paste API credentials into chat.
+- Use environment variables for API key authentication.
+- Always confirm the Endor namespace before scanning, even if a previous config exists.
+- Present the scan plan before running it.
+- Do not run the same scan twice just to summarize results. Parse the first result instead.
+
+## Setup Flow
+
+1. Check whether `endorctl` is available:
+
+```bash
+command -v endorctl && endorctl --version
+```
+
+2. If `endorctl` is missing, ask the user before installing it. Prefer the user's normal package manager when available. Direct downloads should come from Endor Labs and should verify checksums when the platform provides them.
+
+3. Ask for the Endor namespace. Parent and child namespaces are both valid, for example `company` or `company.project`.
+
+4. Check whether authentication is already configured only after user approval:
+
+```bash
+test -f ~/.endorctl/config.yaml && echo "CONFIG_EXISTS" || echo "NOT_AUTHENTICATED"
+```
+
+5. If authentication is needed, ask which mode to use:
+
+- Browser authentication for interactive local development.
+- API key authentication for CI and non-interactive environments.
+
+For API key authentication, tell the user to set values in their shell or secret manager:
+
+```bash
+export ENDOR_API_CREDENTIALS_KEY=<api-key>
+export ENDOR_API_CREDENTIALS_SECRET=<api-secret>
+```
+
+Do not ask for the credential values in chat.
+
+## Browser Authentication
+
+For browser authentication, collect the namespace first so the command can avoid unnecessary prompts:
+
+```bash
+endorctl init --namespace=<namespace>
+```
+
+If the user needs a specific provider, add the appropriate auth mode supported by their installed `endorctl` version, such as Google, GitHub, GitLab, SSO, or generic browser auth.
+
+If authentication fails because the account has multiple tenants or no access to the namespace:
+
+- Show the relevant error.
+- Ask the user to confirm the namespace.
+- Offer to use API key authentication for non-interactive environments.
+- Do not retry indefinitely.
+
+## Running Scans
+
+Before scanning, confirm:
+
+- Repository path.
+- Endor namespace.
+- Scan type, such as default, quick, secrets, SAST, or container.
+- Whether dependency manifests, private package metadata, or release artifacts may be sent to Endor Labs.
+
+For the default scan:
+
+```bash
+endorctl scan --namespace=<namespace>
+```
+
+For a specific scan type, check the installed `endorctl scan --help` output or Endor Labs documentation for the current flag before running the command. Do not guess flag names.
+
+## Result Handling
+
+- Summarize critical and high findings first.
+- Separate vulnerable dependencies, reachability, secrets, malware, license, and policy findings when the scan reports them.
+- Include package names, versions, fix versions, and affected manifests when available.
+- Recommend the smallest practical remediation path.
+- If a namespace or permission error occurs, report it directly and ask the user to choose another namespace or verify Endor Labs access.


### PR DESCRIPTION
## Endor Labs

Adds an Endor Labs plugin for Cline users who want software supply-chain security scans and dependency risk analysis from their coding workflow.

The plugin is intentionally small: it registers the Endor Labs MCP server and bundles setup guidance for `endorctl`. It does not install `endorctl` on plugin install and does not start downloads through `npx`; the MCP server expects `endorctl` to already be installed and available on `PATH`.

## Cline Primitives

This plugin uses two Cline primitives:

- MCP: registers `endor-cli-tools`, a stdio MCP server started with `endorctl ai-tools mcp-server`. The server exposes Endor Labs CLI-backed tools for scanning and analyzing dependency and supply-chain risk.
- Skill: bundles `endor-setup`, which helps Cline verify or install `endorctl`, choose the right Endor namespace, handle browser or API-key authentication, and plan scans with explicit user approval.

## Requirements

Users need `endorctl` installed, Endor Labs access, and an Endor namespace for the repository or tenant they want to scan. Browser authentication can be used for local workflows; API-key authentication should be configured through environment variables such as `ENDOR_API_CREDENTIALS_KEY` and `ENDOR_API_CREDENTIALS_SECRET`.

The skill avoids asking for secrets in chat and asks before installing `endorctl`, starting authentication, reading Endor config state, or running scans. Scan scope should be reviewed before execution, especially for private dependency metadata or production release artifacts.
