### PR TITLE
feat: add aikido security plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Each plugin lives in `plugins/<slug>`. The directory name is the install keyword
 | Plugin | What it adds |
 | --- | --- |
 | `agent-browser` | Web and Electron browser automation via the agent-browser CLI skill. |
+| `aikido` | Aikido Security MCP tools and skills for setup, scans, and issue triage. |
 | `agents-squad` | Background subagents with presets, skills, and shared handoffs. |
 | `background-terminal` | Long-running shell jobs with polling and cleanup tools. |
 | `branch-protector` | A hook that blocks protected branch pushes unless explicitly allowed. |

--- a/plugins/aikido/README.md
+++ b/plugins/aikido/README.md
@@ -1,0 +1,60 @@
+# aikido
+
+Aikido Security support for Cline.
+
+## What It Adds
+
+This plugin adds the `aikido-mcp` MCP server and three bundled skills:
+
+- `aikido-setup`: verify Node.js, start or refresh Aikido browser sign-in, and confirm the MCP server is reachable.
+- `aikido-scan`: scan selected project files for SAST and secret findings through Aikido, then help fix and rescan.
+- `aikido-issues`: list, count, summarize, and triage issues from the Aikido security feed.
+
+The MCP server runs the installed `aikido-mcp` bin from the plugin package:
+
+```bash
+npx --no-install aikido-mcp
+```
+
+The Aikido MCP package is pinned as a plugin dependency, so the server does not rely on startup-time package downloads.
+
+## Install
+
+```bash
+cline plugin install aikido
+cline config mcp
+cline config skills
+```
+
+For local development from this repository:
+
+```bash
+cline plugin install ./plugins/aikido --cwd .
+```
+
+## Example Usage
+
+After installation, ask Cline:
+
+```text
+Use the aikido-setup skill to sign in to Aikido and verify the MCP server.
+```
+
+```text
+Use Aikido to scan the files changed in this branch.
+```
+
+```text
+Show the current high severity Aikido issues for this repository.
+```
+
+## Requirements
+
+- Node.js 18.19.0 or newer.
+- Aikido account access.
+- Browser sign-in through the Aikido MCP login flow.
+- User approval before sending file contents to Aikido scans.
+
+## Security Notes
+
+Aikido scans can send source code, dependency data, and secret-like strings to Aikido for analysis. Confirm scope before scanning, prefer changed or user-selected files over the whole repository, and avoid scanning files that the user has not approved.

--- a/plugins/aikido/index.ts
+++ b/plugins/aikido/index.ts
@@ -1,0 +1,26 @@
+import { dirname } from "node:path"
+import { fileURLToPath } from "node:url"
+import type { AgentPlugin } from "@cline/sdk"
+
+const pluginDir = dirname(fileURLToPath(import.meta.url))
+
+const plugin: AgentPlugin = {
+	name: "aikido",
+	manifest: {
+		capabilities: ["mcp", "skills"],
+	},
+
+	setup(api) {
+		api.registerMcpServer({
+			name: "aikido-mcp",
+			transport: {
+				type: "stdio",
+				command: "npx",
+				args: ["--no-install", "aikido-mcp"],
+				cwd: pluginDir,
+			},
+		})
+	},
+}
+
+export default plugin

--- a/plugins/aikido/package.json
+++ b/plugins/aikido/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "aikido",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Cline plugin that registers Aikido Security MCP tools and bundles Aikido workflow skills.",
+  "cline": {
+    "plugins": [
+      {
+        "paths": [
+          "./index.ts"
+        ],
+        "capabilities": [
+          "mcp",
+          "skills"
+        ]
+      }
+    ]
+  },
+  "dependencies": {
+    "@aikidosec/mcp": "1.0.9"
+  }
+}

--- a/plugins/aikido/skills/aikido-issues/SKILL.md
+++ b/plugins/aikido/skills/aikido-issues/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: aikido-issues
+description: Use this skill when listing, counting, summarizing, or triaging issues from the Aikido Security feed.
+---
+
+# Aikido Issues
+
+Use this skill to inspect Aikido Security feed issues through the `aikido-mcp` server.
+
+## Guardrails
+
+- Ask for scope when the user has not provided a repository, cloud, VM, domain, or container target.
+- Do not request more pages than needed for the user's question.
+- Treat issue details as security-sensitive. Avoid dumping large raw feeds into chat.
+- If the MCP server is unavailable or auth fails, switch to `aikido-setup`.
+
+## Issue Flow
+
+1. Call the Aikido issues list tool exposed by `aikido-mcp`.
+2. Include scope fields only when supplied by the user or reliable workspace context:
+   - `repo_name`
+   - `cloud_name`
+   - `vm_name`
+   - `domain_name`
+   - `container_name`
+3. Include `issue_types` only when the user asks for a category such as open source, leaked secret, cloud, SAST, IaC, malware, EOL, license, container, SCM security, or AI pentest.
+4. Use numeric `page` only when the user needs more than the first page.
+5. Tell the user when additional pages exist.
+
+## Reporting Format
+
+For triage, report issues in this concise form:
+
+```text
+Issue #1: <title>
+- Type: <issue_type>
+- Severity: <issue_severity>
+- Remediation: <issue_remediation>
+```
+
+Prioritize critical and high severity issues first unless the user asks for a different ordering.

--- a/plugins/aikido/skills/aikido-scan/SKILL.md
+++ b/plugins/aikido/skills/aikido-scan/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: aikido-scan
+description: Use this skill when the user asks to scan code with Aikido Security, check SAST findings, detect leaked secrets, or verify security issues in changed files.
+---
+
+# Aikido Scan
+
+Use this skill to run Aikido scans through the `aikido-mcp` server.
+
+## Guardrails
+
+- Confirm scan scope before every request that sends file contents to Aikido.
+- Prefer generated, added, modified, or user-selected files over broad repository scans.
+- Do not scan secrets, private keys, `.env` files, customer data, or unrelated files unless the user explicitly approves.
+- Respect the MCP server limit of 50 files per scan request. Batch only after confirming broad scope is intended.
+- If auth or MCP availability fails, switch to `aikido-setup`.
+
+## Scan Flow
+
+1. Identify candidate files from the user's request, git diff, or the current task.
+2. Present the scan scope and ask for approval before sending any file contents.
+3. Read the approved files.
+4. Call the Aikido full scan tool exposed by `aikido-mcp` with each approved file path and full content.
+5. If findings are returned, summarize:
+   - Title.
+   - Severity.
+   - File and line.
+   - Why it matters.
+   - A concrete remediation.
+6. Apply fixes only when the user wants Cline to fix them or the current task already includes remediation.
+7. Rescan changed files after fixes, up to three focused attempts. Stop earlier if the remaining result is clearly a false positive or needs user judgment.
+8. Report final status and unresolved findings.
+
+## Scope Guidance
+
+Good default scan targets:
+
+- Files modified in the current branch.
+- Files Cline just generated or edited.
+- Files named by the user.
+- Security-sensitive paths such as auth, input validation, command execution, file upload, dependency manifests, or infrastructure files.
+
+Avoid defaulting to whole-repository scans. Ask first because scan cost, runtime, and data exposure are materially different.

--- a/plugins/aikido/skills/aikido-setup/SKILL.md
+++ b/plugins/aikido/skills/aikido-setup/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: aikido-setup
+description: Use this skill when setting up Aikido Security, verifying the Aikido MCP server, signing in, switching accounts, or reauthenticating.
+---
+
+# Aikido Setup
+
+Use this skill to configure and verify Aikido Security MCP access.
+
+## Guardrails
+
+- Verify Node.js before troubleshooting Aikido.
+- Do not ask the user to paste tokens, state values, or credentials into chat.
+- Do not modify sign-in URLs returned by Aikido. Present them exactly as returned.
+- Use reauthentication only when the user asks to switch accounts, refresh auth, or recover from auth failures.
+- If the MCP server is unavailable, report that directly instead of inventing manual token setup.
+
+## Setup Flow
+
+1. Check Node.js:
+
+```bash
+node --version
+```
+
+If Node.js is missing or below 18.19.0, stop and ask the user to install or upgrade Node.js before continuing.
+
+2. Call the `aikido_login` tool exposed by `aikido-mcp`.
+
+- If it reports the user is already signed in, tell the user Aikido is ready.
+- If it returns region-specific sign-in URLs, show the URLs exactly as returned and ask the user to open the correct region in a browser.
+- If the user asked to switch accounts or reauthenticate, call `aikido_login` with `force_reauth: true`.
+
+3. After the user confirms browser sign-in, call `aikido_login` again to verify the session.
+
+4. If the MCP tool is unavailable, ask the user to confirm the `aikido` plugin is installed and enabled, then restart the Cline session if needed.
+
+## Common Failure Modes
+
+- Node.js is too old for the MCP server.
+- The user has not completed browser sign-in.
+- A stale session needs `force_reauth: true`.
+- The MCP server was installed but the current Cline session has not loaded it yet.


### PR DESCRIPTION
## Aikido Security

Adds an Aikido Security plugin for Cline users who want security scanning and issue triage from Aikido in their coding workflow.

The plugin registers the Aikido MCP server and bundles focused skills for setup, file scanning, and feed issue triage. The MCP package is pinned as a plugin dependency and started through `npx --no-install aikido-mcp` from the installed plugin package directory, so it does not rely on startup-time package downloads or a global binary.

## Cline Primitives

This plugin uses two Cline primitives:

- MCP: registers `aikido-mcp`, a stdio MCP server backed by the pinned `@aikidosec/mcp@1.0.9` package. The server exposes Aikido login, scan, and issue-listing tools.
- Skills: bundles `aikido-setup`, `aikido-scan`, and `aikido-issues`.

`aikido-setup` verifies Node.js, starts or refreshes Aikido browser sign-in, and confirms the MCP server is reachable. `aikido-scan` helps select files, get approval before sending file contents, run Aikido scans, apply fixes, and rescan focused changes. `aikido-issues` lists, summarizes, and triages Aikido security feed issues with optional repository, cloud, VM, domain, container, and issue-type scope.

## Requirements

Users need Node.js 18.19.0 or newer and Aikido account access. Authentication happens through the Aikido MCP login flow.

The scan skill treats source-code egress as an explicit approval point. It prefers changed or user-selected files, avoids whole-repository scans by default, and asks before sending file contents to Aikido.
