### PR TITLE
feat: add apollo plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Each plugin lives in `plugins/<slug>`. The directory name is the install keyword
 | --- | --- |
 | `agent-browser` | Web and Electron browser automation via the agent-browser CLI skill. |
 | `agents-squad` | Background subagents with presets, skills, and shared handoffs. |
+| `apollo` | Apollo MCP access and sales workflow skills for prospecting, lead enrichment, sequence loading, and sales analytics. |
 | `background-terminal` | Long-running shell jobs with polling and cleanup tools. |
 | `branch-protector` | A hook that blocks protected branch pushes unless explicitly allowed. |
 | `bundled-skills-demo` | A package plugin that proves bundled skill discovery works. |

--- a/plugins/apollo/LICENSE.apollo
+++ b/plugins/apollo/LICENSE.apollo
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Apollo.io
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/plugins/apollo/README.md
+++ b/plugins/apollo/README.md
@@ -1,0 +1,64 @@
+# apollo
+
+Apollo MCP access and sales workflow skills for prospecting, lead enrichment, sequence loading, and sales analytics from Cline.
+
+## What It Does
+
+Registers the `apollo` MCP server. The server uses Streamable HTTP and OAuth with the user's Apollo account, then exposes Apollo tools for prospect and company search, lead enrichment, contact and sequence actions, and supported sales performance reporting.
+
+Installs these bundled skills:
+
+- `apollo-prospect`: turn an ideal customer profile into a ranked prospect list.
+- `apollo-enrich-lead`: enrich a person, email, LinkedIn URL, or company contact into a usable contact card.
+- `apollo-sequence-load`: prepare, preview, and enroll approved contacts into an Apollo sequence.
+- `apollo-analytics`: answer supported Apollo sales performance questions with focused reporting tables and follow-up actions.
+
+## Install
+
+```bash
+cline plugin install apollo
+```
+
+For local development from this repository:
+
+```bash
+cline plugin install ./plugins/apollo --cwd .
+```
+
+## Example Usage
+
+After installation, ask Cline:
+
+```text
+Find 20 VP Sales prospects at Series B SaaS companies in the US and show me the best matches before enriching anyone.
+```
+
+or:
+
+```text
+Show email reply rate by rep for this quarter and flag the biggest outliers.
+```
+
+## Requirements
+
+- A Cline build with plugin MCP registration and OAuth follow-up support.
+- An Apollo account with access to the workspace, records, sequences, and analytics you want Cline to use.
+- OAuth authorization for the `apollo` MCP server after installation or on first use.
+- Network access to `https://mcp.apollo.io/mcp`.
+- Apollo plan permissions and available credits for credit-consuming actions such as organization search and enrichment.
+
+Apollo MCP reflects the user's existing Apollo permissions. Cline can only perform actions that the authorized Apollo user, workspace plan, and available credits allow.
+
+## Security Notes
+
+Apollo MCP can expose prospect records, company records, emails, phone numbers, CRM data, sequence configuration, activity metrics, and sales analytics through tool results.
+
+Review your AI client's model-training and data-retention settings before connecting Apollo MCP. Prospect, CRM, email, and analytics data may be sent to the model provider during tool use.
+
+Use least-privilege Apollo access where possible. Confirm before using enrichment, revealing contact details, creating contacts, editing CRM records, creating or modifying sequences, or enrolling contacts into sequences.
+
+Sequence enrollment can trigger outbound messages depending on the sequence and sending account configuration. Always verify the sequence, sender, contact list, and volume before approving enrollment.
+
+Do not paste Apollo API keys, OAuth tokens, customer lists, private prospect exports, or enriched contact data into files that may be committed.
+
+The MCP server is installed as plugin-owned configuration. Removing the plugin removes the `apollo` entry that this plugin created.

--- a/plugins/apollo/README.md
+++ b/plugins/apollo/README.md
@@ -13,6 +13,8 @@ Installs these bundled skills:
 - `apollo-sequence-load`: prepare, preview, and enroll approved contacts into an Apollo sequence.
 - `apollo-analytics`: answer supported Apollo sales performance questions with focused reporting tables and follow-up actions.
 
+The bundled Apollo workflow guidance includes material from Apollo.io's MIT-licensed plugin source. See `LICENSE.apollo`.
+
 ## Install
 
 ```bash
@@ -55,7 +57,7 @@ Apollo MCP can expose prospect records, company records, emails, phone numbers, 
 
 Review your AI client's model-training and data-retention settings before connecting Apollo MCP. Prospect, CRM, email, and analytics data may be sent to the model provider during tool use.
 
-Use least-privilege Apollo access where possible. Confirm before using enrichment, revealing contact details, creating contacts, editing CRM records, creating or modifying sequences, or enrolling contacts into sequences.
+Use least-privilege Apollo access where possible. Confirm before using enrichment, revealing contact details, bulk-enriching companies, creating contacts, exporting contact data, editing CRM records, creating or modifying sequences, or enrolling contacts into sequences.
 
 Sequence enrollment can trigger outbound messages depending on the sequence and sending account configuration. Always verify the sequence, sender, contact list, and volume before approving enrollment.
 

--- a/plugins/apollo/index.ts
+++ b/plugins/apollo/index.ts
@@ -1,0 +1,22 @@
+import type { AgentPlugin } from "@cline/sdk"
+
+const APOLLO_MCP_URL = "https://mcp.apollo.io/mcp"
+
+const plugin: AgentPlugin = {
+	name: "apollo",
+	manifest: {
+		capabilities: ["mcp", "skills"],
+	},
+
+	setup(api) {
+		api.registerMcpServer({
+			name: "apollo",
+			transport: {
+				type: "streamableHttp",
+				url: APOLLO_MCP_URL,
+			},
+		})
+	},
+}
+
+export default plugin

--- a/plugins/apollo/package.json
+++ b/plugins/apollo/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "apollo",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Cline plugin that adds Apollo MCP access and sales prospecting skills.",
+  "cline": {
+    "plugins": [
+      {
+        "paths": [
+          "./index.ts"
+        ],
+        "capabilities": [
+          "mcp",
+          "skills"
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/apollo/skills/apollo-analytics/SKILL.md
+++ b/plugins/apollo/skills/apollo-analytics/SKILL.md
@@ -1,29 +1,192 @@
 ---
 name: apollo-analytics
-description: Answer supported Apollo sales performance questions from available analytics data, including sequence, email, engagement, rep, team, and time trend dimensions when Apollo MCP exposes them.
+description: "Answer supported Apollo sales performance questions from available analytics data, including sequence, email, engagement, rep, team, and time trend dimensions."
 ---
 
-# Apollo Analytics
+# Analytics
 
-Use this skill when the user asks for sales performance reporting from Apollo. Apollo analytics tool coverage can vary by workspace, plan, and MCP schema, so discover the available schema first and answer only with supported metrics and dimensions.
+Answer sales performance questions using Apollo's analytics data. Use Apollo MCP tools exposed by Cline; tool names below refer to Apollo MCP tool IDs after the `apollo` server is connected.
 
-## Workflow
+Before calling a named Apollo MCP tool, inspect the connected MCP server's available tools and schemas. Use the named tool only if it is available; otherwise use the closest supported Apollo MCP workflow or ask the user how to proceed.
 
-1. Identify the business question, audience, date range, and whether the user wants a flat answer, ranking, trend, or grouped table.
-2. Use Apollo MCP to discover available analytics tools, schemas, metrics, users, teams, sequences, and dimensions before choosing a query.
-3. Select the smallest useful metric set. Include rates alongside raw counts when the user asks about performance.
-4. Apply the right time range. Default to the last 30 days when the user gives no range.
-5. Add grouping only when the discovered schema supports it, such as by rep, team, sequence, engagement attribute, day, week, or month.
-6. Run one focused query first. If the question spans unrelated dimensions, run separate queries rather than forcing one oversized report.
-7. Validate the result for missing permissions, partial periods, low volume, and obvious outliers before drawing conclusions.
+## Examples
 
-## Output
+- "How many emails did I send in the last 30 days?"
+- "Show team call connect rate this quarter by rep."
+- "What's our email reply rate week over week for this year?"
+- "Break down pipeline and won amount by opportunity stage all time."
+- "Which sequences have the highest reply rate in the last 6 months?"
+- "Show activity summary - emails, calls, meetings, tasks - for each rep this quarter."
+- "How are calls trending by day of week over the last 3 months?"
+- "Show emails sent vs replied broken down by contact stage and email type."
 
-- Lead with the answer, not the query details.
-- Use compact tables for grouped results.
-- Convert decimals to readable percentages and format large numbers with commas.
-- Call out the top outlier, lowest performer, trend break, or biggest gap when relevant.
-- Include the date range, grouping, and any major caveats.
-- Offer one or two useful follow-up actions such as drilling into a sequence, comparing supported team or rep dimensions, or refining the time range.
+## Step 1 - Interpret the Question
 
-Do not export raw prospect or customer-level data unless the user explicitly asks and the workspace is appropriate for that data.
+Parse the user's question to determine the following parameters:
+
+---
+
+### Metrics
+
+Select 1-15 metrics that match what the user is asking about. Always include the rate/percent version alongside raw counts when the user asks about performance.
+
+Email
+`num_emails_sent`, `num_emails_delivered`, `num_emails_opened`, `num_emails_clicked`, `num_emails_replied`, `num_emails_bounced`, `num_emails_unsubscribed`, `percent_emails_replied`, `num_contacts_emailed`, `num_contacts_opened`, `num_contacts_replied`
+
+Calls
+`num_phone_calls`, `num_phone_calls_completed`, `num_phone_calls_connect`, `num_phone_calls_connect_positive`, `num_phone_calls_connect_negative`, `num_phone_calls_connect_neutral`, `percent_phone_calls_connect`, `avg_phone_call_duration`, `num_contacts_called`
+
+Key distinctions:
+- `num_phone_calls_completed` = all logged attempts
+- `num_phone_calls_connect` = recipient actually answered
+- `num_phone_calls_connect_positive/negative/neutral` = connected calls by outcome sentiment
+
+Meetings
+`num_all_meetings_scheduled`, `num_meetings_held`, `num_all_meetings_rescheduled`, `num_calendar_events_scheduled`, `num_calendar_events_cancelled`, `num_all_meetings_scheduled_via_email`, `num_all_meetings_scheduled_via_call`
+
+Key distinctions:
+- `num_all_meetings_scheduled` = includes cancelled
+- `num_meetings_held` = actually occurred
+
+Tasks
+`num_tasks`, `num_tasks_completed`, `num_tasks_scheduled`, `num_tasks_completed_on_time`, `percent_tasks_completed`, `percent_tasks_completed_on_time`, `overdue_tasks`, `unfinished_overdue_tasks`, `percent_unfinished_overdue_tasks`
+
+Key distinctions:
+- `overdue_tasks` = all overdue including completed late
+- `unfinished_overdue_tasks` = still pending and overdue
+- `percent_unfinished_overdue_tasks` = share of scheduled tasks that are overdue and unfinished (vs `num_tasks_scheduled`)
+
+Contacts & Accounts
+`num_contacts`, `num_accounts`, `num_contacts_touched`, `num_accounts_touched`, `num_net_new_people`, `num_net_new_companies`, `num_contacts_with_job_change`
+
+Opportunities
+`num_opportunities`, `num_won`, `num_closed`, `deal_amount`, `won_amount`, `pipeline_amount`, `revenue_amount`, `avg_deal_amount`, `avg_won_amount`, `percent_win_rate`, `avg_salescycle_days`
+
+Sequences
+`num_contacts_added_to_sequence`, `num_contacts_remove_from_sequence`
+
+Conversation Intelligence
+`num_conversations_recorded`, `num_conversations_listened`, `avg_conversation_duration`, `total_conversation_duration`, `avg_talk_ratio`, `avg_question_rate`, `avg_longest_monologue`, `speaker_switches`
+
+LinkedIn
+`num_linkedin_tasks_scheduled`, `num_linkedin_tasks_completed`, `num_linkedin_tasks_skipped`, `percent_linkedin_tasks_completed`
+
+---
+
+### Date Range
+
+Map the user's time reference to a preset modality (preferred) or a custom range:
+
+Presets: `today`, `yesterday`, `current_week`, `current_month`, `current_quarter`, `current_year`, `last_7_days`, `last_2_weeks`, `last_30_days`, `last_3_months`, `last_6_months`, `last_12_months`, `last_4_quarters`, `last_2_years`, `previous_week`, `previous_month`, `previous_quarter`, `previous_year`, `all_time`
+
+Custom: use `range_start` + `range_end` (YYYY-MM-DD) for specific date windows. Do not combine with a modality.
+
+Default to `last_30_days` if no time reference is given.
+
+---
+
+### Breakdown (group_by)
+
+Does the user want data broken down by something? Set `group_by` to one of:
+
+Time patterns (for trends and time series)
+`smart_datetime_hour`, `smart_datetime_day`, `smart_datetime_week`, `smart_datetime_month`, `smart_datetime_year`
+`smart_datetime_hour_of_day`, `smart_datetime_day_of_week`, `smart_datetime_month_of_year`
+
+People & Teams
+`smart_user_id` (by rep), `smart_subteam_id` (by team)
+
+Email dimensions
+`emailer_campaign_id` (by sequence), `emailer_template_id` (by template), `emailer_message_type`, `emailer_step_id`, `emailer_touch_id`, `send_from_email`, `send_from_domain`, `email_account_id`
+
+Calls
+`phone_call_outcome_id`, `phone_call_purpose_id`, `phone_call_sentiment`
+
+Contact attributes
+`contact_stage_id`, `contact_label_ids`, `contact_owner_id`, `persona`, `person_title_unanalyzed`, `person_seniority`, `person_location_country`, `person_location_state`, `person_location_city`
+
+Account & company attributes
+`account_id`, `account_stage_id`, `account_label_ids`, `account_owner_id`, `organization_industries`, `organization_num_current_employees`, `organization_hq_location_country`, `organization_hq_location_state`, `organization_hq_location_city`, `organization_latest_funding_stage_cd`, `organization_current_technologies`
+
+Opportunities
+`opportunity_stage_id`, `opportunity_owner_id`, `opportunity_pipeline_id`, `forecast_category`, `lead_source`, `opportunity_deal_source`
+
+Tasks
+`task_type`, `task_status`
+
+Conversations
+`conversation_state`, `conversation_type`, `tracker_names_unanalyzed`, `calendar_event_setting_type`
+
+Omit `group_by` entirely for a flat summary (single row of totals).
+
+---
+
+### Pivot (pivot_group_by)
+
+If the user wants a cross-tab (e.g. "by rep AND by sequence", "broken down by stage vs email type"), set `group_by` to the primary dimension and `pivot_group_by` to the secondary. The tool returns one table per metric when a pivot is used. Prefer low-cardinality dimensions (e.g. `emailer_message_type`, `contact_stage_id`, `phone_call_sentiment`) as the pivot.
+
+---
+
+### Filters
+
+- "my data" / "for me" / "my performance" -> `filters: { user_ids: ["current"] }`
+- Specific user by Apollo user ID -> `filters: { user_ids: ["<user_id>"] }` (can combine: `["current", "user_id_1"]`)
+- "team" / no user mention -> omit filters entirely (returns team-wide data)
+- Filter by team/subteam -> `filters: { team_ids: ["<subteam_id>"] }`
+- Filter by sequence name -> first call the Apollo MCP `apollo_emailer_campaigns_search` tool to resolve the name to an ID, then pass `filters: { emailer_campaign_ids: ["<id>"] }`
+
+---
+
+### Sort
+
+If the user asks "who has the most...", "ranked by...", or "top reps by...", set:
+```
+sort: { metric: "<metric_name>", asc: false }
+```
+Use `asc: true` for "lowest first" or "worst performing" queries.
+
+Two constraints:
+- Sort only applies when `group_by` is set - it has no effect on flat queries
+- The sort metric must be included in the `metrics` array
+
+---
+
+## Step 2 - Call the Analytics Tool
+
+First confirm that the connected Apollo MCP server exposes `apollo_analytics_sync_report` and that the selected metrics, grouping dimensions, filters, and sort fields are supported for this workspace. If a metric or dimension is unavailable, explain the closest supported alternative before querying.
+
+Use the Apollo MCP `apollo_analytics_sync_report` tool with the parameters determined above.
+
+If the question spans multiple independent dimensions (e.g. "show me email metrics by rep AND separately by sequence"), make two sequential calls.
+
+If the question is ambiguous, make a reasonable default call first, then offer to refine.
+
+---
+
+## Step 3 - Present the Results
+
+Flat response (no group_by): Present as a clean two-column summary table - metric name and value.
+
+Grouped response (group_by only): Present as a table with the dimension as the first column and metrics as subsequent columns. Highlight notable outliers (top performer, lowest rate, biggest gap).
+
+Pivot response (group_by + pivot_group_by): Present each metric as a separate labeled table. Add a brief summary sentence per table.
+
+Always:
+- Convert decimals to readable percentages (e.g. `0.14` -> `14%`)
+- Format large numbers with commas
+- If the response says "Showing first N of M rows", mention the total count and offer to refine
+- Add 1-2 sentences of insight after the data (e.g. "Tuesday has the highest call volume at 355 calls", "Sarah Flores leads reply rate at 14%")
+
+---
+
+## Step 4 - Offer Follow-up Actions
+
+After presenting results, suggest 2-3 relevant next steps:
+
+1. Drill deeper - break down by another dimension (e.g. "want to see this by rep?")
+2. Change date range - compare with a different time period
+3. Add more metrics - "want to add meetings or tasks to this view?"
+4. Pivot view - "want to cross-tab this - e.g. by rep x sequence?"
+5. Export - after explicit approval, format as a CSV-style table for copy-paste
+
+Do not export raw prospect, customer, account, or rep-level data unless the user explicitly asks and the workspace is appropriate for that data.

--- a/plugins/apollo/skills/apollo-analytics/SKILL.md
+++ b/plugins/apollo/skills/apollo-analytics/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: apollo-analytics
+description: Answer supported Apollo sales performance questions from available analytics data, including sequence, email, engagement, rep, team, and time trend dimensions when Apollo MCP exposes them.
+---
+
+# Apollo Analytics
+
+Use this skill when the user asks for sales performance reporting from Apollo. Apollo analytics tool coverage can vary by workspace, plan, and MCP schema, so discover the available schema first and answer only with supported metrics and dimensions.
+
+## Workflow
+
+1. Identify the business question, audience, date range, and whether the user wants a flat answer, ranking, trend, or grouped table.
+2. Use Apollo MCP to discover available analytics tools, schemas, metrics, users, teams, sequences, and dimensions before choosing a query.
+3. Select the smallest useful metric set. Include rates alongside raw counts when the user asks about performance.
+4. Apply the right time range. Default to the last 30 days when the user gives no range.
+5. Add grouping only when the discovered schema supports it, such as by rep, team, sequence, engagement attribute, day, week, or month.
+6. Run one focused query first. If the question spans unrelated dimensions, run separate queries rather than forcing one oversized report.
+7. Validate the result for missing permissions, partial periods, low volume, and obvious outliers before drawing conclusions.
+
+## Output
+
+- Lead with the answer, not the query details.
+- Use compact tables for grouped results.
+- Convert decimals to readable percentages and format large numbers with commas.
+- Call out the top outlier, lowest performer, trend break, or biggest gap when relevant.
+- Include the date range, grouping, and any major caveats.
+- Offer one or two useful follow-up actions such as drilling into a sequence, comparing supported team or rep dimensions, or refining the time range.
+
+Do not export raw prospect or customer-level data unless the user explicitly asks and the workspace is appropriate for that data.

--- a/plugins/apollo/skills/apollo-enrich-lead/SKILL.md
+++ b/plugins/apollo/skills/apollo-enrich-lead/SKILL.md
@@ -1,41 +1,80 @@
 ---
 name: apollo-enrich-lead
-description: Enrich a lead in Apollo from a name, company, email, LinkedIn URL, title, or other identifier, then present a contact card with company context and safe next actions.
+description: "Enrich a lead in Apollo from a name, company, email, LinkedIn URL, title, or other identifier, then present a contact card with company context and safe next actions."
 ---
 
-# Apollo Enrich Lead
+# Enrich Lead
 
-Use this skill for one-off lead lookup and enrichment.
+Turn an identifier into a contact dossier. Use Apollo MCP tools exposed by Cline; tool names below refer to Apollo MCP tool IDs after the `apollo` server is connected.
 
-## Workflow
+Before calling a named Apollo MCP tool, inspect the connected MCP server's available tools and schemas. Use the named tool only if it is available; otherwise use the closest supported Apollo MCP workflow or ask the user how to proceed.
 
-1. Extract every identifier the user provided: name, company, domain, email, LinkedIn URL, job title, location, or seniority.
-2. If the identifier is ambiguous, search first and show the top candidates. Ask the user to pick before enrichment when multiple people could match.
-3. Before any credit-consuming enrichment or contact reveal, tell the user what will likely consume credits and ask for confirmation.
-4. Enrich the selected person through Apollo MCP using the most specific identifiers available.
-5. Enrich the company when firmographic context would help the user decide what to do next.
-6. Present the result as a contact card, omitting fields Apollo did not return.
-7. Offer safe next actions such as saving the contact, finding colleagues, finding similar people, or preparing a sequence-load preview.
+## Examples
 
-## Contact Card
+- "Enrich Tim Zheng at Apollo."
+- "Enrich https://www.linkedin.com/in/timzheng."
+- "Enrich sarah@stripe.com."
+- "Enrich Jane Smith, VP Engineering, Notion."
+- "Find and enrich the CEO of Figma."
 
-Use this shape when data is available:
+## Step 1 - Parse Input
+
+From the user's request, extract every identifier available:
+- First name, last name
+- Company name or domain
+- LinkedIn URL
+- Email address
+- Job title (use as a matching hint)
+
+If the input is ambiguous, for example just "CEO of Figma", first use the Apollo MCP `apollo_mixed_people_api_search` tool with relevant title and domain filters to identify the person. Show likely matches and ask the user to choose before enrichment.
+
+## Step 2 - Enrich the Person
+
+> Credit warning: Tell the user enrichment or reveal actions may consume Apollo credits or reveal allowances. Wait for explicit confirmation before proceeding.
+
+Use the Apollo MCP `apollo_people_match` tool with all available identifiers:
+- `first_name`, `last_name` if name is known
+- `domain` or `organization_name` if company is known
+- `linkedin_url` if LinkedIn is provided
+- `email` if email is provided
+- Set `reveal_personal_emails` to `true` only when the user explicitly approved personal email reveal; otherwise omit it or set it to `false`
+
+If the match fails, try the Apollo MCP `apollo_mixed_people_api_search` tool with looser filters and present the top 3 candidates. Ask the user to pick one, then re-enrich after confirmation.
+
+## Step 3 - Enrich Their Company
+
+Use the Apollo MCP `apollo_organizations_enrich` tool with the person's company domain to pull firmographic context when it helps the user decide what to do next.
+
+## Step 4 - Present the Contact Card
+
+Format the output exactly like this:
+
+---
+
+[Full Name] | [Title]
+[Company Name]  -  [Industry]  -  [Employee Count] employees
 
 | Field | Detail |
-| --- | --- |
-| Name | Full name |
-| Title | Role and seniority |
-| Company | Company name and domain |
-| Location | City, state, country |
-| Email | Work or revealed email |
-| Phone | Direct, mobile, or corporate phone |
-| LinkedIn | Profile URL |
-| Company context | Industry, size, revenue, funding, HQ, or technologies |
-| Suggested next step | One practical action |
+|---|---|
+| Email (work) | ... |
+| Email (personal) | ... (if revealed) |
+| Phone (direct) | ... |
+| Phone (mobile) | ... |
+| Phone (corporate) | ... |
+| Location | City, State, Country |
+| LinkedIn | URL |
+| Company Domain | ... |
+| Company Revenue | Range |
+| Company Funding | Total raised |
+| Company HQ | Location |
 
-## Guardrails
+---
 
-- Never reveal or enrich more contacts than the user requested.
-- Confirm before revealing personal emails, phone numbers, or any other credit-consuming data.
-- Confirm before creating contacts or adding them to sequences.
-- Treat enriched contact data as sensitive. Do not write it into committed files.
+## Step 5 - Offer Next Actions
+
+Ask the user which action to take:
+
+1. Save to Apollo - After explicit approval, create this person as a contact via `apollo_contacts_create` with `run_dedupe: true`
+2. Add to a sequence - Ask which sequence, then run the sequence-load flow
+3. Find colleagues - Search for more people at the same company using `apollo_mixed_people_api_search` with `q_organization_domains_list` set to this company
+4. Find similar people - Search for people with the same title/seniority at other companies

--- a/plugins/apollo/skills/apollo-enrich-lead/SKILL.md
+++ b/plugins/apollo/skills/apollo-enrich-lead/SKILL.md
@@ -1,0 +1,41 @@
+---
+name: apollo-enrich-lead
+description: Enrich a lead in Apollo from a name, company, email, LinkedIn URL, title, or other identifier, then present a contact card with company context and safe next actions.
+---
+
+# Apollo Enrich Lead
+
+Use this skill for one-off lead lookup and enrichment.
+
+## Workflow
+
+1. Extract every identifier the user provided: name, company, domain, email, LinkedIn URL, job title, location, or seniority.
+2. If the identifier is ambiguous, search first and show the top candidates. Ask the user to pick before enrichment when multiple people could match.
+3. Before any credit-consuming enrichment or contact reveal, tell the user what will likely consume credits and ask for confirmation.
+4. Enrich the selected person through Apollo MCP using the most specific identifiers available.
+5. Enrich the company when firmographic context would help the user decide what to do next.
+6. Present the result as a contact card, omitting fields Apollo did not return.
+7. Offer safe next actions such as saving the contact, finding colleagues, finding similar people, or preparing a sequence-load preview.
+
+## Contact Card
+
+Use this shape when data is available:
+
+| Field | Detail |
+| --- | --- |
+| Name | Full name |
+| Title | Role and seniority |
+| Company | Company name and domain |
+| Location | City, state, country |
+| Email | Work or revealed email |
+| Phone | Direct, mobile, or corporate phone |
+| LinkedIn | Profile URL |
+| Company context | Industry, size, revenue, funding, HQ, or technologies |
+| Suggested next step | One practical action |
+
+## Guardrails
+
+- Never reveal or enrich more contacts than the user requested.
+- Confirm before revealing personal emails, phone numbers, or any other credit-consuming data.
+- Confirm before creating contacts or adding them to sequences.
+- Treat enriched contact data as sensitive. Do not write it into committed files.

--- a/plugins/apollo/skills/apollo-prospect/SKILL.md
+++ b/plugins/apollo/skills/apollo-prospect/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: apollo-prospect
+description: Turn an ideal customer profile into a ranked Apollo prospect plan and, after confirmation, use Apollo search or enrichment to produce approved company and lead lists with fit notes.
+---
+
+# Apollo Prospect
+
+Use this skill when the user wants to find leads or accounts matching an ideal customer profile.
+
+## Workflow
+
+1. Parse the ICP into company filters and person filters.
+2. Ask one or two clarifying questions if the request lacks a role, company type, geography, or size signal.
+3. Build a search plan first, including target filters, volume, and which Apollo actions may consume credits.
+4. Before any credit-consuming Apollo search or enrichment, state the expected action and likely credit impact, then ask for confirmation.
+5. Search companies first when company fit matters. Search people directly when the user already supplied narrow person criteria.
+6. Rank results using the user's stated priority: title match, seniority, industry, geography, headcount, technologies, funding, growth signal, or account relevance.
+7. Show a preview after search and ask again before any additional enrichment or contact reveal that may consume credits.
+8. Enrich only the approved number of leads.
+9. Return a ranked table with fit rationale and practical next actions.
+
+## Useful Filters
+
+- Person: title, seniority, department, location, keywords, current company.
+- Company: industry, employee range, location, funding, revenue, technologies, domain list, account stage.
+- Workflow: target volume, required contact fields, sequence target, export format.
+
+## Output
+
+Use a table like:
+
+| Rank | Name | Title | Company | Fit | Evidence | Next action |
+| --- | --- | --- | --- | --- | --- | --- |
+
+Keep fit labels simple:
+
+- Strong: title, seniority, company profile, and geography match.
+- Good: most required criteria match.
+- Partial: useful lead but one important criterion is weak or unknown.
+
+## Guardrails
+
+- Do not run credit-consuming searches, enrichments, or contact reveals until the user confirms the specific action and approximate volume.
+- Keep initial batches small unless the user explicitly asks for volume.
+- Do not enroll prospects into outreach from this skill. Hand off to `apollo-sequence-load` after the user approves the lead list.

--- a/plugins/apollo/skills/apollo-prospect/SKILL.md
+++ b/plugins/apollo/skills/apollo-prospect/SKILL.md
@@ -1,45 +1,92 @@
 ---
 name: apollo-prospect
-description: Turn an ideal customer profile into a ranked Apollo prospect plan and, after confirmation, use Apollo search or enrichment to produce approved company and lead lists with fit notes.
+description: "Turn an ideal customer profile into a ranked Apollo prospecting workflow with company search, decision-maker search, enrichment previews, and approved next actions."
 ---
 
-# Apollo Prospect
+# Prospect
 
-Use this skill when the user wants to find leads or accounts matching an ideal customer profile.
+Go from an ICP description to a ranked, enriched lead list. Use Apollo MCP tools exposed by Cline; tool names below refer to Apollo MCP tool IDs after the `apollo` server is connected.
 
-## Workflow
+Before calling a named Apollo MCP tool, inspect the connected MCP server's available tools and schemas. Use the named tool only if it is available; otherwise use the closest supported Apollo MCP workflow or ask the user how to proceed.
 
-1. Parse the ICP into company filters and person filters.
-2. Ask one or two clarifying questions if the request lacks a role, company type, geography, or size signal.
-3. Build a search plan first, including target filters, volume, and which Apollo actions may consume credits.
-4. Before any credit-consuming Apollo search or enrichment, state the expected action and likely credit impact, then ask for confirmation.
-5. Search companies first when company fit matters. Search people directly when the user already supplied narrow person criteria.
-6. Rank results using the user's stated priority: title match, seniority, industry, geography, headcount, technologies, funding, growth signal, or account relevance.
-7. Show a preview after search and ask again before any additional enrichment or contact reveal that may consume credits.
-8. Enrich only the approved number of leads.
-9. Return a ranked table with fit rationale and practical next actions.
+## Examples
 
-## Useful Filters
+- "Find VP of Engineering prospects at Series B+ SaaS companies in the US, 200-1000 employees."
+- "Find heads of marketing at e-commerce companies in Europe."
+- "Find CTOs at fintech startups, 50-500 employees, New York."
+- "Find procurement managers at manufacturing companies with 1000+ employees."
+- "Find SDR leaders at companies using Salesforce and Outreach."
 
-- Person: title, seniority, department, location, keywords, current company.
-- Company: industry, employee range, location, funding, revenue, technologies, domain list, account stage.
-- Workflow: target volume, required contact fields, sequence target, export format.
+## Step 1 - Parse the ICP
 
-## Output
+Extract structured filters from the user's natural language description:
 
-Use a table like:
+Company filters:
+- Industry/vertical keywords -> `q_organization_keyword_tags`
+- Employee count ranges -> `organization_num_employees_ranges`
+- Company locations -> `organization_locations`
+- Specific domains -> `q_organization_domains_list`
 
-| Rank | Name | Title | Company | Fit | Evidence | Next action |
-| --- | --- | --- | --- | --- | --- | --- |
+Person filters:
+- Job titles -> `person_titles`
+- Seniority levels -> `person_seniorities`
+- Person locations -> `person_locations`
 
-Keep fit labels simple:
+If the ICP is vague, ask 1-2 clarifying questions before proceeding. At minimum, you need a title/role and an industry or company size.
 
-- Strong: title, seniority, company profile, and geography match.
-- Good: most required criteria match.
-- Partial: useful lead but one important criterion is weak or unknown.
+## Step 2 - Search for Companies
 
-## Guardrails
+Before any live Apollo search, show the search plan, target volume, and whether the planned search or enrichment may consume credits or reveal allowances. If credit impact is unclear, ask the user to approve the live search before proceeding.
 
-- Do not run credit-consuming searches, enrichments, or contact reveals until the user confirms the specific action and approximate volume.
-- Keep initial batches small unless the user explicitly asks for volume.
-- Do not enroll prospects into outreach from this skill. Hand off to `apollo-sequence-load` after the user approves the lead list.
+Use the Apollo MCP `apollo_mixed_companies_search` tool with the company filters:
+- `q_organization_keyword_tags` for industry/vertical
+- `organization_num_employees_ranges` for size
+- `organization_locations` for geography
+- Set `per_page` to 25
+
+## Step 3 - Enrich Top Companies
+
+Show the company search preview first. Before bulk enrichment, tell the user which companies will be enriched and ask for confirmation. Then use the Apollo MCP `apollo_organizations_bulk_enrich` tool with the domains from the approved results. This may reveal revenue, funding, headcount, and firmographic data to help rank companies.
+
+## Step 4 - Find Decision Makers
+
+Use the Apollo MCP `apollo_mixed_people_api_search` tool with:
+- `person_titles` and `person_seniorities` from the ICP
+- `q_organization_domains_list` scoped to the enriched company domains
+- `per_page` set to 25
+
+## Step 5 - Enrich Top Leads
+
+> Credit warning: Tell the user exactly how many leads will be enriched and that Apollo credits or reveal allowances may be consumed. Wait for explicit confirmation before proceeding.
+
+Use the Apollo MCP `apollo_people_bulk_match` tool to enrich up to 10 leads per call with:
+- `first_name`, `last_name`, `domain` for each person
+- `reveal_personal_emails` set to `true` only when the user explicitly approved personal email reveal; otherwise omit it or set it to `false`
+
+If more than 10 leads, batch into multiple calls.
+
+## Step 6 - Present the Lead Table
+
+Show results in a ranked table:
+
+### Leads matching: [ICP Summary]
+
+| # | Name | Title | Company | Employees | Revenue | Email | Phone | ICP Fit |
+|---|---|---|---|---|---|---|---|---|
+
+ICP Fit scoring:
+- Strong - title, seniority, company size, and industry all match
+- Good - 3 of 4 criteria match
+- Partial - 2 of 4 criteria match
+
+Summary: Found X leads across Y companies. Z credits consumed.
+
+## Step 7 - Offer Next Actions
+
+Ask the user:
+
+1. Save all to Apollo - After explicit approval, bulk-create contacts via `apollo_contacts_create` with `run_dedupe: true` for each lead
+2. Load into a sequence - Ask which sequence and run the `apollo-sequence-load` flow for these contacts
+3. Deep-dive a company - Enrich or research one company from the list
+4. Refine the search - Adjust filters and re-run
+5. Export - Only after explicit approval, format leads as a CSV-style table for copy-paste

--- a/plugins/apollo/skills/apollo-sequence-load/SKILL.md
+++ b/plugins/apollo/skills/apollo-sequence-load/SKILL.md
@@ -1,0 +1,45 @@
+---
+name: apollo-sequence-load
+description: Prepare and safely enroll approved Apollo contacts into an outreach sequence, including candidate search, preview, enrichment, dedupe, sender selection, and confirmation.
+---
+
+# Apollo Sequence Load
+
+Use this skill when the user wants to add Apollo contacts or prospects to an outreach sequence.
+
+## Safety First
+
+Sequence enrollment can trigger outbound messages depending on Apollo sequence and sending-account settings. Always require explicit confirmation before creating contacts or adding anyone to a sequence.
+
+## Workflow
+
+1. Parse the target audience, desired contact count, sequence name, and any sender requirement.
+2. If the user asks to list sequences, list available sequences and stop.
+3. Resolve the target sequence through Apollo MCP. If there are multiple matches, ask the user to choose.
+4. Resolve the sending account. If there are multiple senders, show choices and ask the user to choose.
+5. Search for candidate contacts or use the lead list already in the conversation.
+6. Show a preview table before enrichment or enrollment.
+7. Resolve existing contacts and dedupe the candidate list before enrichment where Apollo MCP supports it.
+8. State the expected credit usage and outbound risk, then ask for confirmation.
+9. After confirmation, enrich only approved leads that still need enrichment, create missing contacts as needed, and add only the approved contacts to the selected sequence.
+10. Return an enrollment summary with contact count, sequence, sender, credits used, and any failures.
+
+## Preview Table
+
+| # | Name | Title | Company | Location | Reason |
+| --- | --- | --- | --- | --- | --- |
+
+## Confirmation Language
+
+Before enrollment, use a direct confirmation prompt:
+
+```text
+Confirm that you want me to enrich these N leads and add them to the sequence "Sequence Name" from sender@example.com. This may consume about N Apollo credits, and outbound may begin depending on the sequence settings.
+```
+
+## Guardrails
+
+- Do not infer approval from earlier broad intent. Require a final confirmation after showing the exact sequence, sender, volume, and contacts.
+- Default to small batches.
+- Deduplicate before enrichment, contact creation, or enrollment where possible.
+- If a contact is already active in another sequence, do not force enrollment unless the user explicitly approves that risk.

--- a/plugins/apollo/skills/apollo-sequence-load/SKILL.md
+++ b/plugins/apollo/skills/apollo-sequence-load/SKILL.md
@@ -1,45 +1,124 @@
 ---
 name: apollo-sequence-load
-description: Prepare and safely enroll approved Apollo contacts into an outreach sequence, including candidate search, preview, enrichment, dedupe, sender selection, and confirmation.
+description: "Prepare and safely enroll approved Apollo contacts into an outreach sequence, including candidate search, preview, enrichment, dedupe, sender selection, and confirmation."
 ---
 
-# Apollo Sequence Load
+# Sequence Load
 
-Use this skill when the user wants to add Apollo contacts or prospects to an outreach sequence.
-
-## Safety First
+Find, enrich, and load contacts into an outreach sequence end to end. Use Apollo MCP tools exposed by Cline; tool names below refer to Apollo MCP tool IDs after the `apollo` server is connected.
 
 Sequence enrollment can trigger outbound messages depending on Apollo sequence and sending-account settings. Always require explicit confirmation before creating contacts or adding anyone to a sequence.
 
-## Workflow
+Before calling a named Apollo MCP tool, inspect the connected MCP server's available tools and schemas. Use the named tool only if it is available; otherwise use the closest supported Apollo MCP workflow or ask the user how to proceed.
 
-1. Parse the target audience, desired contact count, sequence name, and any sender requirement.
-2. If the user asks to list sequences, list available sequences and stop.
-3. Resolve the target sequence through Apollo MCP. If there are multiple matches, ask the user to choose.
-4. Resolve the sending account. If there are multiple senders, show choices and ask the user to choose.
-5. Search for candidate contacts or use the lead list already in the conversation.
-6. Show a preview table before enrichment or enrollment.
-7. Resolve existing contacts and dedupe the candidate list before enrichment where Apollo MCP supports it.
-8. State the expected credit usage and outbound risk, then ask for confirmation.
-9. After confirmation, enrich only approved leads that still need enrichment, create missing contacts as needed, and add only the approved contacts to the selected sequence.
-10. Return an enrollment summary with contact count, sequence, sender, credits used, and any failures.
+## Examples
 
-## Preview Table
+- "Add 20 VP Sales at SaaS companies to my Q1 Outbound sequence."
+- "Find SDR managers at fintech startups for Cold Outreach v2."
+- "List my Apollo sequences."
+- "Add directors of engineering, 500+ employees, US, to Demo Follow-up."
+- "Load 15 more approved leads into Enterprise Pipeline."
 
-| # | Name | Title | Company | Location | Reason |
-| --- | --- | --- | --- | --- | --- |
+## Step 1 - Parse Input
 
-## Confirmation Language
+From the user's request, extract:
 
-Before enrollment, use a direct confirmation prompt:
+Targeting criteria:
+- Job titles -> `person_titles`
+- Seniority levels -> `person_seniorities`
+- Industry keywords -> `q_organization_keyword_tags`
+- Company size -> `organization_num_employees_ranges`
+- Locations -> `person_locations` or `organization_locations`
 
-```text
-Confirm that you want me to enrich these N leads and add them to the sequence "Sequence Name" from sender@example.com. This may consume about N Apollo credits, and outbound may begin depending on the sequence settings.
-```
+Sequence info:
+- Sequence name (text after "to", "into", or "->")
+- Volume - how many contacts to add (default: 10 if not specified)
 
-## Guardrails
+If the user just says "list sequences", skip to Step 2 and show all available sequences.
 
-- Do not infer approval from earlier broad intent. Require a final confirmation after showing the exact sequence, sender, volume, and contacts.
-- Default to small batches.
-- Deduplicate before enrichment, contact creation, or enrollment where possible.
-- If a contact is already active in another sequence, do not force enrollment unless the user explicitly approves that risk.
+## Step 2 - Find the Sequence
+
+Use the Apollo MCP `apollo_emailer_campaigns_search` tool to find the target sequence:
+- Set `q_name` to the sequence name from input
+
+If no match or multiple matches:
+- Show all available sequences in a table: | Name | ID | Status |
+- Ask the user to pick one
+
+## Step 3 - Get Email Account
+
+Use the Apollo MCP `apollo_email_accounts_index` tool to list linked email accounts.
+
+- If one account -> use automatically
+- If multiple -> show them and ask which to send from
+
+## Step 4 - Find Matching People
+
+Use the Apollo MCP `apollo_mixed_people_api_search` tool with the targeting criteria.
+- Set `per_page` to the requested volume (or 10 by default)
+
+Present the candidates in a preview table:
+
+| # | Name | Title | Company | Location |
+|---|---|---|---|---|
+
+Ask: "Enrich these [N] candidates and create any missing Apollo contacts for [Sequence Name] from [sender]? This may consume about [N] Apollo credits or reveal allowances. I will ask again before enrolling anyone into the sequence."
+
+Wait for confirmation before proceeding.
+
+## Step 5 - Enrich and Create Contacts
+
+For each approved lead:
+
+1. Enrich - Use the Apollo MCP `apollo_people_bulk_match` tool (batch up to 10 per call) with:
+   - `first_name`, `last_name`, `domain` for each person
+   - `reveal_personal_emails` set to `true` only when the user explicitly approved personal email reveal; otherwise omit it or set it to `false`
+
+2. Create contacts - For each enriched person, use the Apollo MCP `apollo_contacts_create` tool with:
+   - `first_name`, `last_name`, `email`, `title`, `organization_name`
+   - `direct_phone` or `mobile_phone` if available
+   - `run_dedupe` set to `true`
+
+Collect all created contact IDs.
+
+## Step 6 - Add to Sequence
+
+Before adding contacts to the sequence, show the final enrollable contact table with name, title, company, email, Apollo contact ID, sequence, sender, and count. Ask for final explicit confirmation that these exact contacts should be enrolled. Do not infer this approval from the earlier enrichment/contact-creation confirmation.
+
+Use the Apollo MCP `apollo_emailer_campaigns_add_contact_ids` tool with:
+- `id`: the sequence ID
+- `emailer_campaign_id`: same sequence ID
+- `contact_ids`: array of created contact IDs
+- `send_email_from_email_account_id`: the chosen email account ID
+- `sequence_active_in_other_campaigns`: `false` (safe default)
+
+## Step 7 - Confirm Enrollment
+
+Show a summary:
+
+---
+
+Sequence loaded successfully
+
+| Field | Value |
+|---|---|
+| Sequence | [Name] |
+| Contacts added | [count] |
+| Sending from | [email address] |
+| Credits used | [count] |
+
+Contacts enrolled:
+
+| Name | Title | Company | Email |
+|---|---|---|---|
+
+---
+
+## Step 8 - Offer Next Actions
+
+Ask the user:
+
+1. Load more - Find and preview another batch of leads
+2. Review sequence - Show sequence details and all enrolled contacts
+3. Remove a contact - Use `apollo_emailer_campaigns_remove_or_stop_contact_ids` to remove specific contacts
+4. Pause a contact - Re-add with `status: "paused"` and an `auto_unpause_at` date


### PR DESCRIPTION
## Apollo

Adds an Apollo.io plugin for sales prospecting, lead enrichment, outreach-sequence preparation, and sales analytics in Cline.

## Cline Primitives

This plugin uses MCP and bundled skills.

The `apollo` MCP server connects to Apollo's remote Streamable HTTP endpoint and uses Apollo authorization through Cline. It exposes authenticated Apollo workflows for people and company search, enrichment, contact actions, sequence actions, email accounts, and analytics depending on the user's Apollo workspace, plan, and scopes.

The bundled skills cover four common Apollo workflows:

- `apollo-prospect` turns an ideal customer profile into company searches, decision-maker searches, enrichment previews, ranked lead tables, and approved next actions.
- `apollo-enrich-lead` resolves a name, email, LinkedIn URL, company, or title into a contact card with company context and safe follow-up actions.
- `apollo-sequence-load` prepares sequence enrollment with sequence lookup, sender selection, candidate preview, enrichment, dedupe, contact creation, and a final confirmation before enrolling exact contacts.
- `apollo-analytics` maps sales-performance questions to supported Apollo metrics, date ranges, groupings, pivots, filters, and reporting tables.

The skills include guardrails for Apollo-specific risk: they ask Cline to inspect available Apollo MCP tools and schemas before relying on named tools, require approval before credit-consuming searches or enrichment, make personal email reveal opt-in, gate exports, and require final explicit approval before sequence enrollment.

## Requirements

Users need an Apollo account with access to the workspace, records, sequences, email accounts, and analytics they want Cline to use. Apollo authorization for the `apollo` MCP server is required after installation or on first use.

Some workflows depend on Apollo plan permissions and available credits or reveal allowances, especially company enrichment, lead enrichment, personal email reveal, contact creation, and sequence workflows. Sequence workflows also require access to the target sequence and sending account.

## Trust Boundary

Apollo can return prospect records, company records, emails, phone numbers, CRM data, sequence configuration, activity metrics, and sales analytics. The plugin has no install-time side effects and stores no static API keys. Apollo access is limited by the authorized Apollo user, workspace plan, and OAuth scopes.

Credit-consuming operations, personal contact reveal, exports, contact creation, CRM mutations, and sequence enrollment are treated as explicit user-approved actions.
