### PR TITLE
feat: add appwrite plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Each plugin lives in `plugins/<slug>`. The directory name is the install keyword
 | --- | --- |
 | `agent-browser` | Web and Electron browser automation via the agent-browser CLI skill. |
 | `agents-squad` | Background subagents with presets, skills, and shared handoffs. |
+| `appwrite` | Appwrite docs/API MCP access plus skills for SDKs, CLI workflows, TablesDB, and guarded site/function deployments. |
 | `background-terminal` | Long-running shell jobs with polling and cleanup tools. |
 | `branch-protector` | A hook that blocks protected branch pushes unless explicitly allowed. |
 | `bundled-skills-demo` | A package plugin that proves bundled skill discovery works. |

--- a/plugins/appwrite/README.md
+++ b/plugins/appwrite/README.md
@@ -1,16 +1,21 @@
-# appwrite
+# Appwrite
 
-Appwrite MCP and skills for building, querying, and deploying Appwrite-backed applications from Cline.
+Appwrite MCP, skills, commands, and guardrails for building, querying, and deploying Appwrite-backed applications from Cline.
 
 ## What It Adds
 
 - `appwrite-docs` MCP server for Appwrite documentation lookup over Streamable HTTP.
 - `appwrite-api` MCP server for Appwrite project operations through `uvx mcp-server-appwrite`.
-- `appwrite-sdk` skill for client and server SDK usage across web, mobile, backend, and server-side languages.
-- `appwrite-cli` skill for Appwrite CLI setup, login, project initialization, pull, push, and non-interactive workflows.
-- `appwrite-tablesdb` skill for TablesDB schema, row, query, permissions, and migration decisions.
-- `appwrite-deployments` skill for guarded site and function deployment workflows.
-- `appwrite-mcp` skill for choosing between the docs MCP and API MCP safely.
+- 15 bundled skills:
+  - `appwrite-cli` for Appwrite CLI setup, login, project initialization, pull, push, and non-interactive workflows.
+  - `appwrite-sdk` as a compatibility router for general SDK requests.
+  - `appwrite-typescript-sdk`, `appwrite-dart-sdk`, `appwrite-kotlin-sdk`, and `appwrite-swift-sdk` for client/mobile/server SDK work.
+  - `appwrite-python-sdk`, `appwrite-ruby-sdk`, `appwrite-go-sdk`, `appwrite-rust-sdk`, `appwrite-dotnet-sdk`, and `appwrite-php-sdk` for server SDK work.
+  - `appwrite-tablesdb` for TablesDB schema, row, query, permissions, and migration decisions.
+  - `appwrite-deployments` for guarded site and function deployment workflows.
+  - `appwrite-mcp` for choosing between the docs MCP and API MCP safely.
+- `/appwrite-deploy-function` and `/appwrite-deploy-site` commands for guided deployment preparation.
+- A safety rule for Appwrite project mutations, deployments, permissions, function executions, API keys, session secrets, and credential-bearing config.
 
 ## Install
 

--- a/plugins/appwrite/README.md
+++ b/plugins/appwrite/README.md
@@ -1,0 +1,49 @@
+# appwrite
+
+Appwrite MCP and skills for building, querying, and deploying Appwrite-backed applications from Cline.
+
+## What It Adds
+
+- `appwrite-docs` MCP server for Appwrite documentation lookup over Streamable HTTP.
+- `appwrite-api` MCP server for Appwrite project operations through `uvx mcp-server-appwrite`.
+- `appwrite-sdk` skill for client and server SDK usage across web, mobile, backend, and server-side languages.
+- `appwrite-cli` skill for Appwrite CLI setup, login, project initialization, pull, push, and non-interactive workflows.
+- `appwrite-tablesdb` skill for TablesDB schema, row, query, permissions, and migration decisions.
+- `appwrite-deployments` skill for guarded site and function deployment workflows.
+- `appwrite-mcp` skill for choosing between the docs MCP and API MCP safely.
+
+## Install
+
+```bash
+cline plugin install appwrite
+```
+
+For local development from this repository:
+
+```bash
+cline plugin install ./plugins/appwrite --cwd .
+```
+
+The docs MCP does not need Appwrite credentials. The API MCP reads these environment variables when the plugin is installed or reinstalled:
+
+```bash
+APPWRITE_ENDPOINT=https://<REGION>.cloud.appwrite.io/v1
+APPWRITE_PROJECT_ID=<PROJECT_ID>
+APPWRITE_API_KEY=<API_KEY>
+```
+
+If any of those variables are missing, Cline skips `appwrite-api` and still installs the docs MCP and skills. Set the variables and reinstall the plugin to add the API MCP.
+
+## Requirements
+
+- Cline with plugin MCP registration support.
+- Network access to `https://mcp-for-docs.appwrite.io` for docs lookup.
+- `uvx` available on `PATH` for the API MCP.
+- An Appwrite endpoint, project ID, and least-privilege API key for the API MCP.
+- Appwrite CLI installed and authenticated before using deployment workflows.
+
+## Security Notes
+
+The API MCP can read or mutate Appwrite project resources according to the API key scopes. Use the narrowest API key that fits the task, keep it out of source control, and avoid exposing it in logs.
+
+Deployment, delete, push, and other irreversible Appwrite operations require explicit user confirmation. Cline should inspect the local `appwrite.config.json`, summarize the intended changes, and only run the command after the user approves the exact target and command.

--- a/plugins/appwrite/index.ts
+++ b/plugins/appwrite/index.ts
@@ -1,14 +1,63 @@
 import type { AgentPlugin } from "@cline/sdk"
 
 const APPWRITE_DOCS_MCP_URL = "https://mcp-for-docs.appwrite.io"
+const PLUGIN_NAME = "appwrite"
+
+const appwriteSafetyRule = [
+	"Appwrite plugin safety:",
+	"- Treat Appwrite API MCP calls, CLI pushes, deployments, deletes, permission changes, auth provider changes, function executions, and schema migrations as live project operations.",
+	"- Before any live mutation, confirm the endpoint, project ID, resource type, resource ID, and exact command or MCP action with the user.",
+	"- Prefer read-only inspection of local files, docs, or project state before mutation.",
+	"- Never print, commit, summarize verbatim, or store Appwrite API keys, JWTs, session secrets, `.env` values, or credential-bearing `appwrite.config.json` content.",
+	"- Keep browser/mobile SDK examples limited to endpoint plus project ID; API keys belong only in trusted server-side code or user-managed environment variables.",
+	"- For deployments, inspect `appwrite.config.json` first and summarize the site/function path, build/runtime settings, and target project before asking for confirmation.",
+].join("\n")
+
+function deploymentPrompt(kind: "function" | "site", input: string): string {
+	const target = input.trim()
+	const label = kind === "function" ? "Appwrite function" : "Appwrite site"
+	const resource = kind === "function" ? "functions" : "sites"
+
+	return [
+		`Help me prepare an ${label} deployment${target ? ` for ${target}` : ""}.`,
+		"",
+		"Use the bundled Appwrite skills. First inspect local Appwrite configuration and relevant project files. Do not run `appwrite push`, `appwrite deploy`, `appwrite delete`, `--force`, or any live project mutation until I confirm the exact command and target.",
+		"",
+		`Focus on ${resource}: verify CLI/auth readiness, endpoint, project ID, resource ID, local path, build/runtime settings, environment variable needs, and any risky changes before proposing the deployment command.`,
+	].join("\n")
+}
 
 const plugin: AgentPlugin = {
-	name: "appwrite",
+	name: PLUGIN_NAME,
 	manifest: {
-		capabilities: ["mcp", "skills"],
+		capabilities: ["mcp", "skills", "commands", "rules"],
 	},
 
 	setup(api) {
+		api.registerRule({
+			id: "appwrite:safety",
+			source: PLUGIN_NAME,
+			content: appwriteSafetyRule,
+		})
+
+		api.registerCommand({
+			name: "appwrite-deploy-function",
+			description: "Prepare a guarded Appwrite function deployment workflow.",
+			handler: (input) => ({
+				reply: "Preparing a guarded Appwrite function deployment workflow.",
+				submitPrompt: deploymentPrompt("function", input),
+			}),
+		})
+
+		api.registerCommand({
+			name: "appwrite-deploy-site",
+			description: "Prepare a guarded Appwrite site deployment workflow.",
+			handler: (input) => ({
+				reply: "Preparing a guarded Appwrite site deployment workflow.",
+				submitPrompt: deploymentPrompt("site", input),
+			}),
+		})
+
 		api.registerMcpServer({
 			name: "appwrite-docs",
 			transport: {

--- a/plugins/appwrite/index.ts
+++ b/plugins/appwrite/index.ts
@@ -1,0 +1,44 @@
+import type { AgentPlugin } from "@cline/sdk"
+
+const APPWRITE_DOCS_MCP_URL = "https://mcp-for-docs.appwrite.io"
+
+const plugin: AgentPlugin = {
+	name: "appwrite",
+	manifest: {
+		capabilities: ["mcp", "skills"],
+	},
+
+	setup(api) {
+		api.registerMcpServer({
+			name: "appwrite-docs",
+			transport: {
+				type: "streamableHttp",
+				url: APPWRITE_DOCS_MCP_URL,
+			},
+		})
+
+		const {
+			APPWRITE_ENDPOINT,
+			APPWRITE_PROJECT_ID,
+			APPWRITE_API_KEY,
+		} = process.env
+
+		if (APPWRITE_ENDPOINT && APPWRITE_PROJECT_ID && APPWRITE_API_KEY) {
+			api.registerMcpServer({
+				name: "appwrite-api",
+				transport: {
+					type: "stdio",
+					command: "uvx",
+					args: ["mcp-server-appwrite"],
+					env: {
+						APPWRITE_ENDPOINT,
+						APPWRITE_PROJECT_ID,
+						APPWRITE_API_KEY,
+					},
+				},
+			})
+		}
+	},
+}
+
+export default plugin

--- a/plugins/appwrite/package.json
+++ b/plugins/appwrite/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0",
   "private": true,
   "type": "module",
-  "description": "Appwrite MCP and skills for SDK, CLI, TablesDB, and deployment workflows.",
+  "description": "Appwrite MCP, commands, rules, and skills for SDK, CLI, TablesDB, and deployment workflows.",
   "cline": {
     "plugins": [
       {
@@ -12,7 +12,9 @@
         ],
         "capabilities": [
           "mcp",
-          "skills"
+          "skills",
+          "commands",
+          "rules"
         ]
       }
     ]

--- a/plugins/appwrite/package.json
+++ b/plugins/appwrite/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "appwrite",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Appwrite MCP and skills for SDK, CLI, TablesDB, and deployment workflows.",
+  "cline": {
+    "plugins": [
+      {
+        "paths": [
+          "./index.ts"
+        ],
+        "capabilities": [
+          "mcp",
+          "skills"
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/appwrite/skills/appwrite-cli/SKILL.md
+++ b/plugins/appwrite/skills/appwrite-cli/SKILL.md
@@ -1,53 +1,543 @@
 ---
 name: appwrite-cli
-description: Use when managing an Appwrite project with the Appwrite CLI. Covers install checks, login, init, pull, push, non-interactive mode, and generated type-safe SDKs.
+description: Appwrite CLI skill. Use when managing Appwrite projects from the command line. Covers installation, login, project initialization, deploying functions/sites/tables/buckets/teams/topics, managing resources, non-interactive CI/CD mode, and generating type-safe SDKs.
 ---
+
 
 # Appwrite CLI
 
-Use this skill when the task involves `appwrite` CLI commands or `appwrite.config.json`.
+## Cline Safety
 
-## First Checks
+- Do not run install, deploy, push, delete, migration, or project mutation commands unless the user asks for that action and confirms the exact target.
+- Keep Appwrite API keys, JWTs, session secrets, endpoint-specific credentials, and .env values out of source control, logs, summaries, and chat unless the user explicitly asks to inspect a redacted form.
+- Prefer least-privilege API keys for server-side examples and keep client-side examples limited to endpoint plus project ID.
 
-- Check whether `appwrite` is available before suggesting CLI commands.
-- Inspect the workspace for `appwrite.config.json` before initializing or pushing anything.
-- Prefer `appwrite login` for local interactive setup.
-- For CI or non-interactive setup, configure the client with endpoint, project ID, and API key from environment variables.
 
-## Common Workflow
-
-1. Verify the CLI is installed.
-2. Confirm the endpoint and project ID.
-3. Run `appwrite login` or configure non-interactive auth.
-4. Run `appwrite init project` only when there is no existing config and the user wants to initialize.
-5. Use `appwrite pull` to reconcile remote resources before editing deployment config.
-6. Review generated or changed `appwrite.config.json` before pushing.
-
-## Non-Interactive Auth
-
-For automation, use the CLI client command with values supplied from the environment:
+## Installation
 
 ```bash
-appwrite client \
-  --endpoint "$APPWRITE_ENDPOINT" \
-  --project-id "$APPWRITE_PROJECT_ID" \
-  --key "$APPWRITE_API_KEY"
+# npm
+npm install -g appwrite-cli
+
+# macOS (Homebrew native binary)
+brew install appwrite
+
+# macOS / Linux (script; ask before running remote install scripts)
+curl -sL https://appwrite.io/cli/install.sh | bash
+
+# Windows (Scoop)
+scoop install https://raw.githubusercontent.com/appwrite/sdk-for-cli/master/scoop/appwrite.config.json
 ```
 
-Do not print the API key, write it to committed files, or include it in command logs.
+Verify installation:
 
-## Push Safety
+```bash
+appwrite -v
+```
 
-- Treat `appwrite push`, `appwrite deploy`, and resource delete commands as side-effecting operations.
-- Before any push, show the target endpoint, project ID, resource type, and exact command.
-- Ask for explicit confirmation before running the command.
-- Prefer scoped pushes such as functions or sites over `appwrite push all` unless the user requests all resources.
-- Avoid `--force` unless the user explicitly approves the exact command.
+## Login & Initialization
 
-## Generated SDKs
+```bash
+# Login to your account
+appwrite login
 
-When generating type-safe SDKs:
+# Login to a self-hosted instance
+appwrite login --endpoint "https://your-instance.com/v1"
 
-- Confirm the output directory is ignored or intended for source control.
-- Do not overwrite existing generated code without checking the current file state.
-- Keep generated code separate from handwritten adapters where practical.
+# Initialize a project (creates appwrite.config.json)
+appwrite init project
+
+# Verify by fetching project info
+appwrite projects get --project-id "<PROJECT_ID>"
+```
+
+## Configuration
+
+```bash
+# Authenticate with Appwrite
+appwrite login
+```
+
+> For the full list of CLI commands, see [CLI Commands](https://appwrite.io/docs/tooling/command-line/commands).
+> For headless / CI/CD usage, see [Non-Interactive Mode](https://appwrite.io/docs/tooling/command-line/non-interactive).
+
+## appwrite.config.json
+
+All resources are configured in a single `appwrite.config.json` file at the project root:
+
+```json
+{
+    "projectId": "<PROJECT_ID>",
+    "endpoint": "https://<REGION>.cloud.appwrite.io/v1",
+    "functions": [],
+    "sites": [],
+    "tablesDB": [],
+    "tables": [],
+    "buckets": [],
+    "teams": [],
+    "topics": []
+}
+```
+
+## Deploying Functions
+
+```bash
+# Create a new function
+appwrite init functions
+
+# Pull existing functions from Console
+appwrite pull functions
+
+# Deploy functions
+appwrite push functions
+```
+
+### Function configuration in appwrite.config.json
+
+```json
+{
+    "functions": [
+        {
+            "$id": "<FUNCTION_ID>",
+            "name": "userAuth",
+            "enabled": true,
+            "live": true,
+            "logging": true,
+            "runtime": "node-18.0",
+            "deployment": "<DEPLOYMENT_ID>",
+            "vars": [],
+            "events": [],
+            "schedule": "",
+            "timeout": 15,
+            "entrypoint": "userAuth.js",
+            "commands": "npm install",
+            "version": "v3",
+            "path": "functions/userAuth"
+        }
+    ]
+}
+```
+
+### Function commands
+
+| Command | Description |
+|---------|-------------|
+| `appwrite functions list` | List all functions |
+| `appwrite functions create` | Create a new function |
+| `appwrite functions get --function-id <ID>` | Get a function by ID |
+| `appwrite functions update --function-id <ID>` | Update a function |
+| `appwrite functions delete --function-id <ID>` | Delete a function |
+| `appwrite functions list-runtimes` | List all active runtimes |
+| `appwrite functions list-deployments --function-id <ID>` | List deployments |
+| `appwrite functions create-deployment --function-id <ID>` | Upload a new deployment |
+| `appwrite functions update-deployment --function-id <ID> --deployment-id <ID>` | Set active deployment |
+| `appwrite functions delete-deployment --function-id <ID> --deployment-id <ID>` | Delete a deployment |
+| `appwrite functions download-deployment --function-id <ID> --deployment-id <ID>` | Download deployment |
+| `appwrite functions create-execution --function-id <ID>` | Trigger execution |
+| `appwrite functions list-executions --function-id <ID>` | List execution logs |
+| `appwrite functions get-execution --function-id <ID> --execution-id <ID>` | Get execution log |
+| `appwrite functions list-variables --function-id <ID>` | List variables |
+| `appwrite functions create-variable --function-id <ID> --key <KEY> --value <VALUE>` | Create variable |
+| `appwrite functions update-variable --function-id <ID> --variable-id <ID> --key <KEY> --value <VALUE>` | Update variable |
+| `appwrite functions delete-variable --function-id <ID> --variable-id <ID>` | Delete variable |
+
+### Trigger a function with body
+
+```bash
+appwrite functions create-execution \
+    --function-id <FUNCTION_ID> \
+    --body '{"key": "value"}'
+```
+
+### Local development
+
+```bash
+appwrite run functions
+```
+
+## Deploying Sites
+
+```bash
+# Create a new site
+appwrite init sites
+
+# Pull existing sites from Console
+appwrite pull sites
+
+# Deploy sites
+appwrite push sites
+```
+
+### Site configuration in appwrite.config.json
+
+```json
+{
+    "sites": [
+        {
+            "$id": "<SITE_ID>",
+            "name": "Documentation template",
+            "enabled": true,
+            "logging": true,
+            "framework": "astro",
+            "timeout": 30,
+            "installCommand": "npm install",
+            "buildCommand": "npm run build",
+            "outputDirectory": "./dist",
+            "specification": "s-1vcpu-512mb",
+            "buildRuntime": "node-22",
+            "adapter": "ssr",
+            "fallbackFile": "",
+            "path": "sites/documentation-template"
+        }
+    ]
+}
+```
+
+### Site commands
+
+| Command | Description |
+|---------|-------------|
+| `appwrite sites list` | List all sites |
+| `appwrite sites create` | Create a new site |
+| `appwrite sites get --site-id <ID>` | Get a site by ID |
+| `appwrite sites update --site-id <ID>` | Update a site |
+| `appwrite sites delete --site-id <ID>` | Delete a site |
+| `appwrite sites list-frameworks` | List available frameworks |
+| `appwrite sites list-specifications` | List allowed specs |
+| `appwrite sites list-templates` | List available templates |
+| `appwrite sites get-template --template-id <ID>` | Get template details |
+| `appwrite sites list-deployments --site-id <ID>` | List deployments |
+| `appwrite sites create-deployment --site-id <ID>` | Create deployment |
+| `appwrite sites get-deployment --site-id <ID> --deployment-id <ID>` | Get deployment |
+| `appwrite sites delete-deployment --site-id <ID> --deployment-id <ID>` | Delete deployment |
+| `appwrite sites update-site-deployment --site-id <ID> --deployment-id <ID>` | Set active deployment |
+| `appwrite sites update-deployment-status --site-id <ID> --deployment-id <ID>` | Cancel ongoing build |
+| `appwrite sites list-variables --site-id <ID>` | List variables |
+| `appwrite sites create-variable --site-id <ID> --key <KEY> --value <VALUE>` | Create variable |
+| `appwrite sites update-variable --site-id <ID> --variable-id <ID> --key <KEY> --value <VALUE>` | Update variable |
+| `appwrite sites delete-variable --site-id <ID> --variable-id <ID>` | Delete variable |
+| `appwrite sites list-logs --site-id <ID>` | List request logs |
+| `appwrite sites get-log --site-id <ID> --log-id <ID>` | Get a log |
+| `appwrite sites delete-log --site-id <ID> --log-id <ID>` | Delete a log |
+
+## Managing Tables (Databases)
+
+```bash
+# Create a new table
+appwrite init tables
+
+# Pull existing tables from Console
+appwrite pull tables
+
+# Deploy tables
+appwrite push tables
+```
+
+### Table configuration in appwrite.config.json
+
+```json
+{
+    "tablesDB": [
+        {
+            "$id": "<DATABASE_ID>",
+            "name": "songs",
+            "enabled": true
+        }
+    ],
+    "tables": [
+        {
+            "$id": "<TABLE_ID>",
+            "$permissions": ["create(\"any\")", "read(\"any\")"],
+            "databaseId": "<DATABASE_ID>",
+            "name": "music",
+            "enabled": true,
+            "rowSecurity": false,
+            "columns": [
+                {
+                    "key": "title",
+                    "type": "varchar",
+                    "required": true,
+                    "size": 255
+                }
+            ],
+            "indexes": []
+        }
+    ]
+}
+```
+
+### Database commands (TablesDB)
+
+| Command | Description |
+|---------|-------------|
+| `appwrite tables-db list-tables --database-id <ID>` | List tables |
+| `appwrite tables-db create-table --database-id <ID>` | Create table |
+| `appwrite tables-db get-table --database-id <ID> --table-id <ID>` | Get table |
+| `appwrite tables-db update-table --database-id <ID> --table-id <ID>` | Update table |
+| `appwrite tables-db delete-table --database-id <ID> --table-id <ID>` | Delete table |
+| `appwrite tables-db list-columns --database-id <ID> --table-id <ID>` | List columns |
+| `appwrite tables-db get-column --database-id <ID> --table-id <ID> --key <KEY>` | Get column |
+| `appwrite tables-db delete-column --database-id <ID> --table-id <ID> --key <KEY>` | Delete column |
+| `appwrite tables-db list-column-indexes --database-id <ID> --table-id <ID>` | List indexes |
+| `appwrite tables-db create-column-index --database-id <ID> --table-id <ID>` | Create index |
+| `appwrite tables-db delete-column-index --database-id <ID> --table-id <ID> --key <KEY>` | Delete index |
+
+### Column type commands
+
+> Note: The legacy `string` type is deprecated. Use explicit string column types instead.
+
+| Command | Description |
+|---------|-------------|
+| `create-varchar-column` | Varchar column -- inline storage, fully indexable (max 16,383 chars, size <= 768 for full index) |
+| `create-text-column` | Text column -- off-page storage, prefix index only (max 16,383 chars) |
+| `create-mediumtext-column` | Mediumtext column -- off-page storage (max ~4M chars) |
+| `create-longtext-column` | Longtext column -- off-page storage (max ~1B chars) |
+| `create-boolean-column` | Boolean column |
+| `create-integer-column` | Integer column (optional min/max) |
+| `create-float-column` | Float column (optional min/max) |
+| `create-email-column` | Email column |
+| `create-url-column` | URL column |
+| `create-ip-column` | IP address column |
+| `create-datetime-column` | Datetime column (ISO 8601) |
+| `create-enum-column` | Enum column (whitelist of accepted values) |
+| `create-relationship-column` | Relationship column |
+
+All column commands use `appwrite tables-db <command> --database-id <ID> --table-id <ID>`.
+
+### Row operations
+
+```bash
+# Create a row
+appwrite tables-db create-row \
+    --database-id "<DATABASE_ID>" --table-id "<TABLE_ID>" \
+    --row-id 'unique()' --data '{ "title": "Hello World" }' \
+    --permissions 'read("any")' 'write("team:abc")'
+
+# List rows (JSON output)
+appwrite tables-db list-rows \
+    --database-id "<DATABASE_ID>" --table-id "<TABLE_ID>" --json
+
+# Get a row
+appwrite tables-db get-row \
+    --database-id "<DATABASE_ID>" --table-id "<TABLE_ID>" --row-id "<ROW_ID>"
+```
+
+## Managing Buckets (Storage)
+
+```bash
+# Create a new bucket
+appwrite init buckets
+
+# Pull existing buckets from Console
+appwrite pull buckets
+
+# Deploy buckets
+appwrite push buckets
+```
+
+### Storage commands
+
+| Command | Description |
+|---------|-------------|
+| `appwrite storage list-buckets` | List all buckets |
+| `appwrite storage create-bucket` | Create a bucket |
+| `appwrite storage get-bucket --bucket-id <ID>` | Get a bucket |
+| `appwrite storage update-bucket --bucket-id <ID>` | Update a bucket |
+| `appwrite storage delete-bucket --bucket-id <ID>` | Delete a bucket |
+| `appwrite storage list-files --bucket-id <ID>` | List files |
+| `appwrite storage create-file --bucket-id <ID>` | Upload a file |
+| `appwrite storage get-file --bucket-id <ID> --file-id <ID>` | Get file metadata |
+| `appwrite storage delete-file --bucket-id <ID> --file-id <ID>` | Delete a file |
+| `appwrite storage get-file-download --bucket-id <ID> --file-id <ID>` | Download a file |
+| `appwrite storage get-file-preview --bucket-id <ID> --file-id <ID>` | Get image preview |
+| `appwrite storage get-file-view --bucket-id <ID> --file-id <ID>` | View file in browser |
+
+## Managing Teams
+
+```bash
+# Create a new team
+appwrite init teams
+
+# Pull existing teams from Console
+appwrite pull teams
+
+# Deploy teams
+appwrite push teams
+```
+
+### Team commands
+
+| Command | Description |
+|---------|-------------|
+| `appwrite teams list` | List all teams |
+| `appwrite teams create` | Create a team |
+| `appwrite teams get --team-id <ID>` | Get a team |
+| `appwrite teams update-name --team-id <ID>` | Update team name |
+| `appwrite teams delete --team-id <ID>` | Delete a team |
+| `appwrite teams list-memberships --team-id <ID>` | List members |
+| `appwrite teams create-membership --team-id <ID>` | Invite a member |
+| `appwrite teams update-membership --team-id <ID> --membership-id <ID>` | Update member roles |
+| `appwrite teams delete-membership --team-id <ID> --membership-id <ID>` | Remove a member |
+| `appwrite teams get-prefs --team-id <ID>` | Get team preferences |
+| `appwrite teams update-prefs --team-id <ID>` | Update team preferences |
+
+## Managing Topics (Messaging)
+
+```bash
+# Create a new topic
+appwrite init topics
+
+# Pull existing topics from Console
+appwrite pull topics
+
+# Deploy topics
+appwrite push topics
+```
+
+### Messaging commands
+
+| Command | Description |
+|---------|-------------|
+| `appwrite messaging list-messages` | List all messages |
+| `appwrite messaging create-email` | Create email message |
+| `appwrite messaging create-push` | Create push notification |
+| `appwrite messaging create-sms` | Create SMS message |
+| `appwrite messaging get-message --message-id <ID>` | Get a message |
+| `appwrite messaging delete --message-id <ID>` | Delete a message |
+| `appwrite messaging list-topics` | List all topics |
+| `appwrite messaging create-topic` | Create a topic |
+| `appwrite messaging get-topic --topic-id <ID>` | Get a topic |
+| `appwrite messaging update-topic --topic-id <ID>` | Update a topic |
+| `appwrite messaging delete-topic --topic-id <ID>` | Delete a topic |
+| `appwrite messaging list-subscribers --topic-id <ID>` | List subscribers |
+| `appwrite messaging create-subscriber --topic-id <ID>` | Add subscriber |
+| `appwrite messaging delete-subscriber --topic-id <ID> --subscriber-id <ID>` | Remove subscriber |
+
+## User Management
+
+```bash
+# Create a user
+appwrite users create --user-id "unique()" \
+    --email hello@appwrite.io
+
+# List users
+appwrite users list
+
+# Get a user
+appwrite users get --user-id "<USER_ID>"
+
+# Delete a user
+appwrite users delete --user-id "<USER_ID>"
+```
+
+## Generate Type-Safe SDK
+
+```bash
+# Auto-detect language and generate
+appwrite generate
+
+# Specify output directory
+appwrite generate --output ./src/generated
+
+# Specify language
+appwrite generate --language typescript
+```
+
+Generated files:
+
+| File | Description |
+|------|-------------|
+| `types.ts` | Type definitions from your database schema |
+| `databases.ts` | Typed database helpers for querying and mutating rows |
+| `constants.ts` | Configuration constants (endpoint, project ID) |
+| `index.ts` | Entry point that exports all helpers |
+
+Usage:
+
+```typescript
+import { databases } from "./generated/appwrite";
+
+const customers = databases.use("main").use("customers");
+
+// Create
+const customer = await customers.create({
+    name: "Walter O' Brian",
+    email: "walter@example.com"
+});
+
+// List with typed queries
+const results = await customers.list({
+    queries: (q) => [
+        q.equal("name", "Walter O' Brian"),
+        q.orderDesc("$createdAt"),
+        q.limit(10)
+    ]
+});
+
+// Update
+await customers.update("customer-id-123", {
+    email: "walter@scorpion.com"
+});
+
+// Delete
+await customers.delete("customer-id-123");
+
+// Bulk create
+await customers.createMany([
+    { name: "Walter O' Brian", email: "walter@example.com" },
+    { name: "Paige Dineen", email: "paige@example.com" }
+]);
+```
+
+## Non-Interactive / CI/CD Mode
+
+For headless automation, see the [Non-Interactive Mode docs](https://appwrite.io/docs/tooling/command-line/non-interactive).
+
+### Deploy non-interactively
+
+Treat non-interactive deploys as live project mutations. Do not run these from
+Cline until the user confirms the endpoint, project ID, resource type, resource
+ID, and exact command. Prefer scoped resource pushes. Avoid `push all` unless
+the user explicitly requests a full-project sync after reviewing the local
+`appwrite.config.json`.
+
+```bash
+# Push a specific resource after explicit confirmation
+appwrite push functions --function-id <FUNCTION_ID> --force
+appwrite push sites --site-id <SITE_ID> --force
+```
+
+## Global Command Options
+
+| Option | Description |
+|--------|-------------|
+| `-v, --version` | Output version number |
+| `-V, --verbose` | Show complete error log |
+| `-j, --json` | Output in JSON format |
+| `-f, --force` | Confirm all warnings |
+| `-a, --all` | Select all resources |
+| `--id [id...]` | Pass a list of IDs |
+| `--report` | Generate GitHub error report link |
+| `--console` | Get direct link to Console |
+| `--open` | Open Console link in browser |
+| `-h, --help` | Display help |
+
+## Examples
+
+```bash
+# List users with JSON output
+appwrite users list --json
+
+# Get verbose error output
+appwrite users list --verbose
+
+# View a row in the Console
+appwrite tables-db get-row \
+    --database-id "<DATABASE_ID>" \
+    --table-id "<TABLE_ID>" \
+    --row-id "<ROW_ID>" \
+    --console --open
+
+# Generate error report
+appwrite login --report
+```

--- a/plugins/appwrite/skills/appwrite-cli/SKILL.md
+++ b/plugins/appwrite/skills/appwrite-cli/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: appwrite-cli
+description: Use when managing an Appwrite project with the Appwrite CLI. Covers install checks, login, init, pull, push, non-interactive mode, and generated type-safe SDKs.
+---
+
+# Appwrite CLI
+
+Use this skill when the task involves `appwrite` CLI commands or `appwrite.config.json`.
+
+## First Checks
+
+- Check whether `appwrite` is available before suggesting CLI commands.
+- Inspect the workspace for `appwrite.config.json` before initializing or pushing anything.
+- Prefer `appwrite login` for local interactive setup.
+- For CI or non-interactive setup, configure the client with endpoint, project ID, and API key from environment variables.
+
+## Common Workflow
+
+1. Verify the CLI is installed.
+2. Confirm the endpoint and project ID.
+3. Run `appwrite login` or configure non-interactive auth.
+4. Run `appwrite init project` only when there is no existing config and the user wants to initialize.
+5. Use `appwrite pull` to reconcile remote resources before editing deployment config.
+6. Review generated or changed `appwrite.config.json` before pushing.
+
+## Non-Interactive Auth
+
+For automation, use the CLI client command with values supplied from the environment:
+
+```bash
+appwrite client \
+  --endpoint "$APPWRITE_ENDPOINT" \
+  --project-id "$APPWRITE_PROJECT_ID" \
+  --key "$APPWRITE_API_KEY"
+```
+
+Do not print the API key, write it to committed files, or include it in command logs.
+
+## Push Safety
+
+- Treat `appwrite push`, `appwrite deploy`, and resource delete commands as side-effecting operations.
+- Before any push, show the target endpoint, project ID, resource type, and exact command.
+- Ask for explicit confirmation before running the command.
+- Prefer scoped pushes such as functions or sites over `appwrite push all` unless the user requests all resources.
+- Avoid `--force` unless the user explicitly approves the exact command.
+
+## Generated SDKs
+
+When generating type-safe SDKs:
+
+- Confirm the output directory is ignored or intended for source control.
+- Do not overwrite existing generated code without checking the current file state.
+- Keep generated code separate from handwritten adapters where practical.

--- a/plugins/appwrite/skills/appwrite-dart-sdk/SKILL.md
+++ b/plugins/appwrite/skills/appwrite-dart-sdk/SKILL.md
@@ -1,0 +1,501 @@
+---
+name: appwrite-dart-sdk
+description: Appwrite Dart SDK skill. Use when building Flutter apps or server-side Dart applications with Appwrite. Covers client-side auth, database queries, file uploads, realtime subscriptions, and server-side admin via API keys.
+---
+
+
+# Appwrite Dart SDK
+
+## Cline Safety
+
+- Do not run install, deploy, push, delete, migration, or project mutation commands unless the user asks for that action and confirms the exact target.
+- Keep Appwrite API keys, JWTs, session secrets, endpoint-specific credentials, and .env values out of source control, logs, summaries, and chat unless the user explicitly asks to inspect a redacted form.
+- Prefer least-privilege API keys for server-side examples and keep client-side examples limited to endpoint plus project ID.
+
+
+## Installation
+
+```bash
+# Flutter (client-side)
+flutter pub add appwrite
+
+# Dart (server-side)
+dart pub add dart_appwrite
+```
+
+## Setting Up the Client
+
+### Client-side (Flutter)
+
+```dart
+import 'package:appwrite/appwrite.dart';
+
+final client = Client()
+    .setEndpoint('https://<REGION>.cloud.appwrite.io/v1')
+    .setProject('[PROJECT_ID]');
+```
+
+### Server-side (Dart)
+
+```dart
+import 'package:dart_appwrite/dart_appwrite.dart';
+
+final client = Client()
+    .setEndpoint('https://<REGION>.cloud.appwrite.io/v1')
+    .setProject(Platform.environment['APPWRITE_PROJECT_ID']!)
+    .setKey(Platform.environment['APPWRITE_API_KEY']!);
+```
+
+## Code Examples
+
+### Authentication (client-side)
+
+```dart
+final account = Account(client);
+
+// Signup
+await account.create(userId: ID.unique(), email: 'user@example.com', password: 'password123', name: 'User Name');
+
+// Login
+final session = await account.createEmailPasswordSession(email: 'user@example.com', password: 'password123');
+
+// OAuth login
+await account.createOAuth2Session(provider: OAuthProvider.google);
+
+// Get current user
+final user = await account.get();
+
+// Logout
+await account.deleteSession(sessionId: 'current');
+```
+
+### User Management (server-side)
+
+```dart
+final users = Users(client);
+
+// Create user
+final user = await users.create(userId: ID.unique(), email: 'user@example.com', password: 'password123', name: 'User Name');
+
+// List users
+final list = await users.list(queries: [Query.limit(25)]);
+
+// Get user
+final fetched = await users.get(userId: '[USER_ID]');
+
+// Delete user
+await users.delete(userId: '[USER_ID]');
+```
+
+### Database Operations
+
+> Note: Use `TablesDB` (not the deprecated `Databases` class) for all new code. Only use `Databases` if the existing codebase already relies on it or the user explicitly requests it.
+>
+> Tip: Prefer named parameters (e.g., `databaseId: '...'`) for all SDK method calls. Only use positional arguments if the existing codebase already uses them or the user explicitly requests it.
+
+```dart
+final tablesDB = TablesDB(client);
+
+// Create database (server-side only)
+final db = await tablesDB.create(databaseId: ID.unique(), name: 'My Database');
+
+// Create table (server-side only)
+final col = await tablesDB.createTable(databaseId: '[DATABASE_ID]', tableId: ID.unique(), name: 'My Table');
+
+// Create row
+final doc = await tablesDB.createRow(
+    databaseId: '[DATABASE_ID]',
+    tableId: '[TABLE_ID]',
+    rowId: ID.unique(),
+    data: {'title': 'Hello', 'done': false},
+);
+
+// Query rows
+final results = await tablesDB.listRows(
+    databaseId: '[DATABASE_ID]',
+    tableId: '[TABLE_ID]',
+    queries: [Query.equal('done', false), Query.limit(10)],
+);
+
+// Get row
+final row = await tablesDB.getRow(databaseId: '[DATABASE_ID]', tableId: '[TABLE_ID]', rowId: '[ROW_ID]');
+
+// Update row
+await tablesDB.updateRow(
+    databaseId: '[DATABASE_ID]',
+    tableId: '[TABLE_ID]',
+    rowId: '[ROW_ID]',
+    data: {'done': true},
+);
+
+// Delete row
+await tablesDB.deleteRow(
+    databaseId: '[DATABASE_ID]',
+    tableId: '[TABLE_ID]',
+    rowId: '[ROW_ID]',
+);
+```
+
+#### String Column Types
+
+> Note: The legacy `string` type is deprecated. Use explicit column types for all new columns.
+
+| Type | Max characters | Indexing | Storage |
+|------|---------------|----------|---------|
+| `varchar` | 16,383 | Full index (if size <= 768) | Inline in row |
+| `text` | 16,383 | Prefix only | Off-page |
+| `mediumtext` | 4,194,303 | Prefix only | Off-page |
+| `longtext` | 1,073,741,823 | Prefix only | Off-page |
+
+- `varchar` is stored inline and counts towards the 64 KB row size limit. Prefer for short, indexed fields like names, slugs, or identifiers.
+- `text`, `mediumtext`, and `longtext` are stored off-page (only a 20-byte pointer lives in the row), so they don't consume the row size budget. `size` is not required for these types.
+
+```dart
+// Create table with explicit string column types
+await tablesDB.createTable(
+    databaseId: '[DATABASE_ID]',
+    tableId: ID.unique(),
+    name: 'articles',
+    columns: [
+        {'key': 'title',    'type': 'varchar',    'size': 255, 'required': true},   // inline, fully indexable
+        {'key': 'summary',  'type': 'text',                    'required': false},  // off-page, prefix index only
+        {'key': 'body',     'type': 'mediumtext',              'required': false},  // up to ~4 M chars
+        {'key': 'raw_data', 'type': 'longtext',                'required': false},  // up to ~1 B chars
+    ],
+);
+```
+
+### Query Methods
+
+```dart
+// Filtering
+Query.equal('field', 'value')             // == (or pass list for IN)
+Query.notEqual('field', 'value')          // !=
+Query.lessThan('field', 100)              // <
+Query.lessThanEqual('field', 100)         // <=
+Query.greaterThan('field', 100)           // >
+Query.greaterThanEqual('field', 100)      // >=
+Query.between('field', 1, 100)            // 1 <= field <= 100
+Query.isNull('field')                     // is null
+Query.isNotNull('field')                  // is not null
+Query.startsWith('field', 'prefix')       // starts with
+Query.endsWith('field', 'suffix')         // ends with
+Query.contains('field', 'sub')            // contains
+Query.search('field', 'keywords')         // full-text search (requires index)
+
+// Sorting
+Query.orderAsc('field')
+Query.orderDesc('field')
+
+// Pagination
+Query.limit(25)                           // max rows (default 25, max 100)
+Query.offset(0)                           // skip N rows
+Query.cursorAfter('[ROW_ID]')             // cursor pagination (preferred)
+Query.cursorBefore('[ROW_ID]')
+
+// Selection & Logic
+Query.select(['field1', 'field2'])        // return only specified fields
+Query.or([Query.equal('a', 1), Query.equal('b', 2)])   // OR
+Query.and([Query.greaterThan('age', 18), Query.lessThan('age', 65)])  // AND (default)
+```
+
+### File Storage
+
+```dart
+final storage = Storage(client);
+
+// Upload file
+final file = await storage.createFile(
+    bucketId: '[BUCKET_ID]',
+    fileId: ID.unique(),
+    file: InputFile.fromPath(path: '/path/to/file.png', filename: 'file.png'),
+);
+
+// Get file preview
+final preview = storage.getFilePreview(bucketId: '[BUCKET_ID]', fileId: '[FILE_ID]', width: 300, height: 300);
+
+// List files
+final files = await storage.listFiles(bucketId: '[BUCKET_ID]');
+
+// Delete file
+await storage.deleteFile(bucketId: '[BUCKET_ID]', fileId: '[FILE_ID]');
+```
+
+#### InputFile Factory Methods
+
+```dart
+// Client-side (Flutter)
+InputFile.fromPath(path: '/path/to/file.png', filename: 'file.png')    // from path
+InputFile.fromBytes(bytes: uint8List, filename: 'file.png')            // from Uint8List
+
+// Server-side (Dart)
+InputFile.fromPath(path: '/path/to/file.png', filename: 'file.png')
+InputFile.fromBytes(bytes: uint8List, filename: 'file.png')
+```
+
+### Teams
+
+```dart
+final teams = Teams(client);
+
+// Create team
+final team = await teams.create(teamId: ID.unique(), name: 'Engineering');
+
+// List teams
+final list = await teams.list();
+
+// Create membership (invite user by email)
+final membership = await teams.createMembership(
+    teamId: '[TEAM_ID]',
+    roles: ['editor'],
+    email: 'user@example.com',
+);
+
+// List memberships
+final members = await teams.listMemberships(teamId: '[TEAM_ID]');
+
+// Update membership roles
+await teams.updateMembership(teamId: '[TEAM_ID]', membershipId: '[MEMBERSHIP_ID]', roles: ['admin']);
+
+// Delete team
+await teams.delete(teamId: '[TEAM_ID]');
+```
+
+> Role-based access: Use `Role.team('[TEAM_ID]')` for all team members or `Role.team('[TEAM_ID]', 'editor')` for a specific team role when setting permissions.
+
+### Real-time Subscriptions (client-side)
+
+```dart
+final realtime = Realtime(client);
+
+// Subscribe to row changes
+final subscription = realtime.subscribe([
+    Channel.tablesdb('[DATABASE_ID]').table('[TABLE_ID]').row(),
+]);
+subscription.stream.listen((response) {
+    print(response.events);   // e.g. ['tablesdb.*.tables.*.rows.*.create']
+    print(response.payload);  // the affected resource
+});
+
+// Subscribe to multiple channels
+final multi = realtime.subscribe([
+    Channel.tablesdb('[DATABASE_ID]').table('[TABLE_ID]').row(),
+    Channel.bucket('[BUCKET_ID]').file(),
+]);
+
+// Cleanup
+subscription.close();
+```
+
+Available channels:
+
+| Channel | Description |
+|---------|-------------|
+| `account` | Changes to the authenticated user's account |
+| `tablesdb.[DB_ID].tables.[TABLE_ID].rows` | All rows in a table |
+| `tablesdb.[DB_ID].tables.[TABLE_ID].rows.[ROW_ID]` | A specific row |
+| `buckets.[BUCKET_ID].files` | All files in a bucket |
+| `buckets.[BUCKET_ID].files.[FILE_ID]` | A specific file |
+| `teams` | Changes to teams the user belongs to |
+| `teams.[TEAM_ID]` | A specific team |
+| `memberships` | The user's team memberships |
+| `memberships.[MEMBERSHIP_ID]` | A specific membership |
+| `functions.[FUNCTION_ID].executions` | Function execution updates |
+
+Response fields: `events` (array), `payload` (resource), `channels` (matched), `timestamp` (ISO 8601).
+
+### Serverless Functions (server-side)
+
+```dart
+final functions = Functions(client);
+
+// Execute function
+final execution = await functions.createExecution(functionId: '[FUNCTION_ID]', body: '{"key": "value"}');
+
+// List executions
+final executions = await functions.listExecutions(functionId: '[FUNCTION_ID]');
+```
+
+#### Writing a Function Handler (Dart runtime)
+
+```dart
+// lib/main.dart -- Appwrite Function entry point
+Future<dynamic> main(final context) async {
+    // context.req.body        -- raw body (String)
+    // context.req.bodyJson    -- parsed JSON (Map or null)
+    // context.req.headers     -- headers (Map)
+    // context.req.method      -- HTTP method
+    // context.req.path        -- URL path
+    // context.req.query       -- query params (Map)
+
+    context.log('Processing: ${context.req.method} ${context.req.path}');
+
+    if (context.req.method == 'GET') {
+        return context.res.json({'message': 'Hello from Appwrite Function!'});
+    }
+
+    return context.res.json({'success': true});      // JSON
+    // return context.res.text('Hello');              // plain text
+    // return context.res.empty();                    // 204
+    // return context.res.redirect('https://...');    // 302
+}
+```
+
+### Server-Side Rendering (SSR) Authentication
+
+SSR apps using server-side Dart (Dart Frog, Shelf, etc.) use the server SDK (`dart_appwrite`) to handle auth. You need two clients:
+
+- Admin client -- uses an API key, creates sessions, bypasses rate limits (reusable singleton)
+- Session client -- uses a session cookie, acts on behalf of a user (create per-request, never share)
+
+```dart
+import 'package:dart_appwrite/dart_appwrite.dart';
+
+// Admin client (reusable)
+final adminClient = Client()
+    .setEndpoint('https://<REGION>.cloud.appwrite.io/v1')
+    .setProject('[PROJECT_ID]')
+    .setKey(Platform.environment['APPWRITE_API_KEY']!);
+
+// Session client (create per-request)
+final sessionClient = Client()
+    .setEndpoint('https://<REGION>.cloud.appwrite.io/v1')
+    .setProject('[PROJECT_ID]');
+
+final session = request.cookies['a_session_[PROJECT_ID]'];
+if (session != null) {
+    sessionClient.setSession(session);
+}
+```
+
+#### Email/Password Login
+
+```dart
+final account = Account(adminClient);
+final session = await account.createEmailPasswordSession(
+    email: body['email'],
+    password: body['password'],
+);
+
+// Cookie name must be a_session_<PROJECT_ID>
+response.headers.add('Set-Cookie',
+    'a_session_[PROJECT_ID]=${session.secret}; '
+    'HttpOnly; Secure; SameSite=Strict; '
+    'Expires=${HttpDate.format(DateTime.parse(session.expire))}; Path=/');
+```
+
+#### Authenticated Requests
+
+```dart
+final session = request.cookies['a_session_[PROJECT_ID]'];
+if (session == null) {
+    return Response(statusCode: 401, body: 'Unauthorized');
+}
+
+final sessionClient = Client()
+    .setEndpoint('https://<REGION>.cloud.appwrite.io/v1')
+    .setProject('[PROJECT_ID]')
+    .setSession(session);
+
+final account = Account(sessionClient);
+final user = await account.get();
+```
+
+#### OAuth2 SSR Flow
+
+```dart
+// Step 1: Redirect to OAuth provider
+final account = Account(adminClient);
+final redirectUrl = await account.createOAuth2Token(
+    provider: OAuthProvider.github,
+    success: 'https://example.com/oauth/success',
+    failure: 'https://example.com/oauth/failure',
+);
+return Response(statusCode: 302, headers: {'Location': redirectUrl});
+
+// Step 2: Handle callback -- exchange token for session
+final account = Account(adminClient);
+final session = await account.createSession(
+    userId: request.uri.queryParameters['userId']!,
+    secret: request.uri.queryParameters['secret']!,
+);
+// Set session cookie as above
+```
+
+> Cookie security: Always use `HttpOnly`, `Secure`, and `SameSite=Strict` to prevent XSS. The cookie name must be `a_session_<PROJECT_ID>`.
+
+> Forwarding user agent: Call `sessionClient.setForwardedUserAgent(request.headers['user-agent'])` to record the end-user's browser info for debugging and security.
+
+## Error Handling
+
+```dart
+import 'package:appwrite/appwrite.dart';
+// AppwriteException is included in the main import
+
+try {
+    final row = await tablesDB.getRow(databaseId: '[DATABASE_ID]', tableId: '[TABLE_ID]', rowId: '[ROW_ID]');
+} on AppwriteException catch (e) {
+    print(e.message);    // human-readable message
+    print(e.code);       // HTTP status code (int)
+    print(e.type);       // error type (e.g. 'document_not_found')
+    print(e.response);   // full response body (Map)
+}
+```
+
+Common error codes:
+
+| Code | Meaning |
+|------|---------|
+| `401` | Unauthorized -- missing or invalid session/API key |
+| `403` | Forbidden -- insufficient permissions |
+| `404` | Not found -- resource does not exist |
+| `409` | Conflict -- duplicate ID or unique constraint |
+| `429` | Rate limited -- too many requests |
+
+## Permissions & Roles (Critical)
+
+Appwrite uses permission strings to control access to resources. Each permission pairs an action (`read`, `update`, `delete`, `create`, or `write` which grants create + update + delete) with a role target. By default, no user has access unless permissions are explicitly set at the document/file level or inherited from the collection/bucket settings. Permissions are arrays of strings built with the `Permission` and `Role` helpers.
+
+```dart
+import 'package:appwrite/appwrite.dart';
+// Permission and Role are included in the main package import
+```
+
+### Database Row with Permissions
+
+```dart
+final doc = await tablesDB.createRow(
+    databaseId: '[DATABASE_ID]',
+    tableId: '[TABLE_ID]',
+    rowId: ID.unique(),
+    data: {'title': 'Hello World'},
+    permissions: [
+        Permission.read(Role.user('[USER_ID]')),     // specific user can read
+        Permission.update(Role.user('[USER_ID]')),   // specific user can update
+        Permission.read(Role.team('[TEAM_ID]')),     // all team members can read
+        Permission.read(Role.any()),                 // anyone (including guests) can read
+    ],
+);
+```
+
+### File Upload with Permissions
+
+```dart
+final file = await storage.createFile(
+    bucketId: '[BUCKET_ID]',
+    fileId: ID.unique(),
+    file: InputFile.fromPath(path: '/path/to/file.png', filename: 'file.png'),
+    permissions: [
+        Permission.read(Role.any()),
+        Permission.update(Role.user('[USER_ID]')),
+        Permission.delete(Role.user('[USER_ID]')),
+    ],
+);
+```
+
+> When to set permissions: Set document/file-level permissions when you need per-resource access control. If all documents in a collection share the same rules, configure permissions at the collection/bucket level and leave document permissions empty.
+
+> Common mistakes:
+> - Forgetting permissions -- the resource becomes inaccessible to all users (including the creator)
+> - `Role.any()` with `write`/`update`/`delete` -- allows any user, including unauthenticated guests, to modify or remove the resource
+> - `Permission.read(Role.any())` on sensitive data -- makes the resource publicly readable

--- a/plugins/appwrite/skills/appwrite-deployments/SKILL.md
+++ b/plugins/appwrite/skills/appwrite-deployments/SKILL.md
@@ -38,7 +38,7 @@ For function work:
 
 - Check the `functions` section in `appwrite.config.json`.
 - Verify runtime, entrypoint, install command, timeout, path, events, schedule, and environment variable needs.
-- Run local tests or lint when available.
+- Run local tests or build checks first when available.
 - Prefer a single function push with a specific function ID when possible.
 
 Typical command shape after confirmation:
@@ -47,19 +47,19 @@ Typical command shape after confirmation:
 appwrite push functions --function-id <FUNCTION_ID>
 ```
 
-## Pull Before Push
+Use `--force` only when the user has approved the exact force command.
 
-If the local config may be stale, suggest pulling first:
+## Review Before Deploy
 
-```bash
-appwrite pull functions
-appwrite pull sites
-```
+Before proposing a command, report:
 
-Do not overwrite local changes without checking the git diff.
+- target endpoint and project ID
+- resource type and ID
+- source path and build/runtime settings
+- files changed since the last deployment-related pull
+- any environment variables, secrets, schedules, events, or permissions that may change behavior
 
 ## Secrets
 
-- Keep function environment variables out of source control.
 - Do not commit API keys, webhook secrets, session secrets, or `.env` files.
 - If a deployment needs secrets, confirm they are configured through Appwrite or the deployment environment rather than embedded in code.

--- a/plugins/appwrite/skills/appwrite-deployments/SKILL.md
+++ b/plugins/appwrite/skills/appwrite-deployments/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: appwrite-deployments
+description: Use when preparing or running Appwrite site and function deployment workflows. Requires config review and explicit confirmation before push, deploy, delete, or force operations.
+---
+
+# Appwrite Deployments
+
+Use this skill when the user wants to deploy, update, or inspect Appwrite sites or functions.
+
+## Guardrails
+
+- Never run deployment, push, delete, or force commands automatically.
+- Read `appwrite.config.json` before proposing a deployment command.
+- Summarize the endpoint, project ID, resource type, resource ID, local path, build command, runtime, and output directory before execution.
+- Ask the user to confirm the exact command before running it.
+- Avoid production-impacting commands when the target project or endpoint is unclear.
+
+## Sites
+
+For site work:
+
+- Check the `sites` section in `appwrite.config.json`.
+- Verify framework, build command, output directory, adapter, timeout, and site path.
+- Run the local build or tests first when the repository has a clear script.
+- Prefer a single site push with a specific site ID when possible.
+
+Typical command shape after confirmation:
+
+```bash
+appwrite push sites --site-id <SITE_ID>
+```
+
+Use `--force` only when the user has approved the exact force command.
+
+## Functions
+
+For function work:
+
+- Check the `functions` section in `appwrite.config.json`.
+- Verify runtime, entrypoint, install command, timeout, path, events, schedule, and environment variable needs.
+- Run local tests or lint when available.
+- Prefer a single function push with a specific function ID when possible.
+
+Typical command shape after confirmation:
+
+```bash
+appwrite push functions --function-id <FUNCTION_ID>
+```
+
+## Pull Before Push
+
+If the local config may be stale, suggest pulling first:
+
+```bash
+appwrite pull functions
+appwrite pull sites
+```
+
+Do not overwrite local changes without checking the git diff.
+
+## Secrets
+
+- Keep function environment variables out of source control.
+- Do not commit API keys, webhook secrets, session secrets, or `.env` files.
+- If a deployment needs secrets, confirm they are configured through Appwrite or the deployment environment rather than embedded in code.

--- a/plugins/appwrite/skills/appwrite-dotnet-sdk/SKILL.md
+++ b/plugins/appwrite/skills/appwrite-dotnet-sdk/SKILL.md
@@ -1,0 +1,411 @@
+---
+name: appwrite-dotnet-sdk
+description: Appwrite .NET SDK skill. Use when building server-side C# or .NET applications with Appwrite, including ASP.NET and Blazor integrations. Covers user management, database/table CRUD, file storage, and functions via API keys.
+---
+
+
+# Appwrite .NET SDK
+
+## Cline Safety
+
+- Do not run install, deploy, push, delete, migration, or project mutation commands unless the user asks for that action and confirms the exact target.
+- Keep Appwrite API keys, JWTs, session secrets, endpoint-specific credentials, and .env values out of source control, logs, summaries, and chat unless the user explicitly asks to inspect a redacted form.
+- Prefer least-privilege API keys for server-side examples and keep client-side examples limited to endpoint plus project ID.
+
+
+## Installation
+
+```bash
+dotnet add package Appwrite
+```
+
+## Setting Up the Client
+
+```csharp
+using Appwrite;
+using Appwrite.Services;
+using Appwrite.Models;
+
+var client = new Client()
+    .SetEndpoint("https://<REGION>.cloud.appwrite.io/v1")
+    .SetProject(Environment.GetEnvironmentVariable("APPWRITE_PROJECT_ID"))
+    .SetKey(Environment.GetEnvironmentVariable("APPWRITE_API_KEY"));
+```
+
+## Code Examples
+
+### User Management
+
+```csharp
+var users = new Users(client);
+
+// Create user
+var user = await users.Create(ID.Unique(), "user@example.com", null, "password123", "User Name");
+
+// List users
+var list = await users.List(new List<string> { Query.Limit(25) });
+
+// Get user
+var fetched = await users.Get("[USER_ID]");
+
+// Delete user
+await users.Delete("[USER_ID]");
+```
+
+### Database Operations
+
+> Note: Use `TablesDB` (not the deprecated `Databases` class) for all new code. Only use `Databases` if the existing codebase already relies on it or the user explicitly requests it.
+>
+> Tip: Prefer named arguments (e.g., `databaseId: "..."`) for all SDK method calls. Only use positional arguments if the existing codebase already uses them or the user explicitly requests it.
+
+```csharp
+var tablesDB = new TablesDB(client);
+
+// Create database
+var db = await tablesDB.Create(ID.Unique(), "My Database");
+
+// Create row
+var doc = await tablesDB.CreateRow("[DATABASE_ID]", "[TABLE_ID]", ID.Unique(),
+    new Dictionary<string, object> { { "title", "Hello World" } });
+
+// Query rows
+var results = await tablesDB.ListRows("[DATABASE_ID]", "[TABLE_ID]",
+    new List<string> { Query.Equal("title", "Hello World"), Query.Limit(10) });
+
+// Get row
+var row = await tablesDB.GetRow("[DATABASE_ID]", "[TABLE_ID]", "[ROW_ID]");
+
+// Update row
+await tablesDB.UpdateRow("[DATABASE_ID]", "[TABLE_ID]", "[ROW_ID]",
+    new Dictionary<string, object> { { "title", "Updated" } });
+
+// Delete row
+await tablesDB.DeleteRow("[DATABASE_ID]", "[TABLE_ID]", "[ROW_ID]");
+```
+
+#### String Column Types
+
+> Note: The legacy `string` type is deprecated. Use explicit column types for all new columns.
+
+| Type | Max characters | Indexing | Storage |
+|------|---------------|----------|---------|
+| `varchar` | 16,383 | Full index (if size <= 768) | Inline in row |
+| `text` | 16,383 | Prefix only | Off-page |
+| `mediumtext` | 4,194,303 | Prefix only | Off-page |
+| `longtext` | 1,073,741,823 | Prefix only | Off-page |
+
+- `varchar` is stored inline and counts towards the 64 KB row size limit. Prefer for short, indexed fields like names, slugs, or identifiers.
+- `text`, `mediumtext`, and `longtext` are stored off-page (only a 20-byte pointer lives in the row), so they don't consume the row size budget. `size` is not required for these types.
+
+```csharp
+// Create table with explicit string column types
+await tablesDB.CreateTable("[DATABASE_ID]", ID.Unique(), "articles",
+    new List<object> {
+        new { key = "title",    type = "varchar",    size = 255, required = true  },  // inline, fully indexable
+        new { key = "summary",  type = "text",                   required = false },  // off-page, prefix index only
+        new { key = "body",     type = "mediumtext",             required = false },  // up to ~4 M chars
+        new { key = "raw_data", type = "longtext",               required = false },  // up to ~1 B chars
+    });
+```
+
+### Query Methods
+
+```csharp
+// Filtering
+Query.Equal("field", "value")             // == (or pass array for IN)
+Query.NotEqual("field", "value")          // !=
+Query.LessThan("field", 100)             // <
+Query.LessThanEqual("field", 100)        // <=
+Query.GreaterThan("field", 100)          // >
+Query.GreaterThanEqual("field", 100)     // >=
+Query.Between("field", 1, 100)           // 1 <= field <= 100
+Query.IsNull("field")                    // is null
+Query.IsNotNull("field")                 // is not null
+Query.StartsWith("field", "prefix")      // starts with
+Query.EndsWith("field", "suffix")        // ends with
+Query.Contains("field", "sub")           // contains
+Query.Search("field", "keywords")        // full-text search (requires index)
+
+// Sorting
+Query.OrderAsc("field")
+Query.OrderDesc("field")
+
+// Pagination
+Query.Limit(25)                          // max rows (default 25, max 100)
+Query.Offset(0)                          // skip N rows
+Query.CursorAfter("[ROW_ID]")            // cursor pagination (preferred)
+Query.CursorBefore("[ROW_ID]")
+
+// Selection & Logic
+Query.Select(new List<string> { "field1", "field2" })
+Query.Or(new List<string> { Query.Equal("a", 1), Query.Equal("b", 2) })   // OR
+Query.And(new List<string> { Query.GreaterThan("age", 18), Query.LessThan("age", 65) })  // AND (default)
+```
+
+### File Storage
+
+```csharp
+var storage = new Storage(client);
+
+// Upload file
+var file = await storage.CreateFile("[BUCKET_ID]", ID.Unique(), InputFile.FromPath("/path/to/file.png"));
+
+// List files
+var files = await storage.ListFiles("[BUCKET_ID]");
+
+// Delete file
+await storage.DeleteFile("[BUCKET_ID]", "[FILE_ID]");
+```
+
+#### InputFile Factory Methods
+
+```csharp
+using Appwrite.Models;
+
+InputFile.FromPath("/path/to/file.png")                          // from filesystem path
+InputFile.FromBytes(byteArray, "file.png", "image/png")          // from byte[]
+InputFile.FromStream(stream, "file.png", "image/png", size)      // from Stream (size required)
+```
+
+### Teams
+
+```csharp
+var teams = new Teams(client);
+
+// Create team
+var team = await teams.Create(ID.Unique(), "Engineering");
+
+// List teams
+var list = await teams.List();
+
+// Create membership (invite user by email)
+var membership = await teams.CreateMembership(
+    teamId: "[TEAM_ID]",
+    roles: new List<string> { "editor" },
+    email: "user@example.com"
+);
+
+// List memberships
+var members = await teams.ListMemberships("[TEAM_ID]");
+
+// Update membership roles
+await teams.UpdateMembership("[TEAM_ID]", "[MEMBERSHIP_ID]", new List<string> { "admin" });
+
+// Delete team
+await teams.Delete("[TEAM_ID]");
+```
+
+> Role-based access: Use `Role.Team("[TEAM_ID]")` for all team members or `Role.Team("[TEAM_ID]", "editor")` for a specific team role when setting permissions.
+
+### Serverless Functions
+
+```csharp
+var functions = new Functions(client);
+
+// Execute function
+var execution = await functions.CreateExecution("[FUNCTION_ID]", body: "{\"key\": \"value\"}");
+
+// List executions
+var executions = await functions.ListExecutions("[FUNCTION_ID]");
+```
+
+#### Writing a Function Handler (.NET runtime)
+
+```csharp
+// src/Main.cs -- Appwrite Function entry point
+using System.Text.Json;
+
+public async Task<RuntimeOutput> Main(RuntimeContext context)
+{
+    // context.Req.Body        -- raw body (string)
+    // context.Req.BodyJson    -- parsed JSON (JsonElement)
+    // context.Req.Headers     -- headers (Dictionary)
+    // context.Req.Method      -- HTTP method
+    // context.Req.Path        -- URL path
+    // context.Req.Query       -- query params (Dictionary)
+
+    context.Log($"Processing: {context.Req.Method} {context.Req.Path}");
+
+    if (context.Req.Method == "GET")
+        return context.Res.Json(new { message = "Hello from Appwrite Function!" });
+
+    return context.Res.Json(new { success = true });      // JSON
+    // context.Res.Text("Hello");                         // plain text
+    // context.Res.Empty();                               // 204
+    // context.Res.Redirect("https://...");               // 302
+}
+```
+
+### Server-Side Rendering (SSR) Authentication
+
+SSR apps using .NET frameworks (ASP.NET, Blazor Server, etc.) use the server SDK to handle auth. You need two clients:
+
+- Admin client -- uses an API key, creates sessions, bypasses rate limits (reusable singleton)
+- Session client -- uses a session cookie, acts on behalf of a user (create per-request, never share)
+
+```csharp
+using Appwrite;
+using Appwrite.Services;
+
+// Admin client (reusable)
+var adminClient = new Client()
+    .SetEndpoint("https://<REGION>.cloud.appwrite.io/v1")
+    .SetProject("[PROJECT_ID]")
+    .SetKey(Environment.GetEnvironmentVariable("APPWRITE_API_KEY"));
+
+// Session client (create per-request)
+var sessionClient = new Client()
+    .SetEndpoint("https://<REGION>.cloud.appwrite.io/v1")
+    .SetProject("[PROJECT_ID]");
+
+var session = Request.Cookies["a_session_[PROJECT_ID]"];
+if (session != null)
+{
+    sessionClient.SetSession(session);
+}
+```
+
+#### Email/Password Login (ASP.NET Minimal API)
+
+```csharp
+app.MapPost("/login", async (HttpContext ctx, LoginRequest body) =>
+{
+    var account = new Account(adminClient);
+    var session = await account.CreateEmailPasswordSession(body.Email, body.Password);
+
+    // Cookie name must be a_session_<PROJECT_ID>
+    ctx.Response.Cookies.Append("a_session_[PROJECT_ID]", session.Secret, new CookieOptions
+    {
+        HttpOnly = true,
+        Secure = true,
+        SameSite = SameSiteMode.Strict,
+        Path = "/",
+    });
+
+    return Results.Ok(new { success = true });
+});
+```
+
+#### Authenticated Requests
+
+```csharp
+app.MapGet("/user", async (HttpContext ctx) =>
+{
+    var session = ctx.Request.Cookies["a_session_[PROJECT_ID]"];
+    if (session == null) return Results.Unauthorized();
+
+    var sessionClient = new Client()
+        .SetEndpoint("https://<REGION>.cloud.appwrite.io/v1")
+        .SetProject("[PROJECT_ID]")
+        .SetSession(session);
+
+    var account = new Account(sessionClient);
+    var user = await account.Get();
+    return Results.Ok(user);
+});
+```
+
+#### OAuth2 SSR Flow
+
+```csharp
+// Step 1: Redirect to OAuth provider
+app.MapGet("/oauth", async () =>
+{
+    var account = new Account(adminClient);
+    var redirectUrl = await account.CreateOAuth2Token(
+        provider: OAuthProvider.Github,
+        success: "https://example.com/oauth/success",
+        failure: "https://example.com/oauth/failure"
+    );
+    return Results.Redirect(redirectUrl);
+});
+
+// Step 2: Handle callback -- exchange token for session
+app.MapGet("/oauth/success", async (HttpContext ctx, string userId, string secret) =>
+{
+    var account = new Account(adminClient);
+    var session = await account.CreateSession(userId, secret);
+
+    ctx.Response.Cookies.Append("a_session_[PROJECT_ID]", session.Secret, new CookieOptions
+    {
+        HttpOnly = true, Secure = true, SameSite = SameSiteMode.Strict, Path = "/",
+    });
+
+    return Results.Ok(new { success = true });
+});
+```
+
+> Cookie security: Always use `HttpOnly`, `Secure`, and `SameSite = SameSiteMode.Strict` to prevent XSS. The cookie name must be `a_session_<PROJECT_ID>`.
+
+> Forwarding user agent: Call `sessionClient.SetForwardedUserAgent(ctx.Request.Headers["User-Agent"])` to record the end-user's browser info for debugging and security.
+
+## Error Handling
+
+```csharp
+using Appwrite;
+
+try
+{
+    var row = await tablesDB.GetRow("[DATABASE_ID]", "[TABLE_ID]", "[ROW_ID]");
+}
+catch (AppwriteException e)
+{
+    Console.WriteLine(e.Message);    // human-readable message
+    Console.WriteLine(e.Code);       // HTTP status code (int)
+    Console.WriteLine(e.Type);       // error type (e.g. "document_not_found")
+    Console.WriteLine(e.Response);   // full response body
+}
+```
+
+Common error codes:
+
+| Code | Meaning |
+|------|---------|
+| `401` | Unauthorized -- missing or invalid session/API key |
+| `403` | Forbidden -- insufficient permissions |
+| `404` | Not found -- resource does not exist |
+| `409` | Conflict -- duplicate ID or unique constraint |
+| `429` | Rate limited -- too many requests |
+
+## Permissions & Roles (Critical)
+
+Appwrite uses permission strings to control access to resources. Each permission pairs an action (`read`, `update`, `delete`, `create`, or `write` which grants create + update + delete) with a role target. By default, no user has access unless permissions are explicitly set at the document/file level or inherited from the collection/bucket settings. Permissions are arrays of strings built with the `Permission` and `Role` helpers.
+
+```csharp
+using Appwrite;
+// Permission and Role are included in the main namespace
+```
+
+### Database Row with Permissions
+
+```csharp
+var doc = await tablesDB.CreateRow("[DATABASE_ID]", "[TABLE_ID]", ID.Unique(),
+    new Dictionary<string, object> { { "title", "Hello World" } },
+    new List<string>
+    {
+        Permission.Read(Role.User("[USER_ID]")),     // specific user can read
+        Permission.Update(Role.User("[USER_ID]")),   // specific user can update
+        Permission.Read(Role.Team("[TEAM_ID]")),     // all team members can read
+        Permission.Read(Role.Any()),                 // anyone (including guests) can read
+    });
+```
+
+### File Upload with Permissions
+
+```csharp
+var file = await storage.CreateFile("[BUCKET_ID]", ID.Unique(),
+    InputFile.FromPath("/path/to/file.png"),
+    new List<string>
+    {
+        Permission.Read(Role.Any()),
+        Permission.Update(Role.User("[USER_ID]")),
+        Permission.Delete(Role.User("[USER_ID]")),
+    });
+```
+
+> When to set permissions: Set document/file-level permissions when you need per-resource access control. If all documents in a collection share the same rules, configure permissions at the collection/bucket level and leave document permissions empty.
+
+> Common mistakes:
+> - Forgetting permissions -- the resource becomes inaccessible to all users (including the creator)
+> - `Role.Any()` with `write`/`update`/`delete` -- allows any user, including unauthenticated guests, to modify or remove the resource
+> - `Permission.Read(Role.Any())` on sensitive data -- makes the resource publicly readable

--- a/plugins/appwrite/skills/appwrite-go-sdk/SKILL.md
+++ b/plugins/appwrite/skills/appwrite-go-sdk/SKILL.md
@@ -1,0 +1,474 @@
+---
+name: appwrite-go-sdk
+description: Appwrite Go SDK skill. Use when building server-side Go applications with Appwrite. Covers user management, database/table CRUD, file storage, and functions via API keys.
+---
+
+
+# Appwrite Go SDK
+
+## Cline Safety
+
+- Do not run install, deploy, push, delete, migration, or project mutation commands unless the user asks for that action and confirms the exact target.
+- Keep Appwrite API keys, JWTs, session secrets, endpoint-specific credentials, and .env values out of source control, logs, summaries, and chat unless the user explicitly asks to inspect a redacted form.
+- Prefer least-privilege API keys for server-side examples and keep client-side examples limited to endpoint plus project ID.
+
+
+## Installation
+
+```bash
+go get github.com/appwrite/sdk-for-go
+```
+
+## Setting Up the Client
+
+```go
+import (
+    "os"
+
+    "github.com/appwrite/sdk-for-go/client"
+    "github.com/appwrite/sdk-for-go/id"
+    "github.com/appwrite/sdk-for-go/users"
+    "github.com/appwrite/sdk-for-go/tablesdb"
+    "github.com/appwrite/sdk-for-go/storage"
+)
+
+clt := client.New(
+    client.WithEndpoint("https://<REGION>.cloud.appwrite.io/v1"),
+    client.WithProject(os.Getenv("APPWRITE_PROJECT_ID")),
+    client.WithKey(os.Getenv("APPWRITE_API_KEY")),
+)
+```
+
+## Code Examples
+
+### User Management
+
+```go
+service := users.New(clt)
+
+// Create user
+user, err := service.Create(
+    id.Unique(),
+    "user@example.com",
+    "password123",
+    users.WithCreateName("User Name"),
+)
+
+// List users
+list, err := service.List()
+
+// Get user
+fetched, err := service.Get("[USER_ID]")
+
+// Delete user
+_, err = service.Delete("[USER_ID]")
+```
+
+### Database Operations
+
+> Note: Use `TablesDB` (not the deprecated `Databases` class) for all new code. Only use `Databases` if the existing codebase already relies on it or the user explicitly requests it.
+>
+> Tip: Prefer explicit functional option parameters (e.g., `tablesdb.WithUpdateRowData(...)`) over bare positional arguments where available. Only use positional-only style if the existing codebase already uses it or the user explicitly requests it.
+
+```go
+service := tablesdb.New(clt)
+
+// Create database
+db, err := service.Create(id.Unique(), "My Database")
+
+// Create row
+doc, err := service.CreateRow(
+    "[DATABASE_ID]",
+    "[TABLE_ID]",
+    id.Unique(),
+    map[string]interface{}{"title": "Hello World"},
+)
+
+// List rows
+results, err := service.ListRows("[DATABASE_ID]", "[TABLE_ID]")
+
+// Get row
+row, err := service.GetRow("[DATABASE_ID]", "[TABLE_ID]", "[ROW_ID]")
+
+// Update row
+_, err = service.UpdateRow(
+    "[DATABASE_ID]",
+    "[TABLE_ID]",
+    "[ROW_ID]",
+    tablesdb.WithUpdateRowData(map[string]interface{}{"title": "Updated"}),
+)
+
+// Delete row
+_, err = service.DeleteRow("[DATABASE_ID]", "[TABLE_ID]", "[ROW_ID]")
+```
+
+#### String Column Types
+
+> Note: The legacy `string` type is deprecated. Use explicit column types for all new columns.
+
+| Type | Max characters | Indexing | Storage |
+|------|---------------|----------|---------|
+| `varchar` | 16,383 | Full index (if size <= 768) | Inline in row |
+| `text` | 16,383 | Prefix only | Off-page |
+| `mediumtext` | 4,194,303 | Prefix only | Off-page |
+| `longtext` | 1,073,741,823 | Prefix only | Off-page |
+
+- `varchar` is stored inline and counts towards the 64 KB row size limit. Prefer for short, indexed fields like names, slugs, or identifiers.
+- `text`, `mediumtext`, and `longtext` are stored off-page (only a 20-byte pointer lives in the row), so they don't consume the row size budget. `size` is not required for these types.
+
+```go
+// Create table with explicit string column types
+_, err = service.CreateTable(
+    "[DATABASE_ID]",
+    id.Unique(),
+    "articles",
+    tablesdb.WithCreateTableColumns([]map[string]interface{}{
+        {"key": "title",    "type": "varchar",    "size": 255, "required": true},
+        {"key": "summary",  "type": "text",                    "required": false},
+        {"key": "body",     "type": "mediumtext",              "required": false},
+        {"key": "raw_data", "type": "longtext",                "required": false},
+    }),
+)
+```
+
+### Query Methods
+
+```go
+import "github.com/appwrite/sdk-for-go/query"
+
+// Filtering
+query.Equal("field", "value")             // == (or pass slice for IN)
+query.NotEqual("field", "value")          // !=
+query.LessThan("field", 100)             // <
+query.LessThanEqual("field", 100)        // <=
+query.GreaterThan("field", 100)          // >
+query.GreaterThanEqual("field", 100)     // >=
+query.Between("field", 1, 100)           // 1 <= field <= 100
+query.IsNull("field")                    // is null
+query.IsNotNull("field")                 // is not null
+query.StartsWith("field", "prefix")      // starts with
+query.EndsWith("field", "suffix")        // ends with
+query.Contains("field", "sub")           // contains
+query.Search("field", "keywords")        // full-text search (requires index)
+
+// Sorting
+query.OrderAsc("field")
+query.OrderDesc("field")
+
+// Pagination
+query.Limit(25)                          // max rows (default 25, max 100)
+query.Offset(0)                          // skip N rows
+query.CursorAfter("[ROW_ID]")            // cursor pagination (preferred)
+query.CursorBefore("[ROW_ID]")
+
+// Selection & Logic
+query.Select([]string{"field1", "field2"})
+query.Or([]string{query.Equal("a", 1), query.Equal("b", 2)})    // OR
+query.And([]string{query.GreaterThan("age", 18), query.LessThan("age", 65)})  // AND (default)
+```
+
+### File Storage
+
+```go
+import "github.com/appwrite/sdk-for-go/file"
+
+service := storage.New(clt)
+
+// Upload file
+f, err := service.CreateFile(
+    "[BUCKET_ID]",
+    "[FILE_ID]",
+    file.NewInputFile("/path/to/file.png", "file.png"),
+)
+
+// List files
+files, err := service.ListFiles("[BUCKET_ID]")
+
+// Delete file
+_, err = service.DeleteFile("[BUCKET_ID]", "[FILE_ID]")
+```
+
+#### InputFile Factory Methods
+
+```go
+import "github.com/appwrite/sdk-for-go/file"
+
+file.NewInputFile("/path/to/file.png", "file.png")          // from filesystem path
+file.NewInputFileFromReader(reader, "file.png", size)        // from io.Reader (size required)
+file.NewInputFileFromBytes(data, "file.png")                 // from []byte
+```
+
+### Teams
+
+```go
+import "github.com/appwrite/sdk-for-go/teams"
+
+svc := teams.New(clt)
+
+// Create team
+team, err := svc.Create(id.Unique(), "Engineering")
+
+// List teams
+list, err := svc.List()
+
+// Create membership (invite user by email)
+membership, err := svc.CreateMembership(
+    "[TEAM_ID]",
+    []string{"editor"},
+    teams.WithCreateMembershipEmail("user@example.com"),
+)
+
+// List memberships
+members, err := svc.ListMemberships("[TEAM_ID]")
+
+// Update membership roles
+_, err = svc.UpdateMembership("[TEAM_ID]", "[MEMBERSHIP_ID]", []string{"admin"})
+
+// Delete team
+_, err = svc.Delete("[TEAM_ID]")
+```
+
+> Role-based access: Use `role.Team("[TEAM_ID]")` for all team members or `role.Team("[TEAM_ID]", "editor")` for a specific team role when setting permissions.
+
+### Serverless Functions
+
+```go
+import "github.com/appwrite/sdk-for-go/functions"
+
+svc := functions.New(clt)
+
+// Execute function
+execution, err := svc.CreateExecution(
+    "[FUNCTION_ID]",
+    functions.WithCreateExecutionBody(`{"key": "value"}`),
+)
+
+// List executions
+executions, err := svc.ListExecutions("[FUNCTION_ID]")
+```
+
+#### Writing a Function Handler (Go runtime)
+
+```go
+// src/main.go -- Appwrite Function entry point
+package handler
+
+import (
+    "github.com/open-runtimes/types-for-go/v4/openruntimes"
+)
+
+func Main(context openruntimes.Context) openruntimes.Response {
+    // context.Req.Body        -- raw body (string)
+    // context.Req.BodyJson    -- parsed JSON (map[string]interface{})
+    // context.Req.Headers     -- headers (map[string]string)
+    // context.Req.Method      -- HTTP method
+    // context.Req.Path        -- URL path
+    // context.Req.Query       -- query params (map[string]string)
+
+    context.Log("Processing: " + context.Req.Method + " " + context.Req.Path)
+
+    if context.Req.Method == "GET" {
+        return context.Res.Json(map[string]interface{}{"message": "Hello!"})
+    }
+
+    return context.Res.Json(map[string]interface{}{"success": true})
+    // context.Res.Text("Hello")                  // plain text
+    // context.Res.Empty()                         // 204
+    // context.Res.Redirect("https://...")          // 302
+}
+```
+
+### Server-Side Rendering (SSR) Authentication
+
+SSR apps using Go frameworks (net/http, Gin, Echo, Chi, etc.) use the server SDK to handle auth. You need two clients:
+
+- Admin client -- uses an API key, creates sessions, bypasses rate limits (reusable singleton)
+- Session client -- uses a session cookie, acts on behalf of a user (create per-request, never share)
+
+```go
+import (
+    "github.com/appwrite/sdk-for-go/client"
+    "github.com/appwrite/sdk-for-go/account"
+)
+
+// Admin client (reusable)
+adminClient := client.New(
+    client.WithEndpoint("https://<REGION>.cloud.appwrite.io/v1"),
+    client.WithProject(os.Getenv("APPWRITE_PROJECT_ID")),
+    client.WithKey(os.Getenv("APPWRITE_API_KEY")),
+)
+
+// Session client (create per-request)
+sessionClient := client.New(
+    client.WithEndpoint("https://<REGION>.cloud.appwrite.io/v1"),
+    client.WithProject(os.Getenv("APPWRITE_PROJECT_ID")),
+)
+
+cookie, err := r.Cookie("a_session_[PROJECT_ID]")
+if err == nil {
+    sessionClient.SetSession(cookie.Value)
+}
+```
+
+#### Email/Password Login
+
+```go
+http.HandleFunc("/login", func(w http.ResponseWriter, r *http.Request) {
+    svc := account.New(adminClient)
+    session, err := svc.CreateEmailPasswordSession(r.FormValue("email"), r.FormValue("password"))
+    if err != nil {
+        http.Error(w, err.Error(), http.StatusBadRequest)
+        return
+    }
+
+    // Cookie name must be a_session_<PROJECT_ID>
+    http.SetCookie(w, &http.Cookie{
+        Name:     "a_session_[PROJECT_ID]",
+        Value:    session.Secret,
+        HttpOnly: true,
+        Secure:   true,
+        SameSite: http.SameSiteStrictMode,
+        Path:     "/",
+    })
+
+    w.Header().Set("Content-Type", "application/json")
+    w.Write([]byte(`{"success": true}`))
+})
+```
+
+#### Authenticated Requests
+
+```go
+http.HandleFunc("/user", func(w http.ResponseWriter, r *http.Request) {
+    cookie, err := r.Cookie("a_session_[PROJECT_ID]")
+    if err != nil {
+        http.Error(w, "Unauthorized", http.StatusUnauthorized)
+        return
+    }
+
+    sessionClient := client.New(
+        client.WithEndpoint("https://<REGION>.cloud.appwrite.io/v1"),
+        client.WithProject(os.Getenv("APPWRITE_PROJECT_ID")),
+        client.WithSession(cookie.Value),
+    )
+
+    svc := account.New(sessionClient)
+    user, err := svc.Get()
+    // Marshal user to JSON and write response
+})
+```
+
+#### OAuth2 SSR Flow
+
+```go
+// Step 1: Redirect to OAuth provider
+http.HandleFunc("/oauth", func(w http.ResponseWriter, r *http.Request) {
+    svc := account.New(adminClient)
+    redirectURL, err := svc.CreateOAuth2Token(
+        "github",
+        account.WithCreateOAuth2TokenSuccess("https://example.com/oauth/success"),
+        account.WithCreateOAuth2TokenFailure("https://example.com/oauth/failure"),
+    )
+    if err != nil {
+        http.Error(w, err.Error(), http.StatusInternalServerError)
+        return
+    }
+    http.Redirect(w, r, redirectURL, http.StatusFound)
+})
+
+// Step 2: Handle callback -- exchange token for session
+http.HandleFunc("/oauth/success", func(w http.ResponseWriter, r *http.Request) {
+    svc := account.New(adminClient)
+    session, err := svc.CreateSession(r.URL.Query().Get("userId"), r.URL.Query().Get("secret"))
+    if err != nil {
+        http.Error(w, err.Error(), http.StatusBadRequest)
+        return
+    }
+
+    http.SetCookie(w, &http.Cookie{
+        Name: "a_session_[PROJECT_ID]", Value: session.Secret,
+        HttpOnly: true, Secure: true, SameSite: http.SameSiteStrictMode, Path: "/",
+    })
+    w.Write([]byte(`{"success": true}`))
+})
+```
+
+> Cookie security: Always use `HttpOnly`, `Secure`, and `SameSiteStrictMode` to prevent XSS. The cookie name must be `a_session_<PROJECT_ID>`.
+
+> Forwarding user agent: Call `sessionClient.SetForwardedUserAgent(r.Header.Get("User-Agent"))` to record the end-user's browser info for debugging and security.
+
+## Error Handling
+
+```go
+import "github.com/appwrite/sdk-for-go/apperr"
+
+doc, err := service.GetRow("[DATABASE_ID]", "[TABLE_ID]", "[ROW_ID]")
+if err != nil {
+    var appErr *apperr.AppwriteException
+    if errors.As(err, &appErr) {
+        fmt.Println(appErr.Message)    // human-readable message
+        fmt.Println(appErr.Code)       // HTTP status code (int)
+        fmt.Println(appErr.Type)       // error type (e.g. "document_not_found")
+    }
+}
+```
+
+Common error codes:
+
+| Code | Meaning |
+|------|---------|
+| `401` | Unauthorized -- missing or invalid session/API key |
+| `403` | Forbidden -- insufficient permissions |
+| `404` | Not found -- resource does not exist |
+| `409` | Conflict -- duplicate ID or unique constraint |
+| `429` | Rate limited -- too many requests |
+
+## Permissions & Roles (Critical)
+
+Appwrite uses permission strings to control access to resources. Each permission pairs an action (`read`, `update`, `delete`, `create`, or `write` which grants create + update + delete) with a role target. By default, no user has access unless permissions are explicitly set at the document/file level or inherited from the collection/bucket settings. Permissions are arrays of strings built with the `permission` and `role` helpers.
+
+```go
+import (
+    "github.com/appwrite/sdk-for-go/permission"
+    "github.com/appwrite/sdk-for-go/role"
+)
+```
+
+### Database Row with Permissions
+
+```go
+doc, err := service.CreateRow(
+    "[DATABASE_ID]",
+    "[TABLE_ID]",
+    "[ROW_ID]",
+    map[string]interface{}{"title": "Hello World"},
+    tablesdb.WithCreateRowPermissions([]string{
+        permission.Read(role.User("[USER_ID]")),     // specific user can read
+        permission.Update(role.User("[USER_ID]")),   // specific user can update
+        permission.Read(role.Team("[TEAM_ID]")),     // all team members can read
+        permission.Read(role.Any()),                 // anyone (including guests) can read
+    }),
+)
+```
+
+### File Upload with Permissions
+
+```go
+f, err := service.CreateFile(
+    "[BUCKET_ID]",
+    "[FILE_ID]",
+    file.NewInputFile("/path/to/file.png", "file.png"),
+    storage.WithCreateFilePermissions([]string{
+        permission.Read(role.Any()),
+        permission.Update(role.User("[USER_ID]")),
+        permission.Delete(role.User("[USER_ID]")),
+    }),
+)
+```
+
+> When to set permissions: Set document/file-level permissions when you need per-resource access control. If all documents in a collection share the same rules, configure permissions at the collection/bucket level and leave document permissions empty.
+
+> Common mistakes:
+> - Forgetting permissions -- the resource becomes inaccessible to all users (including the creator)
+> - `role.Any()` with `write`/`update`/`delete` -- allows any user, including unauthenticated guests, to modify or remove the resource
+> - `permission.Read(role.Any())` on sensitive data -- makes the resource publicly readable

--- a/plugins/appwrite/skills/appwrite-kotlin-sdk/SKILL.md
+++ b/plugins/appwrite/skills/appwrite-kotlin-sdk/SKILL.md
@@ -1,0 +1,553 @@
+---
+name: appwrite-kotlin-sdk
+description: Appwrite Kotlin SDK skill. Use when building native Android apps or server-side Kotlin/JVM backends with Appwrite. Covers auth, database queries, uploads, realtime, and server-side admin via API keys.
+---
+
+
+# Appwrite Kotlin SDK
+
+## Cline Safety
+
+- Do not run install, deploy, push, delete, migration, or project mutation commands unless the user asks for that action and confirms the exact target.
+- Keep Appwrite API keys, JWTs, session secrets, endpoint-specific credentials, and .env values out of source control, logs, summaries, and chat unless the user explicitly asks to inspect a redacted form.
+- Prefer least-privilege API keys for server-side examples and keep client-side examples limited to endpoint plus project ID.
+
+
+## Installation
+
+```kotlin
+// build.gradle.kts -- Android
+implementation("io.appwrite:sdk-for-android:+")
+
+// build.gradle.kts -- Server (Kotlin JVM)
+implementation("io.appwrite:sdk-for-kotlin:+")
+```
+
+## Setting Up the Client
+
+### Client-side (Android)
+
+```kotlin
+import io.appwrite.Client
+import io.appwrite.ID
+import io.appwrite.Query
+import io.appwrite.enums.OAuthProvider
+import io.appwrite.services.Account
+import io.appwrite.services.Realtime
+import io.appwrite.services.TablesDB
+import io.appwrite.services.Storage
+import io.appwrite.models.InputFile
+
+val client = Client(context)
+    .setEndpoint("https://<REGION>.cloud.appwrite.io/v1")
+    .setProject("[PROJECT_ID]")
+```
+
+### Server-side (Kotlin JVM)
+
+```kotlin
+import io.appwrite.Client
+import io.appwrite.ID
+import io.appwrite.Query
+import io.appwrite.services.Users
+import io.appwrite.services.TablesDB
+import io.appwrite.services.Storage
+import io.appwrite.services.Functions
+
+val client = Client()
+    .setEndpoint("https://<REGION>.cloud.appwrite.io/v1")
+    .setProject(System.getenv("APPWRITE_PROJECT_ID"))
+    .setKey(System.getenv("APPWRITE_API_KEY"))
+```
+
+## Code Examples
+
+### Authentication (client-side)
+
+```kotlin
+val account = Account(client)
+
+// Signup
+account.create(
+    userId = ID.unique(),
+    email = "user@example.com",
+    password = "password123",
+    name = "User Name"
+)
+
+// Login
+val session = account.createEmailPasswordSession(
+    email = "user@example.com",
+    password = "password123"
+)
+
+// OAuth
+account.createOAuth2Session(activity = activity, provider = OAuthProvider.GOOGLE)
+
+// Get current user
+val user = account.get()
+
+// Logout
+account.deleteSession(sessionId = "current")
+```
+
+### User Management (server-side)
+
+```kotlin
+val users = Users(client)
+
+// Create user
+val user = users.create(
+    userId = ID.unique(),
+    email = "user@example.com",
+    password = "password123",
+    name = "User Name"
+)
+
+// List users
+val list = users.list()
+
+// Get user
+val fetched = users.get(userId = "[USER_ID]")
+
+// Delete user
+users.delete(userId = "[USER_ID]")
+```
+
+### Database Operations
+
+> Note: Use `TablesDB` (not the deprecated `Databases` class) for all new code. Only use `Databases` if the existing codebase already relies on it or the user explicitly requests it.
+>
+> Tip: Prefer named arguments (e.g., `databaseId = "..."`) for all SDK method calls. Only use positional arguments if the existing codebase already uses them or the user explicitly requests it.
+
+```kotlin
+val tablesDB = TablesDB(client)
+
+// Create database (server-side only)
+val db = tablesDB.create(databaseId = ID.unique(), name = "My Database")
+
+// Create row
+val doc = tablesDB.createRow(
+    databaseId = "[DATABASE_ID]",
+    tableId = "[TABLE_ID]",
+    rowId = ID.unique(),
+    data = mapOf("title" to "Hello", "done" to false)
+)
+
+// Query rows
+val results = tablesDB.listRows(
+    databaseId = "[DATABASE_ID]",
+    tableId = "[TABLE_ID]",
+    queries = listOf(Query.equal("done", false), Query.limit(10))
+)
+
+// Get row
+val row = tablesDB.getRow(databaseId = "[DATABASE_ID]", tableId = "[TABLE_ID]", rowId = "[ROW_ID]")
+
+// Update row
+tablesDB.updateRow(
+    databaseId = "[DATABASE_ID]",
+    tableId = "[TABLE_ID]",
+    rowId = "[ROW_ID]",
+    data = mapOf("done" to true)
+)
+
+// Delete row
+tablesDB.deleteRow(
+    databaseId = "[DATABASE_ID]",
+    tableId = "[TABLE_ID]",
+    rowId = "[ROW_ID]"
+)
+```
+
+#### String Column Types
+
+> Note: The legacy `string` type is deprecated. Use explicit column types for all new columns.
+
+| Type | Max characters | Indexing | Storage |
+|------|---------------|----------|---------|
+| `varchar` | 16,383 | Full index (if size <= 768) | Inline in row |
+| `text` | 16,383 | Prefix only | Off-page |
+| `mediumtext` | 4,194,303 | Prefix only | Off-page |
+| `longtext` | 1,073,741,823 | Prefix only | Off-page |
+
+- `varchar` is stored inline and counts towards the 64 KB row size limit. Prefer for short, indexed fields like names, slugs, or identifiers.
+- `text`, `mediumtext`, and `longtext` are stored off-page (only a 20-byte pointer lives in the row), so they don't consume the row size budget. `size` is not required for these types.
+
+```kotlin
+// Create table with explicit string column types
+tablesDB.createTable(
+    databaseId = "[DATABASE_ID]",
+    tableId = ID.unique(),
+    name = "articles",
+    columns = listOf(
+        mapOf("key" to "title",    "type" to "varchar",    "size" to 255, "required" to true),
+        mapOf("key" to "summary",  "type" to "text",                      "required" to false),
+        mapOf("key" to "body",     "type" to "mediumtext",                "required" to false),
+        mapOf("key" to "raw_data", "type" to "longtext",                  "required" to false),
+    )
+)
+```
+
+### Query Methods
+
+```kotlin
+// Filtering
+Query.equal("field", "value")             // == (or pass list for IN)
+Query.notEqual("field", "value")          // !=
+Query.lessThan("field", 100)              // <
+Query.lessThanEqual("field", 100)         // <=
+Query.greaterThan("field", 100)           // >
+Query.greaterThanEqual("field", 100)      // >=
+Query.between("field", 1, 100)            // 1 <= field <= 100
+Query.isNull("field")                     // is null
+Query.isNotNull("field")                  // is not null
+Query.startsWith("field", "prefix")       // starts with
+Query.endsWith("field", "suffix")         // ends with
+Query.contains("field", "sub")            // contains
+Query.search("field", "keywords")         // full-text search (requires index)
+
+// Sorting
+Query.orderAsc("field")
+Query.orderDesc("field")
+
+// Pagination
+Query.limit(25)                           // max rows (default 25, max 100)
+Query.offset(0)                           // skip N rows
+Query.cursorAfter("[ROW_ID]")             // cursor pagination (preferred)
+Query.cursorBefore("[ROW_ID]")
+
+// Selection & Logic
+Query.select(listOf("field1", "field2"))
+Query.or(listOf(Query.equal("a", 1), Query.equal("b", 2)))   // OR
+Query.and(listOf(Query.greaterThan("age", 18), Query.lessThan("age", 65)))  // AND (default)
+```
+
+### File Storage
+
+```kotlin
+val storage = Storage(client)
+
+// Upload file
+val file = storage.createFile(
+    bucketId = "[BUCKET_ID]",
+    fileId = ID.unique(),
+    file = InputFile.fromPath("/path/to/file.png")
+)
+
+// Get file preview
+val preview = storage.getFilePreview(
+    bucketId = "[BUCKET_ID]",
+    fileId = "[FILE_ID]",
+    width = 300,
+    height = 300
+)
+
+// List files
+val files = storage.listFiles(bucketId = "[BUCKET_ID]")
+
+// Delete file
+storage.deleteFile(bucketId = "[BUCKET_ID]", fileId = "[FILE_ID]")
+```
+
+#### InputFile Factory Methods
+
+```kotlin
+import io.appwrite.models.InputFile
+
+InputFile.fromPath("/path/to/file.png")              // from filesystem path
+InputFile.fromBytes(byteArray, "file.png")           // from ByteArray
+```
+
+### Teams
+
+```kotlin
+val teams = Teams(client)
+
+// Create team
+val team = teams.create(teamId = ID.unique(), name = "Engineering")
+
+// List teams
+val list = teams.list()
+
+// Create membership (invite user by email)
+val membership = teams.createMembership(
+    teamId = "[TEAM_ID]",
+    roles = listOf("editor"),
+    email = "user@example.com"
+)
+
+// List memberships
+val members = teams.listMemberships(teamId = "[TEAM_ID]")
+
+// Update membership roles
+teams.updateMembership(teamId = "[TEAM_ID]", membershipId = "[MEMBERSHIP_ID]", roles = listOf("admin"))
+
+// Delete team
+teams.delete(teamId = "[TEAM_ID]")
+```
+
+> Role-based access: Use `Role.team("[TEAM_ID]")` for all team members or `Role.team("[TEAM_ID]", "editor")` for a specific team role when setting permissions.
+
+### Real-time Subscriptions (client-side)
+
+```kotlin
+import io.appwrite.Channel
+
+val realtime = Realtime(client)
+
+// Subscribe to row changes
+val subscription = realtime.subscribe(
+    Channel.tablesdb("[DATABASE_ID]").table("[TABLE_ID]").row()
+) { response ->
+    println(response.events)   // e.g. ["tablesdb.*.tables.*.rows.*.create"]
+    println(response.payload)  // the affected resource
+}
+
+// Subscribe to multiple channels
+val multi = realtime.subscribe(
+    Channel.tablesdb("[DATABASE_ID]").table("[TABLE_ID]").row(),
+    Channel.bucket("[BUCKET_ID]").file()
+) { response -> /* ... */ }
+
+// Cleanup
+subscription.close()
+```
+
+Available channels:
+
+| Channel | Description |
+|---------|-------------|
+| `account` | Changes to the authenticated user's account |
+| `tablesdb.[DB_ID].tables.[TABLE_ID].rows` | All rows in a table |
+| `tablesdb.[DB_ID].tables.[TABLE_ID].rows.[ROW_ID]` | A specific row |
+| `buckets.[BUCKET_ID].files` | All files in a bucket |
+| `buckets.[BUCKET_ID].files.[FILE_ID]` | A specific file |
+| `teams` | Changes to teams the user belongs to |
+| `teams.[TEAM_ID]` | A specific team |
+| `memberships` | The user's team memberships |
+| `functions.[FUNCTION_ID].executions` | Function execution updates |
+
+Response fields: `events` (array), `payload` (resource), `channels` (matched), `timestamp` (ISO 8601).
+
+### Serverless Functions (server-side)
+
+```kotlin
+val functions = Functions(client)
+
+// Execute function
+val execution = functions.createExecution(
+    functionId = "[FUNCTION_ID]",
+    body = """{"key": "value"}"""
+)
+
+// List executions
+val executions = functions.listExecutions(functionId = "[FUNCTION_ID]")
+```
+
+#### Writing a Function Handler (Kotlin runtime)
+
+```kotlin
+// src/Main.kt -- Appwrite Function entry point
+import io.openruntimes.kotlin.RuntimeContext
+import io.openruntimes.kotlin.RuntimeOutput
+
+fun main(context: RuntimeContext): RuntimeOutput {
+    // context.req.body        -- raw body (String)
+    // context.req.bodyJson    -- parsed JSON (Map)
+    // context.req.headers     -- headers (Map)
+    // context.req.method      -- HTTP method
+    // context.req.path        -- URL path
+    // context.req.query       -- query params (Map)
+
+    context.log("Processing: ${context.req.method} ${context.req.path}")
+
+    if (context.req.method == "GET") {
+        return context.res.json(mapOf("message" to "Hello from Appwrite Function!"))
+    }
+
+    return context.res.json(mapOf("success" to true))    // JSON
+    // context.res.text("Hello")                          // plain text
+    // context.res.empty()                                // 204
+    // context.res.redirect("https://...")                 // 302
+}
+```
+
+### Server-Side Rendering (SSR) Authentication
+
+SSR apps using Kotlin server frameworks (Ktor, Spring Boot, etc.) use the server SDK to handle auth. You need two clients:
+
+- Admin client -- uses an API key, creates sessions, bypasses rate limits (reusable singleton)
+- Session client -- uses a session cookie, acts on behalf of a user (create per-request, never share)
+
+```kotlin
+import io.appwrite.Client
+import io.appwrite.services.Account
+import io.appwrite.enums.OAuthProvider
+
+// Admin client (reusable)
+val adminClient = Client()
+    .setEndpoint("https://<REGION>.cloud.appwrite.io/v1")
+    .setProject("[PROJECT_ID]")
+    .setKey(System.getenv("APPWRITE_API_KEY"))
+
+// Session client (create per-request)
+val sessionClient = Client()
+    .setEndpoint("https://<REGION>.cloud.appwrite.io/v1")
+    .setProject("[PROJECT_ID]")
+
+val session = call.request.cookies["a_session_[PROJECT_ID]"]
+if (session != null) {
+    sessionClient.setSession(session)
+}
+```
+
+#### Email/Password Login (Ktor)
+
+```kotlin
+post("/login") {
+    val body = call.receive<LoginRequest>()
+    val account = Account(adminClient)
+    val session = account.createEmailPasswordSession(
+        email = body.email,
+        password = body.password,
+    )
+
+    // Cookie name must be a_session_<PROJECT_ID>
+    call.response.cookies.append(Cookie(
+        name = "a_session_[PROJECT_ID]",
+        value = session.secret,
+        httpOnly = true,
+        secure = true,
+        extensions = mapOf("SameSite" to "Strict"),
+        path = "/",
+    ))
+    call.respond(mapOf("success" to true))
+}
+```
+
+#### Authenticated Requests
+
+```kotlin
+get("/user") {
+    val session = call.request.cookies["a_session_[PROJECT_ID]"]
+        ?: return@get call.respond(HttpStatusCode.Unauthorized)
+
+    val sessionClient = Client()
+        .setEndpoint("https://<REGION>.cloud.appwrite.io/v1")
+        .setProject("[PROJECT_ID]")
+        .setSession(session)
+
+    val account = Account(sessionClient)
+    val user = account.get()
+    call.respond(user)
+}
+```
+
+#### OAuth2 SSR Flow
+
+```kotlin
+// Step 1: Redirect to OAuth provider
+get("/oauth") {
+    val account = Account(adminClient)
+    val redirectUrl = account.createOAuth2Token(
+        provider = OAuthProvider.GITHUB,
+        success = "https://example.com/oauth/success",
+        failure = "https://example.com/oauth/failure",
+    )
+    call.respondRedirect(redirectUrl)
+}
+
+// Step 2: Handle callback -- exchange token for session
+get("/oauth/success") {
+    val account = Account(adminClient)
+    val session = account.createSession(
+        userId = call.parameters["userId"]!!,
+        secret = call.parameters["secret"]!!,
+    )
+
+    call.response.cookies.append(Cookie(
+        name = "a_session_[PROJECT_ID]", value = session.secret,
+        httpOnly = true, secure = true,
+        extensions = mapOf("SameSite" to "Strict"), path = "/",
+    ))
+    call.respond(mapOf("success" to true))
+}
+```
+
+> Cookie security: Always use `httpOnly`, `secure`, and `SameSite=Strict` to prevent XSS. The cookie name must be `a_session_<PROJECT_ID>`.
+
+> Forwarding user agent: Call `sessionClient.setForwardedUserAgent(call.request.headers["User-Agent"])` to record the end-user's browser info for debugging and security.
+
+## Error Handling
+
+```kotlin
+import io.appwrite.AppwriteException
+
+try {
+    val row = tablesDB.getRow(databaseId = "[DATABASE_ID]", tableId = "[TABLE_ID]", rowId = "[ROW_ID]")
+} catch (e: AppwriteException) {
+    println(e.message)     // human-readable message
+    println(e.code)        // HTTP status code (Int)
+    println(e.type)        // error type (e.g. "document_not_found")
+    println(e.response)    // full response body (Map)
+}
+```
+
+Common error codes:
+
+| Code | Meaning |
+|------|---------|
+| `401` | Unauthorized -- missing or invalid session/API key |
+| `403` | Forbidden -- insufficient permissions |
+| `404` | Not found -- resource does not exist |
+| `409` | Conflict -- duplicate ID or unique constraint |
+| `429` | Rate limited -- too many requests |
+
+## Permissions & Roles (Critical)
+
+Appwrite uses permission strings to control access to resources. Each permission pairs an action (`read`, `update`, `delete`, `create`, or `write` which grants create + update + delete) with a role target. By default, no user has access unless permissions are explicitly set at the document/file level or inherited from the collection/bucket settings. Permissions are arrays of strings built with the `Permission` and `Role` helpers.
+
+```kotlin
+import io.appwrite.Permission
+import io.appwrite.Role
+```
+
+### Database Row with Permissions
+
+```kotlin
+val doc = tablesDB.createRow(
+    databaseId = "[DATABASE_ID]",
+    tableId = "[TABLE_ID]",
+    rowId = ID.unique(),
+    data = mapOf("title" to "Hello World"),
+    permissions = listOf(
+        Permission.read(Role.user("[USER_ID]")),     // specific user can read
+        Permission.update(Role.user("[USER_ID]")),   // specific user can update
+        Permission.read(Role.team("[TEAM_ID]")),     // all team members can read
+        Permission.read(Role.any()),                 // anyone (including guests) can read
+    )
+)
+```
+
+### File Upload with Permissions
+
+```kotlin
+val file = storage.createFile(
+    bucketId = "[BUCKET_ID]",
+    fileId = ID.unique(),
+    file = InputFile.fromPath("/path/to/file.png"),
+    permissions = listOf(
+        Permission.read(Role.any()),
+        Permission.update(Role.user("[USER_ID]")),
+        Permission.delete(Role.user("[USER_ID]")),
+    )
+)
+```
+
+> When to set permissions: Set document/file-level permissions when you need per-resource access control. If all documents in a collection share the same rules, configure permissions at the collection/bucket level and leave document permissions empty.
+
+> Common mistakes:
+> - Forgetting permissions -- the resource becomes inaccessible to all users (including the creator)
+> - `Role.any()` with `write`/`update`/`delete` -- allows any user, including unauthenticated guests, to modify or remove the resource
+> - `Permission.read(Role.any())` on sensitive data -- makes the resource publicly readable

--- a/plugins/appwrite/skills/appwrite-mcp/SKILL.md
+++ b/plugins/appwrite/skills/appwrite-mcp/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: appwrite-mcp
+description: Use when deciding how to use the Appwrite MCP servers. Covers docs lookup, API MCP credential requirements, and safe Appwrite project mutation boundaries.
+---
+
+# Appwrite MCP
+
+This plugin registers two MCP servers:
+
+- `appwrite-docs` for Appwrite documentation lookup.
+- `appwrite-api` for Appwrite project operations through the Appwrite MCP server.
+
+## Choosing A Server
+
+- Use docs lookup for API references, SDK examples, migration questions, CLI command syntax, and best practices.
+- Use the API MCP only when the user asks to inspect or change actual Appwrite project resources.
+- If project state can be answered from local files, inspect the workspace before calling the API MCP.
+
+## API MCP Setup
+
+The API MCP requires these environment variables when the plugin is installed or reinstalled:
+
+```bash
+APPWRITE_ENDPOINT=https://<REGION>.cloud.appwrite.io/v1
+APPWRITE_PROJECT_ID=<PROJECT_ID>
+APPWRITE_API_KEY=<API_KEY>
+```
+
+If any value is missing, Cline skips `appwrite-api` and keeps the docs MCP and skills installed.
+
+## Safe Use
+
+- Treat API MCP calls as authenticated access to the target Appwrite project.
+- Prefer read-only inspection before mutation.
+- Confirm target endpoint, project ID, and resource IDs before making changes.
+- Ask for explicit user confirmation before deletes, deployment changes, permission changes, auth provider changes, function executions, or bulk writes.
+- Do not expose API keys in prompts, logs, files, or summaries.

--- a/plugins/appwrite/skills/appwrite-mcp/SKILL.md
+++ b/plugins/appwrite/skills/appwrite-mcp/SKILL.md
@@ -8,7 +8,7 @@ description: Use when deciding how to use the Appwrite MCP servers. Covers docs 
 This plugin registers two MCP servers:
 
 - `appwrite-docs` for Appwrite documentation lookup.
-- `appwrite-api` for Appwrite project operations through the Appwrite MCP server.
+- `appwrite-api` for Appwrite project operations through the Appwrite MCP server when required credentials are available.
 
 ## Choosing A Server
 

--- a/plugins/appwrite/skills/appwrite-php-sdk/SKILL.md
+++ b/plugins/appwrite/skills/appwrite-php-sdk/SKILL.md
@@ -1,0 +1,392 @@
+---
+name: appwrite-php-sdk
+description: Appwrite PHP SDK skill. Use when building server-side PHP applications with Appwrite, including Laravel and Symfony integrations. Covers user management, database/table CRUD, file storage, and functions via API keys.
+---
+
+
+# Appwrite PHP SDK
+
+## Cline Safety
+
+- Do not run install, deploy, push, delete, migration, or project mutation commands unless the user asks for that action and confirms the exact target.
+- Keep Appwrite API keys, JWTs, session secrets, endpoint-specific credentials, and .env values out of source control, logs, summaries, and chat unless the user explicitly asks to inspect a redacted form.
+- Prefer least-privilege API keys for server-side examples and keep client-side examples limited to endpoint plus project ID.
+
+
+## Installation
+
+```bash
+composer require appwrite/appwrite
+```
+
+## Setting Up the Client
+
+```php
+use Appwrite\Client;
+use Appwrite\ID;
+use Appwrite\Query;
+use Appwrite\Services\Users;
+use Appwrite\Services\TablesDB;
+use Appwrite\Services\Storage;
+use Appwrite\Services\Functions;
+use Appwrite\InputFile;
+
+$client = (new Client())
+    ->setEndpoint('https://<REGION>.cloud.appwrite.io/v1')
+    ->setProject(getenv('APPWRITE_PROJECT_ID'))
+    ->setKey(getenv('APPWRITE_API_KEY'));
+```
+
+## Code Examples
+
+### User Management
+
+```php
+$users = new Users($client);
+
+// Create user
+$user = $users->create(ID::unique(), 'user@example.com', null, 'password123', 'User Name');
+
+// List users
+$list = $users->list([Query::limit(25)]);
+
+// Get user
+$fetched = $users->get('[USER_ID]');
+
+// Delete user
+$users->delete('[USER_ID]');
+```
+
+### Database Operations
+
+> Note: Use `TablesDB` (not the deprecated `Databases` class) for all new code. Only use `Databases` if the existing codebase already relies on it or the user explicitly requests it.
+>
+> Tip: Prefer named arguments (PHP 8+, e.g., `databaseId: '...'`) for all SDK method calls. Only use positional arguments if the existing codebase already uses them or the user explicitly requests it.
+
+```php
+$tablesDB = new TablesDB($client);
+
+// Create database
+$db = $tablesDB->create(ID::unique(), 'My Database');
+
+// Create row
+$doc = $tablesDB->createRow('[DATABASE_ID]', '[TABLE_ID]', ID::unique(), [
+    'title' => 'Hello World'
+]);
+
+// Query rows
+$results = $tablesDB->listRows('[DATABASE_ID]', '[TABLE_ID]', [
+    Query::equal('title', ['Hello World']),
+    Query::limit(10)
+]);
+
+// Get row
+$row = $tablesDB->getRow('[DATABASE_ID]', '[TABLE_ID]', '[ROW_ID]');
+
+// Update row
+$tablesDB->updateRow('[DATABASE_ID]', '[TABLE_ID]', '[ROW_ID]', [
+    'title' => 'Updated'
+]);
+
+// Delete row
+$tablesDB->deleteRow('[DATABASE_ID]', '[TABLE_ID]', '[ROW_ID]');
+```
+
+#### String Column Types
+
+> Note: The legacy `string` type is deprecated. Use explicit column types for all new columns.
+
+| Type | Max characters | Indexing | Storage |
+|------|---------------|----------|---------|
+| `varchar` | 16,383 | Full index (if size <= 768) | Inline in row |
+| `text` | 16,383 | Prefix only | Off-page |
+| `mediumtext` | 4,194,303 | Prefix only | Off-page |
+| `longtext` | 1,073,741,823 | Prefix only | Off-page |
+
+- `varchar` is stored inline and counts towards the 64 KB row size limit. Prefer for short, indexed fields like names, slugs, or identifiers.
+- `text`, `mediumtext`, and `longtext` are stored off-page (only a 20-byte pointer lives in the row), so they don't consume the row size budget. `size` is not required for these types.
+
+```php
+// Create table with explicit string column types
+$tablesDB->createTable('[DATABASE_ID]', ID::unique(), 'articles', [
+    ['key' => 'title',    'type' => 'varchar',    'size' => 255, 'required' => true],
+    ['key' => 'summary',  'type' => 'text',                      'required' => false],
+    ['key' => 'body',     'type' => 'mediumtext',                'required' => false],
+    ['key' => 'raw_data', 'type' => 'longtext',                  'required' => false],
+]);
+```
+
+### Query Methods
+
+```php
+// Filtering
+Query::equal('field', ['value'])            // == (always pass array)
+Query::notEqual('field', ['value'])         // !=
+Query::lessThan('field', 100)              // <
+Query::lessThanEqual('field', 100)         // <=
+Query::greaterThan('field', 100)           // >
+Query::greaterThanEqual('field', 100)      // >=
+Query::between('field', 1, 100)            // 1 <= field <= 100
+Query::isNull('field')                     // is null
+Query::isNotNull('field')                  // is not null
+Query::startsWith('field', 'prefix')       // starts with
+Query::endsWith('field', 'suffix')         // ends with
+Query::contains('field', ['sub'])          // contains (string or array)
+Query::search('field', 'keywords')         // full-text search (requires index)
+
+// Sorting
+Query::orderAsc('field')
+Query::orderDesc('field')
+
+// Pagination
+Query::limit(25)                           // max rows (default 25, max 100)
+Query::offset(0)                           // skip N rows
+Query::cursorAfter('[ROW_ID]')             // cursor pagination (preferred)
+Query::cursorBefore('[ROW_ID]')
+
+// Selection & Logic
+Query::select(['field1', 'field2'])        // return only specified fields
+Query::or([Query::equal('a', [1]), Query::equal('b', [2])])   // OR
+Query::and([Query::greaterThan('age', 18), Query::lessThan('age', 65)])  // AND (default)
+```
+
+### File Storage
+
+```php
+$storage = new Storage($client);
+
+// Upload file
+$file = $storage->createFile('[BUCKET_ID]', ID::unique(), InputFile::withPath('/path/to/file.png'));
+
+// List files
+$files = $storage->listFiles('[BUCKET_ID]');
+
+// Delete file
+$storage->deleteFile('[BUCKET_ID]', '[FILE_ID]');
+```
+
+#### InputFile Factory Methods
+
+```php
+use Appwrite\InputFile;
+
+InputFile::withPath('/path/to/file.png')                    // from filesystem path
+InputFile::withData('Hello world', 'hello.txt')             // from string content
+```
+
+### Teams
+
+```php
+$teams = new Teams($client);
+
+// Create team
+$team = $teams->create(ID::unique(), 'Engineering');
+
+// List teams
+$list = $teams->list();
+
+// Create membership (invite user by email)
+$membership = $teams->createMembership('[TEAM_ID]', ['editor'], email: 'user@example.com');
+
+// List memberships
+$members = $teams->listMemberships('[TEAM_ID]');
+
+// Update membership roles
+$teams->updateMembership('[TEAM_ID]', '[MEMBERSHIP_ID]', ['admin']);
+
+// Delete team
+$teams->delete('[TEAM_ID]');
+```
+
+> Role-based access: Use `Role::team('[TEAM_ID]')` for all team members or `Role::team('[TEAM_ID]', 'editor')` for a specific team role when setting permissions.
+
+### Serverless Functions
+
+```php
+$functions = new Functions($client);
+
+// Execute function
+$execution = $functions->createExecution('[FUNCTION_ID]', '{"key": "value"}');
+
+// List executions
+$executions = $functions->listExecutions('[FUNCTION_ID]');
+```
+
+#### Writing a Function Handler (PHP runtime)
+
+```php
+// src/main.php -- Appwrite Function entry point
+return function ($context) {
+    // $context->req->body        -- raw body (string)
+    // $context->req->bodyJson    -- parsed JSON (array or null)
+    // $context->req->headers     -- headers (array)
+    // $context->req->method      -- HTTP method
+    // $context->req->path        -- URL path
+    // $context->req->query       -- query params (array)
+
+    $context->log('Processing: ' . $context->req->method . ' ' . $context->req->path);
+
+    if ($context->req->method === 'GET') {
+        return $context->res->json(['message' => 'Hello from Appwrite Function!']);
+    }
+
+    $data = $context->req->bodyJson ?? [];
+    if (!isset($data['name'])) {
+        $context->error('Missing name field');
+        return $context->res->json(['error' => 'Name is required'], 400);
+    }
+
+    return $context->res->json(['success' => true]);      // JSON
+    // return $context->res->text('Hello');                // plain text
+    // return $context->res->empty();                      // 204
+    // return $context->res->redirect('https://...');      // 302
+};
+```
+
+### Server-Side Rendering (SSR) Authentication
+
+SSR apps (Laravel, Symfony, etc.) use the server SDK to handle auth. You need two clients:
+
+- Admin client -- uses an API key, creates sessions, bypasses rate limits (reusable singleton)
+- Session client -- uses a session cookie, acts on behalf of a user (create per-request, never share)
+
+```php
+use Appwrite\Client;
+use Appwrite\Services\Account;
+
+// Admin client (reusable)
+$adminClient = (new Client())
+    ->setEndpoint('https://<REGION>.cloud.appwrite.io/v1')
+    ->setProject('[PROJECT_ID]')
+    ->setKey(getenv('APPWRITE_API_KEY'));
+
+// Session client (create per-request)
+$sessionClient = (new Client())
+    ->setEndpoint('https://<REGION>.cloud.appwrite.io/v1')
+    ->setProject('[PROJECT_ID]');
+
+$session = $_COOKIE['a_session_[PROJECT_ID]'] ?? null;
+if ($session) {
+    $sessionClient->setSession($session);
+}
+```
+
+#### Email/Password Login
+
+```php
+$account = new Account($adminClient);
+$session = $account->createEmailPasswordSession($email, $password);
+
+// Cookie name must be a_session_<PROJECT_ID>
+setcookie('a_session_[PROJECT_ID]', $session['secret'], [
+    'httpOnly' => true,
+    'secure' => true,
+    'sameSite' => 'strict',
+    'expires' => strtotime($session['expire']),
+    'path' => '/',
+]);
+```
+
+#### Authenticated Requests
+
+```php
+$session = $_COOKIE['a_session_[PROJECT_ID]'] ?? null;
+if (!$session) {
+    http_response_code(401);
+    exit;
+}
+
+$sessionClient->setSession($session);
+$account = new Account($sessionClient);
+$user = $account->get();
+```
+
+#### OAuth2 SSR Flow
+
+```php
+// Step 1: Redirect to OAuth provider
+$account = new Account($adminClient);
+$redirectUrl = $account->createOAuth2Token(
+    OAuthProvider::GITHUB(),
+    'https://example.com/oauth/success',
+    'https://example.com/oauth/failure',
+);
+header('Location: ' . $redirectUrl);
+
+// Step 2: Handle callback -- exchange token for session
+$account = new Account($adminClient);
+$session = $account->createSession($_GET['userId'], $_GET['secret']);
+
+setcookie('a_session_[PROJECT_ID]', $session['secret'], [
+    'httpOnly' => true, 'secure' => true, 'sameSite' => 'strict',
+    'expires' => strtotime($session['expire']), 'path' => '/',
+]);
+```
+
+> Cookie security: Always use `httpOnly`, `secure`, and `sameSite: 'strict'` to prevent XSS. The cookie name must be `a_session_<PROJECT_ID>`.
+
+> Forwarding user agent: Call `$sessionClient->setForwardedUserAgent($_SERVER['HTTP_USER_AGENT'])` to record the end-user's browser info for debugging and security.
+
+## Error Handling
+
+```php
+use Appwrite\AppwriteException;
+
+try {
+    $row = $tablesDB->getRow('[DATABASE_ID]', '[TABLE_ID]', '[ROW_ID]');
+} catch (AppwriteException $e) {
+    echo $e->getMessage();   // human-readable error message
+    echo $e->getCode();      // HTTP status code (int)
+    echo $e->getType();      // Appwrite error type string (e.g. 'document_not_found')
+    echo $e->getResponse();  // full response body (array)
+}
+```
+
+Common error codes:
+
+| Code | Meaning |
+|------|---------|
+| `401` | Unauthorized -- missing or invalid session/API key |
+| `403` | Forbidden -- insufficient permissions for this action |
+| `404` | Not found -- resource does not exist |
+| `409` | Conflict -- duplicate ID or unique constraint violation |
+| `429` | Rate limited -- too many requests, retry after backoff |
+
+## Permissions & Roles (Critical)
+
+Appwrite uses permission strings to control access to resources. Each permission pairs an action (`read`, `update`, `delete`, `create`, or `write` which grants create + update + delete) with a role target. By default, no user has access unless permissions are explicitly set at the document/file level or inherited from the collection/bucket settings. Permissions are arrays of strings built with the `Permission` and `Role` helpers.
+
+```php
+use Appwrite\Permission;
+use Appwrite\Role;
+```
+
+### Database Row with Permissions
+
+```php
+$doc = $tablesDB->createRow('[DATABASE_ID]', '[TABLE_ID]', ID::unique(), [
+    'title' => 'Hello World'
+], [
+    Permission::read(Role::user('[USER_ID]')),     // specific user can read
+    Permission::update(Role::user('[USER_ID]')),   // specific user can update
+    Permission::read(Role::team('[TEAM_ID]')),     // all team members can read
+    Permission::read(Role::any()),                 // anyone (including guests) can read
+]);
+```
+
+### File Upload with Permissions
+
+```php
+$file = $storage->createFile('[BUCKET_ID]', ID::unique(), InputFile::withPath('/path/to/file.png'), [
+    Permission::read(Role::any()),
+    Permission::update(Role::user('[USER_ID]')),
+    Permission::delete(Role::user('[USER_ID]')),
+]);
+```
+
+> When to set permissions: Set document/file-level permissions when you need per-resource access control. If all documents in a collection share the same rules, configure permissions at the collection/bucket level and leave document permissions empty.
+
+> Common mistakes:
+> - Forgetting permissions -- the resource becomes inaccessible to all users (including the creator)
+> - `Role::any()` with `write`/`update`/`delete` -- allows any user, including unauthenticated guests, to modify or remove the resource
+> - `Permission::read(Role::any())` on sensitive data -- makes the resource publicly readable

--- a/plugins/appwrite/skills/appwrite-python-sdk/SKILL.md
+++ b/plugins/appwrite/skills/appwrite-python-sdk/SKILL.md
@@ -1,0 +1,415 @@
+---
+name: appwrite-python-sdk
+description: Appwrite Python SDK skill. Use when building server-side Python applications with Appwrite, including Django, Flask, and FastAPI integrations. Covers user management, database/table CRUD, file storage, and functions via API keys.
+---
+
+
+# Appwrite Python SDK
+
+## Cline Safety
+
+- Do not run install, deploy, push, delete, migration, or project mutation commands unless the user asks for that action and confirms the exact target.
+- Keep Appwrite API keys, JWTs, session secrets, endpoint-specific credentials, and .env values out of source control, logs, summaries, and chat unless the user explicitly asks to inspect a redacted form.
+- Prefer least-privilege API keys for server-side examples and keep client-side examples limited to endpoint plus project ID.
+
+
+## Installation
+
+```bash
+pip install appwrite
+```
+
+## Setting Up the Client
+
+```python
+from appwrite.client import Client
+from appwrite.id import ID
+from appwrite.query import Query
+from appwrite.services.users import Users
+from appwrite.services.tables_db import TablesDB
+from appwrite.services.storage import Storage
+from appwrite.services.functions import Functions
+from appwrite.enums.o_auth_provider import OAuthProvider
+
+import os
+
+client = (Client()
+    .set_endpoint('https://<REGION>.cloud.appwrite.io/v1')
+    .set_project(os.environ['APPWRITE_PROJECT_ID'])
+    .set_key(os.environ['APPWRITE_API_KEY']))
+```
+
+## Code Examples
+
+### User Management
+
+```python
+users = Users(client)
+
+# Create user
+user = users.create(ID.unique(), 'user@example.com', None, 'password123', 'User Name')
+
+# List users
+result = users.list([Query.limit(25)])
+
+# Get user
+fetched = users.get('[USER_ID]')
+
+# Delete user
+users.delete('[USER_ID]')
+```
+
+### Database Operations
+
+> Note: Use `TablesDB` (not the deprecated `Databases` class) for all new code. Only use `Databases` if the existing codebase already relies on it or the user explicitly requests it.
+>
+> Tip: Prefer keyword arguments (e.g., `database_id='...'`) over positional arguments for all SDK method calls. Only use positional style if the existing codebase already uses it or the user explicitly requests it.
+
+```python
+tables_db = TablesDB(client)
+
+# Create database
+db = tables_db.create(ID.unique(), 'My Database')
+
+# Create row
+doc = tables_db.create_row('[DATABASE_ID]', '[TABLE_ID]', ID.unique(), {
+    'title': 'Hello World'
+})
+
+# Query rows
+results = tables_db.list_rows('[DATABASE_ID]', '[TABLE_ID]', [
+    Query.equal('title', 'Hello World'),
+    Query.limit(10)
+])
+
+# Get row
+row = tables_db.get_row('[DATABASE_ID]', '[TABLE_ID]', '[ROW_ID]')
+
+# Update row
+tables_db.update_row('[DATABASE_ID]', '[TABLE_ID]', '[ROW_ID]', {
+    'title': 'Updated'
+})
+
+# Delete row
+tables_db.delete_row('[DATABASE_ID]', '[TABLE_ID]', '[ROW_ID]')
+```
+
+#### String Column Types
+
+> Note: The legacy `string` type is deprecated. Use explicit column types for all new columns.
+
+| Type | Max characters | Indexing | Storage |
+|------|---------------|----------|---------|
+| `varchar` | 16,383 | Full index (if size <= 768) | Inline in row |
+| `text` | 16,383 | Prefix only | Off-page |
+| `mediumtext` | 4,194,303 | Prefix only | Off-page |
+| `longtext` | 1,073,741,823 | Prefix only | Off-page |
+
+- `varchar` is stored inline and counts towards the 64 KB row size limit. Prefer for short, indexed fields like names, slugs, or identifiers.
+- `text`, `mediumtext`, and `longtext` are stored off-page (only a 20-byte pointer lives in the row), so they don't consume the row size budget. `size` is not required for these types.
+
+```python
+# Create table with explicit string column types
+tables_db.create_table(
+    database_id='[DATABASE_ID]',
+    table_id=ID.unique(),
+    name='articles',
+    columns=[
+        {'key': 'title',    'type': 'varchar',    'size': 255, 'required': True},   # inline, fully indexable
+        {'key': 'summary',  'type': 'text',                    'required': False},  # off-page, prefix index only
+        {'key': 'body',     'type': 'mediumtext',              'required': False},  # up to ~4 M chars
+        {'key': 'raw_data', 'type': 'longtext',                'required': False},  # up to ~1 B chars
+    ]
+)
+```
+
+### Query Methods
+
+```python
+# Filtering
+Query.equal('field', 'value')             # == (or pass list for IN)
+Query.not_equal('field', 'value')         # !=
+Query.less_than('field', 100)             # <
+Query.less_than_equal('field', 100)       # <=
+Query.greater_than('field', 100)          # >
+Query.greater_than_equal('field', 100)    # >=
+Query.between('field', 1, 100)            # 1 <= field <= 100
+Query.is_null('field')                    # is null
+Query.is_not_null('field')                # is not null
+Query.starts_with('field', 'prefix')      # starts with
+Query.ends_with('field', 'suffix')        # ends with
+Query.contains('field', 'sub')            # contains (string or array)
+Query.search('field', 'keywords')         # full-text search (requires index)
+
+# Sorting
+Query.order_asc('field')
+Query.order_desc('field')
+
+# Pagination
+Query.limit(25)                           # max rows (default 25, max 100)
+Query.offset(0)                           # skip N rows
+Query.cursor_after('[ROW_ID]')            # cursor pagination (preferred)
+Query.cursor_before('[ROW_ID]')
+
+# Selection & Logic
+Query.select(['field1', 'field2'])        # return only specified fields
+Query.or_queries([Query.equal('a', 1), Query.equal('b', 2)])   # OR
+Query.and_queries([Query.greater_than('age', 18), Query.less_than('age', 65)])  # AND (default)
+```
+
+### File Storage
+
+```python
+from appwrite.input_file import InputFile
+
+storage = Storage(client)
+
+# Upload file
+file = storage.create_file('[BUCKET_ID]', ID.unique(), InputFile.from_path('/path/to/file.png'))
+
+# List files
+files = storage.list_files('[BUCKET_ID]')
+
+# Delete file
+storage.delete_file('[BUCKET_ID]', '[FILE_ID]')
+```
+
+#### InputFile Factory Methods
+
+```python
+from appwrite.input_file import InputFile
+
+InputFile.from_path('/path/to/file.png')             # from filesystem path
+InputFile.from_bytes(byte_data, 'file.png')          # from bytes
+InputFile.from_string('Hello world', 'hello.txt')    # from string content
+```
+
+### Teams
+
+```python
+from appwrite.services.teams import Teams
+
+teams = Teams(client)
+
+# Create team
+team = teams.create(ID.unique(), 'Engineering')
+
+# List teams
+team_list = teams.list()
+
+# Create membership (invite user by email)
+membership = teams.create_membership('[TEAM_ID]', roles=['editor'], email='user@example.com')
+
+# List memberships
+members = teams.list_memberships('[TEAM_ID]')
+
+# Update membership roles
+teams.update_membership('[TEAM_ID]', '[MEMBERSHIP_ID]', roles=['admin'])
+
+# Delete team
+teams.delete('[TEAM_ID]')
+```
+
+> Role-based access: Use `Role.team('[TEAM_ID]')` for all team members or `Role.team('[TEAM_ID]', 'editor')` for a specific team role when setting permissions.
+
+### Serverless Functions
+
+```python
+functions = Functions(client)
+
+# Execute function
+execution = functions.create_execution('[FUNCTION_ID]', body='{"key": "value"}')
+
+# List executions
+executions = functions.list_executions('[FUNCTION_ID]')
+```
+
+#### Writing a Function Handler (Python runtime)
+
+```python
+# src/main.py -- Appwrite Function entry point
+def main(context):
+    # context.req -- request object
+    #   .body        -- raw request body (string)
+    #   .body_json   -- parsed JSON body (dict, or None if not JSON)
+    #   .headers     -- request headers (dict)
+    #   .method      -- HTTP method (GET, POST, etc.)
+    #   .path        -- URL path
+    #   .query       -- parsed query parameters (dict)
+    #   .query_string -- raw query string
+
+    context.log('Processing: ' + context.req.method + ' ' + context.req.path)
+
+    if context.req.method == 'GET':
+        return context.res.json({'message': 'Hello from Appwrite Function!'})
+
+    data = context.req.body_json or {}
+    if 'name' not in data:
+        context.error('Missing name field')
+        return context.res.json({'error': 'Name is required'}, 400)
+
+    # Response methods
+    return context.res.json({'success': True})                    # JSON response
+    # return context.res.text('Hello')                           # plain text
+    # return context.res.empty()                                 # 204 No Content
+    # return context.res.redirect('https://example.com')         # 302 Redirect
+    # return context.res.send('data', 200, {'X-Custom': '1'})   # custom response
+```
+
+### Server-Side Rendering (SSR) Authentication
+
+SSR apps (Flask, Django, FastAPI, etc.) use the server SDK to handle auth. You need two clients:
+
+- Admin client -- uses an API key, creates sessions, bypasses rate limits (reusable singleton)
+- Session client -- uses a session cookie, acts on behalf of a user (create per-request, never share)
+
+```python
+from appwrite.client import Client
+from appwrite.services.account import Account
+from flask import request, jsonify, make_response, redirect
+
+# Admin client (reusable)
+admin_client = (Client()
+    .set_endpoint('https://<REGION>.cloud.appwrite.io/v1')
+    .set_project('[PROJECT_ID]')
+    .set_key(os.environ['APPWRITE_API_KEY']))
+
+# Session client (create per-request)
+session_client = (Client()
+    .set_endpoint('https://<REGION>.cloud.appwrite.io/v1')
+    .set_project('[PROJECT_ID]'))
+
+session = request.cookies.get('a_session_[PROJECT_ID]')
+if session:
+    session_client.set_session(session)
+```
+
+#### Email/Password Login
+
+```python
+@app.post('/login')
+def login():
+    account = Account(admin_client)
+    session = account.create_email_password_session(
+        request.json['email'], request.json['password']
+    )
+
+    # Cookie name must be a_session_<PROJECT_ID>
+    resp = make_response(jsonify({'success': True}))
+    resp.set_cookie('a_session_[PROJECT_ID]', session['secret'],
+                    httponly=True, secure=True, samesite='Strict',
+                    expires=session['expire'], path='/')
+    return resp
+```
+
+#### Authenticated Requests
+
+```python
+@app.get('/user')
+def get_user():
+    session = request.cookies.get('a_session_[PROJECT_ID]')
+    if not session:
+        return jsonify({'error': 'Unauthorized'}), 401
+
+    session_client = (Client()
+        .set_endpoint('https://<REGION>.cloud.appwrite.io/v1')
+        .set_project('[PROJECT_ID]')
+        .set_session(session))
+
+    account = Account(session_client)
+    return jsonify(account.get())
+```
+
+#### OAuth2 SSR Flow
+
+```python
+# Step 1: Redirect to OAuth provider
+@app.get('/oauth')
+def oauth():
+    account = Account(admin_client)
+    redirect_url = account.create_o_auth2_token(
+        OAuthProvider.Github,
+        'https://example.com/oauth/success',
+        'https://example.com/oauth/failure',
+    )
+    return redirect(redirect_url)
+
+# Step 2: Handle callback -- exchange token for session
+@app.get('/oauth/success')
+def oauth_success():
+    account = Account(admin_client)
+    session = account.create_session(request.args['userId'], request.args['secret'])
+
+    resp = make_response(jsonify({'success': True}))
+    resp.set_cookie('a_session_[PROJECT_ID]', session['secret'],
+                    httponly=True, secure=True, samesite='Strict',
+                    expires=session['expire'], path='/')
+    return resp
+```
+
+> Cookie security: Always use `httponly`, `secure`, and `samesite='Strict'` to prevent XSS. The cookie name must be `a_session_<PROJECT_ID>`.
+
+> Forwarding user agent: Call `session_client.set_forwarded_user_agent(request.headers.get('user-agent'))` to record the end-user's browser info for debugging and security.
+
+## Error Handling
+
+```python
+from appwrite.exception import AppwriteException
+
+try:
+    row = tables_db.get_row('[DATABASE_ID]', '[TABLE_ID]', '[ROW_ID]')
+except AppwriteException as e:
+    print(e.message)    # human-readable error message
+    print(e.code)       # HTTP status code (int)
+    print(e.type)       # Appwrite error type string (e.g. 'document_not_found')
+    print(e.response)   # full response body (dict)
+```
+
+Common error codes:
+
+| Code | Meaning |
+|------|---------|
+| `401` | Unauthorized -- missing or invalid session/API key |
+| `403` | Forbidden -- insufficient permissions for this action |
+| `404` | Not found -- resource does not exist |
+| `409` | Conflict -- duplicate ID or unique constraint violation |
+| `429` | Rate limited -- too many requests, retry after backoff |
+
+## Permissions & Roles (Critical)
+
+Appwrite uses permission strings to control access to resources. Each permission pairs an action (`read`, `update`, `delete`, `create`, or `write` which grants create + update + delete) with a role target. By default, no user has access unless permissions are explicitly set at the document/file level or inherited from the collection/bucket settings. Permissions are arrays of strings built with the `Permission` and `Role` helpers.
+
+```python
+from appwrite.permission import Permission
+from appwrite.role import Role
+```
+
+### Database Row with Permissions
+
+```python
+doc = tables_db.create_row('[DATABASE_ID]', '[TABLE_ID]', ID.unique(), {
+    'title': 'Hello World'
+}, [
+    Permission.read(Role.user('[USER_ID]')),     # specific user can read
+    Permission.update(Role.user('[USER_ID]')),   # specific user can update
+    Permission.read(Role.team('[TEAM_ID]')),     # all team members can read
+    Permission.read(Role.any()),                 # anyone (including guests) can read
+])
+```
+
+### File Upload with Permissions
+
+```python
+file = storage.create_file('[BUCKET_ID]', ID.unique(), InputFile.from_path('/path/to/file.png'), [
+    Permission.read(Role.any()),
+    Permission.update(Role.user('[USER_ID]')),
+    Permission.delete(Role.user('[USER_ID]')),
+])
+```
+
+> When to set permissions: Set document/file-level permissions when you need per-resource access control. If all documents in a collection share the same rules, configure permissions at the collection/bucket level and leave document permissions empty.
+
+> Common mistakes:
+> - Forgetting permissions -- the resource becomes inaccessible to all users (including the creator)
+> - `Role.any()` with `write`/`update`/`delete` -- allows any user, including unauthenticated guests, to modify or remove the resource
+> - `Permission.read(Role.any())` on sensitive data -- makes the resource publicly readable

--- a/plugins/appwrite/skills/appwrite-ruby-sdk/SKILL.md
+++ b/plugins/appwrite/skills/appwrite-ruby-sdk/SKILL.md
@@ -1,0 +1,428 @@
+---
+name: appwrite-ruby-sdk
+description: Appwrite Ruby SDK skill. Use when building server-side Ruby applications with Appwrite, including Rails and Sinatra integrations. Covers user management, database/table CRUD, file storage, and functions via API keys.
+---
+
+
+# Appwrite Ruby SDK
+
+## Cline Safety
+
+- Do not run install, deploy, push, delete, migration, or project mutation commands unless the user asks for that action and confirms the exact target.
+- Keep Appwrite API keys, JWTs, session secrets, endpoint-specific credentials, and .env values out of source control, logs, summaries, and chat unless the user explicitly asks to inspect a redacted form.
+- Prefer least-privilege API keys for server-side examples and keep client-side examples limited to endpoint plus project ID.
+
+
+## Installation
+
+```bash
+gem install appwrite
+```
+
+## Setting Up the Client
+
+```ruby
+require 'appwrite'
+
+include Appwrite
+
+client = Client.new
+    .set_endpoint('https://<REGION>.cloud.appwrite.io/v1')
+    .set_project(ENV['APPWRITE_PROJECT_ID'])
+    .set_key(ENV['APPWRITE_API_KEY'])
+```
+
+## Code Examples
+
+### User Management
+
+```ruby
+users = Users.new(client)
+
+# Create user
+user = users.create(user_id: ID.unique, email: 'user@example.com', password: 'password123', name: 'User Name')
+
+# List users
+list = users.list(queries: [Query.limit(25)])
+
+# Get user
+fetched = users.get(user_id: '[USER_ID]')
+
+# Delete user
+users.delete(user_id: '[USER_ID]')
+```
+
+### Database Operations
+
+> Note: Use `TablesDB` (not the deprecated `Databases` class) for all new code. Only use `Databases` if the existing codebase already relies on it or the user explicitly requests it.
+>
+> Tip: Prefer keyword arguments (e.g., `database_id: '...'`) for all SDK method calls. Only use positional arguments if the existing codebase already uses them or the user explicitly requests it.
+
+```ruby
+tables_db = TablesDB.new(client)
+
+# Create database
+db = tables_db.create(database_id: ID.unique, name: 'My Database')
+
+# Create row
+doc = tables_db.create_row(
+    database_id: '[DATABASE_ID]',
+    table_id: '[TABLE_ID]',
+    row_id: ID.unique,
+    data: { title: 'Hello World' }
+)
+
+# Query rows
+results = tables_db.list_rows(
+    database_id: '[DATABASE_ID]',
+    table_id: '[TABLE_ID]',
+    queries: [Query.equal('title', 'Hello World'), Query.limit(10)]
+)
+
+# Get row
+row = tables_db.get_row(database_id: '[DATABASE_ID]', table_id: '[TABLE_ID]', row_id: '[ROW_ID]')
+
+# Update row
+tables_db.update_row(
+    database_id: '[DATABASE_ID]',
+    table_id: '[TABLE_ID]',
+    row_id: '[ROW_ID]',
+    data: { title: 'Updated' }
+)
+
+# Delete row
+tables_db.delete_row(database_id: '[DATABASE_ID]', table_id: '[TABLE_ID]', row_id: '[ROW_ID]')
+```
+
+#### String Column Types
+
+> Note: The legacy `string` type is deprecated. Use explicit column types for all new columns.
+
+| Type | Max characters | Indexing | Storage |
+|------|---------------|----------|---------|
+| `varchar` | 16,383 | Full index (if size <= 768) | Inline in row |
+| `text` | 16,383 | Prefix only | Off-page |
+| `mediumtext` | 4,194,303 | Prefix only | Off-page |
+| `longtext` | 1,073,741,823 | Prefix only | Off-page |
+
+- `varchar` is stored inline and counts towards the 64 KB row size limit. Prefer for short, indexed fields like names, slugs, or identifiers.
+- `text`, `mediumtext`, and `longtext` are stored off-page (only a 20-byte pointer lives in the row), so they don't consume the row size budget. `size` is not required for these types.
+
+```ruby
+# Create table with explicit string column types
+tables_db.create_table(
+    database_id: '[DATABASE_ID]',
+    table_id: ID.unique,
+    name: 'articles',
+    columns: [
+        { key: 'title',    type: 'varchar',    size: 255, required: true  },  # inline, fully indexable
+        { key: 'summary',  type: 'text',                  required: false },  # off-page, prefix index only
+        { key: 'body',     type: 'mediumtext',            required: false },  # up to ~4 M chars
+        { key: 'raw_data', type: 'longtext',              required: false },  # up to ~1 B chars
+    ]
+)
+```
+
+### Query Methods
+
+```ruby
+# Filtering
+Query.equal('field', 'value')             # == (or pass array for IN)
+Query.not_equal('field', 'value')         # !=
+Query.less_than('field', 100)             # <
+Query.less_than_equal('field', 100)       # <=
+Query.greater_than('field', 100)          # >
+Query.greater_than_equal('field', 100)    # >=
+Query.between('field', 1, 100)            # 1 <= field <= 100
+Query.is_null('field')                    # is null
+Query.is_not_null('field')                # is not null
+Query.starts_with('field', 'prefix')      # starts with
+Query.ends_with('field', 'suffix')        # ends with
+Query.contains('field', 'sub')            # contains
+Query.search('field', 'keywords')         # full-text search (requires index)
+
+# Sorting
+Query.order_asc('field')
+Query.order_desc('field')
+
+# Pagination
+Query.limit(25)                           # max rows (default 25, max 100)
+Query.offset(0)                           # skip N rows
+Query.cursor_after('[ROW_ID]')            # cursor pagination (preferred)
+Query.cursor_before('[ROW_ID]')
+
+# Selection & Logic
+Query.select(['field1', 'field2'])        # return only specified fields
+Query.or([Query.equal('a', 1), Query.equal('b', 2)])   # OR
+Query.and([Query.greater_than('age', 18), Query.less_than('age', 65)])  # AND (default)
+```
+
+### File Storage
+
+```ruby
+storage = Storage.new(client)
+
+# Upload file
+file = storage.create_file(bucket_id: '[BUCKET_ID]', file_id: ID.unique, file: InputFile.from_path('/path/to/file.png'))
+
+# List files
+files = storage.list_files(bucket_id: '[BUCKET_ID]')
+
+# Delete file
+storage.delete_file(bucket_id: '[BUCKET_ID]', file_id: '[FILE_ID]')
+```
+
+#### InputFile Factory Methods
+
+```ruby
+InputFile.from_path('/path/to/file.png')             # from filesystem path
+InputFile.from_string('Hello world', 'hello.txt')    # from string content
+```
+
+### Teams
+
+```ruby
+teams = Teams.new(client)
+
+# Create team
+team = teams.create(team_id: ID.unique, name: 'Engineering')
+
+# List teams
+list = teams.list
+
+# Create membership (invite user by email)
+membership = teams.create_membership(
+    team_id: '[TEAM_ID]',
+    roles: ['editor'],
+    email: 'user@example.com'
+)
+
+# List memberships
+members = teams.list_memberships(team_id: '[TEAM_ID]')
+
+# Update membership roles
+teams.update_membership(team_id: '[TEAM_ID]', membership_id: '[MEMBERSHIP_ID]', roles: ['admin'])
+
+# Delete team
+teams.delete(team_id: '[TEAM_ID]')
+```
+
+> Role-based access: Use `Role.team('[TEAM_ID]')` for all team members or `Role.team('[TEAM_ID]', 'editor')` for a specific team role when setting permissions.
+
+### Serverless Functions
+
+```ruby
+functions = Functions.new(client)
+
+# Execute function
+execution = functions.create_execution(function_id: '[FUNCTION_ID]', body: '{"key": "value"}')
+
+# List executions
+executions = functions.list_executions(function_id: '[FUNCTION_ID]')
+```
+
+#### Writing a Function Handler (Ruby runtime)
+
+```ruby
+# src/main.rb -- Appwrite Function entry point
+def main(context)
+    # context.req.body         -- raw body (String)
+    # context.req.body_json    -- parsed JSON (Hash or nil)
+    # context.req.headers      -- headers (Hash)
+    # context.req.method       -- HTTP method
+    # context.req.path         -- URL path
+    # context.req.query        -- query params (Hash)
+
+    context.log("Processing: #{context.req.method} #{context.req.path}")
+
+    if context.req.method == 'GET'
+        return context.res.json({ message: 'Hello from Appwrite Function!' })
+    end
+
+    context.res.json({ success: true })          # JSON
+    # context.res.text('Hello')                  # plain text
+    # context.res.empty                          # 204
+    # context.res.redirect('https://...')         # 302
+end
+```
+
+### Server-Side Rendering (SSR) Authentication
+
+SSR apps using Ruby frameworks (Rails, Sinatra, etc.) use the server SDK to handle auth. You need two clients:
+
+- Admin client -- uses an API key, creates sessions, bypasses rate limits (reusable singleton)
+- Session client -- uses a session cookie, acts on behalf of a user (create per-request, never share)
+
+```ruby
+require 'appwrite'
+include Appwrite
+
+# Admin client (reusable)
+admin_client = Client.new
+    .set_endpoint('https://<REGION>.cloud.appwrite.io/v1')
+    .set_project('[PROJECT_ID]')
+    .set_key(ENV['APPWRITE_API_KEY'])
+
+# Session client (create per-request)
+session_client = Client.new
+    .set_endpoint('https://<REGION>.cloud.appwrite.io/v1')
+    .set_project('[PROJECT_ID]')
+
+session = cookies['a_session_[PROJECT_ID]']
+session_client.set_session(session) if session
+```
+
+#### Email/Password Login (Sinatra)
+
+```ruby
+post '/login' do
+    account = Account.new(admin_client)
+    session = account.create_email_password_session(
+        email: params[:email],
+        password: params[:password]
+    )
+
+    # Cookie name must be a_session_<PROJECT_ID>
+    response.set_cookie('a_session_[PROJECT_ID]', {
+        value: session.secret,
+        httponly: true,
+        secure: true,
+        same_site: :strict,
+        path: '/',
+    })
+
+    content_type :json
+    { success: true }.to_json
+end
+```
+
+#### Authenticated Requests
+
+```ruby
+get '/user' do
+    session = request.cookies['a_session_[PROJECT_ID]']
+    halt 401, { error: 'Unauthorized' }.to_json unless session
+
+    session_client = Client.new
+        .set_endpoint('https://<REGION>.cloud.appwrite.io/v1')
+        .set_project('[PROJECT_ID]')
+        .set_session(session)
+
+    account = Account.new(session_client)
+    user = account.get
+
+    content_type :json
+    user.to_json
+end
+```
+
+#### OAuth2 SSR Flow
+
+```ruby
+# Step 1: Redirect to OAuth provider
+get '/oauth' do
+    account = Account.new(admin_client)
+    redirect_url = account.create_o_auth2_token(
+        provider: OAuthProvider::GITHUB,
+        success: 'https://example.com/oauth/success',
+        failure: 'https://example.com/oauth/failure'
+    )
+    redirect redirect_url
+end
+
+# Step 2: Handle callback -- exchange token for session
+get '/oauth/success' do
+    account = Account.new(admin_client)
+    session = account.create_session(
+        user_id: params[:userId],
+        secret: params[:secret]
+    )
+
+    response.set_cookie('a_session_[PROJECT_ID]', {
+        value: session.secret,
+        httponly: true, secure: true, same_site: :strict, path: '/',
+    })
+
+    content_type :json
+    { success: true }.to_json
+end
+```
+
+> Cookie security: Always use `httponly`, `secure`, and `same_site: :strict` to prevent XSS. The cookie name must be `a_session_<PROJECT_ID>`.
+
+> Forwarding user agent: Call `session_client.set_forwarded_user_agent(request.user_agent)` to record the end-user's browser info for debugging and security.
+
+## Error Handling
+
+```ruby
+require 'appwrite'
+include Appwrite
+
+begin
+    row = tables_db.get_row(database_id: '[DATABASE_ID]', table_id: '[TABLE_ID]', row_id: '[ROW_ID]')
+rescue Appwrite::Exception => e
+    puts e.message    # human-readable message
+    puts e.code       # HTTP status code (Integer)
+    puts e.type       # error type (e.g. 'document_not_found')
+    puts e.response   # full response body (Hash)
+end
+```
+
+Common error codes:
+
+| Code | Meaning |
+|------|---------|
+| `401` | Unauthorized -- missing or invalid session/API key |
+| `403` | Forbidden -- insufficient permissions |
+| `404` | Not found -- resource does not exist |
+| `409` | Conflict -- duplicate ID or unique constraint |
+| `429` | Rate limited -- too many requests |
+
+## Permissions & Roles (Critical)
+
+Appwrite uses permission strings to control access to resources. Each permission pairs an action (`read`, `update`, `delete`, `create`, or `write` which grants create + update + delete) with a role target. By default, no user has access unless permissions are explicitly set at the document/file level or inherited from the collection/bucket settings. Permissions are arrays of strings built with the `Permission` and `Role` helpers.
+
+```ruby
+# Permission and Role are included in the main require
+require 'appwrite'
+include Appwrite
+```
+
+### Database Row with Permissions
+
+```ruby
+doc = tables_db.create_row(
+    database_id: '[DATABASE_ID]',
+    table_id: '[TABLE_ID]',
+    row_id: ID.unique,
+    data: { title: 'Hello World' },
+    permissions: [
+        Permission.read(Role.user('[USER_ID]')),     # specific user can read
+        Permission.update(Role.user('[USER_ID]')),   # specific user can update
+        Permission.read(Role.team('[TEAM_ID]')),     # all team members can read
+        Permission.read(Role.any),                   # anyone (including guests) can read
+    ]
+)
+```
+
+### File Upload with Permissions
+
+```ruby
+file = storage.create_file(
+    bucket_id: '[BUCKET_ID]',
+    file_id: ID.unique,
+    file: InputFile.from_path('/path/to/file.png'),
+    permissions: [
+        Permission.read(Role.any),
+        Permission.update(Role.user('[USER_ID]')),
+        Permission.delete(Role.user('[USER_ID]')),
+    ]
+)
+```
+
+> When to set permissions: Set document/file-level permissions when you need per-resource access control. If all documents in a collection share the same rules, configure permissions at the collection/bucket level and leave document permissions empty.
+
+> Common mistakes:
+> - Forgetting permissions -- the resource becomes inaccessible to all users (including the creator)
+> - `Role.any` with `write`/`update`/`delete` -- allows any user, including unauthenticated guests, to modify or remove the resource
+> - `Permission.read(Role.any)` on sensitive data -- makes the resource publicly readable

--- a/plugins/appwrite/skills/appwrite-rust-sdk/SKILL.md
+++ b/plugins/appwrite/skills/appwrite-rust-sdk/SKILL.md
@@ -1,0 +1,420 @@
+---
+name: appwrite-rust-sdk
+description: Appwrite Rust SDK skill. Use when building server-side Rust applications with Appwrite. Covers async client setup, user management, TablesDB operations, storage, functions, permissions, queries, and error handling.
+---
+
+
+# Appwrite Rust SDK
+
+## Cline Safety
+
+- Do not run install, deploy, push, delete, migration, or project mutation commands unless the user asks for that action and confirms the exact target.
+- Keep Appwrite API keys, JWTs, session secrets, endpoint-specific credentials, and .env values out of source control, logs, summaries, and chat unless the user explicitly asks to inspect a redacted form.
+- Prefer least-privilege API keys for server-side examples and keep client-side examples limited to endpoint plus project ID.
+
+
+## Installation
+
+```bash
+cargo add appwrite
+cargo add tokio --features full
+cargo add serde_json
+```
+
+Or add dependencies manually:
+
+```toml
+[dependencies]
+appwrite = "0.3.0"
+tokio = { version = "1", features = ["full"] }
+serde_json = "1"
+```
+
+## Setting Up the Client
+
+The Rust SDK is async. Use it from a Tokio runtime and authenticate server-side with an API key.
+
+```rust
+use appwrite::Client;
+use std::env;
+
+let client = Client::new()
+    .set_endpoint("https://<REGION>.cloud.appwrite.io/v1")
+    .set_project(env::var("APPWRITE_PROJECT_ID")?)
+    .set_key(env::var("APPWRITE_API_KEY")?);
+```
+
+### Complete server skeleton
+
+```rust
+use appwrite::query::Query;
+use appwrite::services::Users;
+use appwrite::Client;
+use std::env;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let client = Client::new()
+        .set_endpoint("https://<REGION>.cloud.appwrite.io/v1")
+        .set_project(env::var("APPWRITE_PROJECT_ID")?)
+        .set_key(env::var("APPWRITE_API_KEY")?);
+
+    let users = Users::new(&client);
+    let _list = users
+        .list(Some(vec![Query::limit(25).to_string()]), None, Some(true))
+        .await?;
+
+    Ok(())
+}
+```
+
+## Code Examples
+
+### User Management
+
+```rust
+use appwrite::id::ID;
+use appwrite::query::Query;
+use appwrite::services::Users;
+
+let users = Users::new(&client);
+
+// Create user
+let _user = users
+    .create(
+        ID::unique(),
+        Some("user@example.com"),
+        None,
+        Some("password123"),
+        Some("User Name"),
+    )
+    .await?;
+
+// List users
+let _list = users
+    .list(Some(vec![Query::limit(25).to_string()]), None, Some(true))
+    .await?;
+
+// Get user
+let _fetched = users.get("[USER_ID]").await?;
+
+// Delete user
+users.delete("[USER_ID]").await?;
+```
+
+### Database Operations
+
+> Note: Use `TablesDB` for new code. Only use `Databases` if the existing project explicitly depends on the legacy Databases API.
+>
+> Rust SDK calling convention: Methods are async, use positional parameters, and represent optional API parameters as `Option<T>`. Pass `None` for optional values you are not setting.
+
+```rust
+use appwrite::id::ID;
+use appwrite::permission::Permission;
+use appwrite::query::Query;
+use appwrite::role::Role;
+use appwrite::services::TablesDB;
+use serde_json::json;
+
+let tables_db = TablesDB::new(&client);
+
+// Create database
+let _database = tables_db
+    .create(ID::unique(), "My Database", Some(true))
+    .await?;
+
+// Create table
+let _table = tables_db
+    .create_table(
+        "[DATABASE_ID]",
+        ID::unique(),
+        "articles",
+        Some(vec![
+            Permission::read(Role::any()).to_string(),
+            Permission::create(Role::users(None)).to_string(),
+        ]),
+        Some(true),
+        Some(true),
+        None,
+        None,
+    )
+    .await?;
+
+// Create row
+let _row = tables_db
+    .create_row(
+        "[DATABASE_ID]",
+        "[TABLE_ID]",
+        ID::unique(),
+        json!({
+            "title": "Hello World",
+            "done": false
+        }),
+        None,
+        None,
+    )
+    .await?;
+
+// Query rows
+let _rows = tables_db
+    .list_rows(
+        "[DATABASE_ID]",
+        "[TABLE_ID]",
+        Some(vec![
+            Query::equal("done", false).to_string(),
+            Query::limit(10).to_string(),
+        ]),
+        None,
+        Some(true),
+        None,
+    )
+    .await?;
+
+// Get row
+let _row = tables_db
+    .get_row("[DATABASE_ID]", "[TABLE_ID]", "[ROW_ID]", None, None)
+    .await?;
+
+// Update row
+let _updated = tables_db
+    .update_row(
+        "[DATABASE_ID]",
+        "[TABLE_ID]",
+        "[ROW_ID]",
+        Some(json!({ "done": true })),
+        None,
+        None,
+    )
+    .await?;
+
+// Delete row
+tables_db
+    .delete_row("[DATABASE_ID]", "[TABLE_ID]", "[ROW_ID]", None)
+    .await?;
+```
+
+#### String Column Types
+
+> Note: The legacy `string` column type is deprecated. Use explicit string column types for new tables.
+
+| Type | Max characters | Indexing | Storage |
+|------|---------------|----------|---------|
+| `varchar` | 16,383 | Full index (if size <= 768) | Inline in row |
+| `text` | 16,383 | Prefix only | Off-page |
+| `mediumtext` | 4,194,303 | Prefix only | Off-page |
+| `longtext` | 1,073,741,823 | Prefix only | Off-page |
+
+- `varchar` is stored inline and counts toward the 64 KB row size limit. Prefer it for short, indexed fields like names, slugs, and identifiers.
+- `text`, `mediumtext`, and `longtext` are stored off-page, so they do not consume the row size budget. `size` is not required for these types.
+
+```rust
+use appwrite::enums::{OrderBy, TablesDBIndexType};
+
+// Short, indexed string
+let _title = tables_db
+    .create_varchar_column(
+        "[DATABASE_ID]",
+        "[TABLE_ID]",
+        "title",
+        255,
+        true,
+        None,
+        None,
+        None,
+    )
+    .await?;
+
+// Off-page longer text
+let _summary = tables_db
+    .create_text_column("[DATABASE_ID]", "[TABLE_ID]", "summary", false, None, None, None)
+    .await?;
+
+let _body = tables_db
+    .create_mediumtext_column("[DATABASE_ID]", "[TABLE_ID]", "body", false, None, None, None)
+    .await?;
+
+let _raw_data = tables_db
+    .create_longtext_column("[DATABASE_ID]", "[TABLE_ID]", "raw_data", false, None, None, None)
+    .await?;
+
+// Index only the varchar column fully.
+let _index = tables_db
+    .create_index(
+        "[DATABASE_ID]",
+        "[TABLE_ID]",
+        "title_idx",
+        TablesDBIndexType::Key,
+        vec!["title"],
+        Some(vec![OrderBy::Asc]),
+        Some(vec![255]),
+    )
+    .await?;
+```
+
+### Query Methods
+
+`TablesDB` methods accept `Option<Vec<String>>` for queries. Convert each `Query` to a string.
+
+```rust
+use appwrite::query::Query;
+use serde_json::Value;
+
+let queries = vec![
+    Query::equal("status", "published").to_string(),
+    Query::not_equal("archived", true).to_string(),
+    Query::greater_than("views", 100).to_string(),
+    Query::less_than_equal("priority", 5).to_string(),
+    Query::between("score", 1, 100).to_string(),
+    Query::is_not_null("publishedAt").to_string(),
+    Query::search("title", "rust appwrite").to_string(),
+    Query::contains("tags", "rust").to_string(),
+    Query::order_desc("$createdAt").to_string(),
+    Query::limit(25).to_string(),
+    Query::offset(50).to_string(),
+];
+
+let multi_value = Query::equal(
+    "status",
+    Value::Array(vec![
+        Value::String("draft".to_string()),
+        Value::String("published".to_string()),
+    ]),
+)
+.to_string();
+```
+
+### File Storage
+
+```rust
+use appwrite::id::ID;
+use appwrite::input_file::InputFile;
+use appwrite::permission::Permission;
+use appwrite::query::Query;
+use appwrite::role::Role;
+use appwrite::services::Storage;
+
+let storage = Storage::new(&client);
+
+// Create bucket
+let _bucket = storage
+    .create_bucket(
+        ID::unique(),
+        "Uploads",
+        Some(vec![
+            Permission::read(Role::any()).to_string(),
+            Permission::create(Role::users(None)).to_string(),
+        ]),
+        Some(true),
+        Some(true),
+        Some(30_000_000),
+        Some(vec!["jpg".to_string(), "png".to_string(), "pdf".to_string()]),
+        None,
+        Some(true),
+        Some(true),
+        Some(true),
+    )
+    .await?;
+
+// Upload from disk
+let input = InputFile::from_path("avatar.png", Some("image/png")).await?;
+let _file = storage
+    .create_file(
+        "[BUCKET_ID]",
+        ID::unique(),
+        input,
+        Some(vec![Permission::read(Role::any()).to_string()]),
+    )
+    .await?;
+
+// Upload from bytes
+let input = InputFile::from_bytes(b"hello".to_vec(), "hello.txt", Some("text/plain"));
+let _file = storage.create_file("[BUCKET_ID]", ID::unique(), input, None).await?;
+
+// List files
+let _files = storage
+    .list_files("[BUCKET_ID]", Some(vec![Query::limit(10).to_string()]), None, Some(true))
+    .await?;
+
+// Download file bytes
+let _content = storage
+    .get_file_download("[BUCKET_ID]", "[FILE_ID]", None)
+    .await?;
+
+// Delete file
+storage.delete_file("[BUCKET_ID]", "[FILE_ID]").await?;
+```
+
+### Functions
+
+```rust
+use appwrite::enums::ExecutionMethod;
+use appwrite::query::Query;
+use appwrite::services::Functions;
+use serde_json::json;
+
+let functions = Functions::new(&client);
+
+// List functions
+let _functions = functions
+    .list(Some(vec![Query::limit(25).to_string()]), None, Some(true))
+    .await?;
+
+// Execute function
+let _execution = functions
+    .create_execution(
+        "[FUNCTION_ID]",
+        Some(r#"{"hello":"world"}"#),
+        Some(false),
+        Some("/jobs/sync"),
+        Some(ExecutionMethod::POST),
+        Some(json!({ "content-type": "application/json" })),
+        None,
+    )
+    .await?;
+
+// Get execution
+let _execution = functions
+    .get_execution("[FUNCTION_ID]", "[EXECUTION_ID]")
+    .await?;
+```
+
+### Permissions
+
+```rust
+use appwrite::permission::Permission;
+use appwrite::role::Role;
+
+let permissions = vec![
+    Permission::read(Role::any()).to_string(),
+    Permission::create(Role::users(None)).to_string(),
+    Permission::update(Role::user("[USER_ID]", None)).to_string(),
+    Permission::delete(Role::team("[TEAM_ID]", Some("owner"))).to_string(),
+];
+```
+
+### Error Handling
+
+```rust
+match users.get("[USER_ID]").await {
+    Ok(user) => {
+        let _user = user;
+    }
+    Err(error) if error.status_code() == 404 => {
+        eprintln!("User not found: {}", error.get_message());
+    }
+    Err(error) => {
+        eprintln!("Appwrite error {}: {}", error.status_code(), error.get_message());
+        return Err(Box::new(error) as Box<dyn std::error::Error>);
+    }
+}
+```
+
+## Common Pitfalls
+
+- The Rust SDK is currently a server-side SDK. Prefer TypeScript/Web, Flutter, Apple, Android, or React Native SDKs for browser/mobile client auth flows.
+- Always `await` service calls.
+- Pass `None` for optional parameters you are not using.
+- Use `TablesDB`, not legacy `Databases`, for new database code.
+- Convert queries with `.to_string()` before passing them to APIs that expect `Option<Vec<String>>`.
+- Use `serde_json::json!({...})` for row data and JSON bodies.
+- Use `InputFile::from_path(...).await?` or `InputFile::from_bytes(...)` for uploads.

--- a/plugins/appwrite/skills/appwrite-sdk/SKILL.md
+++ b/plugins/appwrite/skills/appwrite-sdk/SKILL.md
@@ -1,52 +1,38 @@
 ---
 name: appwrite-sdk
-description: Use when writing Appwrite SDK code for web, mobile, backend, or server-side apps. Covers client setup, auth, storage, realtime, functions, and server-side API key boundaries.
+description: Use when the user asks generally for Appwrite SDK help and the implementation language is unclear or mixed. Route to the language-specific Appwrite SDK skills after identifying the target runtime.
 ---
 
-# Appwrite SDK
+# Appwrite SDK Router
 
-Use this skill when the task involves Appwrite SDK code in TypeScript, JavaScript, React Native, Flutter, Dart, Kotlin, Swift, Python, Ruby, Go, Rust, .NET, PHP, or another supported runtime.
+Use this skill as the compatibility and dispatch layer for Appwrite SDK work.
+When the language or runtime is known, load the matching focused skill:
 
-## Client Boundaries
+| Runtime | Skill |
+| --- | --- |
+| TypeScript, JavaScript, React Native, Node.js, Deno | `appwrite-typescript-sdk` |
+| Flutter, Dart | `appwrite-dart-sdk` |
+| Android, Kotlin/JVM | `appwrite-kotlin-sdk` |
+| iOS, macOS, Swift, server-side Swift | `appwrite-swift-sdk` |
+| Python, Django, Flask, FastAPI | `appwrite-python-sdk` |
+| Ruby, Rails, Sinatra | `appwrite-ruby-sdk` |
+| Go | `appwrite-go-sdk` |
+| Rust | `appwrite-rust-sdk` |
+| .NET, C#, ASP.NET, Blazor | `appwrite-dotnet-sdk` |
+| PHP, Laravel, Symfony | `appwrite-php-sdk` |
+
+## How To Route
+
+1. Identify the target runtime from the repository, package files, existing imports, or the user's request.
+2. If the runtime is ambiguous, ask a short clarification before writing SDK code.
+3. Load the focused language skill and follow its examples.
+4. For database schema, table, row, permission, index, or migration design, also use `appwrite-tablesdb`.
+5. For CLI setup, project pull/push, function deployment, or site deployment, use `appwrite-cli` and `appwrite-deployments`.
+6. For live project inspection or mutation through MCP, use `appwrite-mcp`.
+
+## Boundaries
 
 - Browser and mobile clients should use endpoint plus project ID only.
-- Server-side clients can use endpoint, project ID, and an API key loaded from environment variables.
-- Never hard-code API keys, JWTs, session secrets, or project credentials in source files.
-- Prefer the SDK idioms already used in the repository before changing style.
-- For new database work, prefer TablesDB APIs. Use legacy Databases APIs only when the existing codebase already depends on them or the user explicitly asks for it.
-
-## Setup Pattern
-
-When adding SDK setup, identify the runtime first:
-
-- Web: use the browser SDK package and create `Client`, `Account`, `TablesDB`, `Storage`, and `Realtime` from the client.
-- React Native: use the React Native SDK package. Do not use browser OAuth session helpers that rely on regular web redirects.
-- Node.js or server runtimes: use the server SDK package and read `APPWRITE_ENDPOINT`, `APPWRITE_PROJECT_ID`, and `APPWRITE_API_KEY` from environment variables.
-- Mobile or desktop native runtimes: use the platform SDK and follow platform-specific file and OAuth flows.
-
-## Auth Guidance
-
-- Use account/session APIs only on client-side user flows.
-- Use users/admin APIs only from trusted server-side code with an API key.
-- For React Native OAuth, use a token plus deep-link flow instead of browser-only OAuth session helpers.
-- Avoid creating admin users, deleting users, or modifying auth providers unless the user explicitly requested that operation.
-
-## Storage And Realtime
-
-- For uploads, use the platform-native file input type expected by the SDK.
-- Validate bucket IDs, file IDs, MIME type assumptions, and permissions before writing code.
-- Subscribe to realtime channels narrowly. Unsubscribe on teardown or component unmount.
-- Do not subscribe to broad wildcard channels unless the user asks and the blast radius is clear.
-
-## Functions
-
-- Treat function executions as server-side side effects.
-- Inspect payload shape, timeout assumptions, and auth context before invoking a function.
-- Do not deploy or execute production functions without explicit user approval.
-
-## Implementation Checklist
-
-- Confirm endpoint, project ID, database ID, table ID, bucket ID, and function ID sources.
-- Preserve existing SDK package versions and code style where possible.
-- Use environment variables for secrets and update local examples with placeholders only.
-- Add error handling around Appwrite SDK calls so API errors surface with useful context.
+- API keys belong in trusted server-side code or user-managed environment variables.
+- Do not print, commit, or log Appwrite API keys, JWTs, session secrets, `.env` values, or credential-bearing config.
+- Ask for explicit confirmation before project mutations, deletes, deployments, permission changes, function executions, or migrations.

--- a/plugins/appwrite/skills/appwrite-sdk/SKILL.md
+++ b/plugins/appwrite/skills/appwrite-sdk/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: appwrite-sdk
+description: Use when writing Appwrite SDK code for web, mobile, backend, or server-side apps. Covers client setup, auth, storage, realtime, functions, and server-side API key boundaries.
+---
+
+# Appwrite SDK
+
+Use this skill when the task involves Appwrite SDK code in TypeScript, JavaScript, React Native, Flutter, Dart, Kotlin, Swift, Python, Ruby, Go, Rust, .NET, PHP, or another supported runtime.
+
+## Client Boundaries
+
+- Browser and mobile clients should use endpoint plus project ID only.
+- Server-side clients can use endpoint, project ID, and an API key loaded from environment variables.
+- Never hard-code API keys, JWTs, session secrets, or project credentials in source files.
+- Prefer the SDK idioms already used in the repository before changing style.
+- For new database work, prefer TablesDB APIs. Use legacy Databases APIs only when the existing codebase already depends on them or the user explicitly asks for it.
+
+## Setup Pattern
+
+When adding SDK setup, identify the runtime first:
+
+- Web: use the browser SDK package and create `Client`, `Account`, `TablesDB`, `Storage`, and `Realtime` from the client.
+- React Native: use the React Native SDK package. Do not use browser OAuth session helpers that rely on regular web redirects.
+- Node.js or server runtimes: use the server SDK package and read `APPWRITE_ENDPOINT`, `APPWRITE_PROJECT_ID`, and `APPWRITE_API_KEY` from environment variables.
+- Mobile or desktop native runtimes: use the platform SDK and follow platform-specific file and OAuth flows.
+
+## Auth Guidance
+
+- Use account/session APIs only on client-side user flows.
+- Use users/admin APIs only from trusted server-side code with an API key.
+- For React Native OAuth, use a token plus deep-link flow instead of browser-only OAuth session helpers.
+- Avoid creating admin users, deleting users, or modifying auth providers unless the user explicitly requested that operation.
+
+## Storage And Realtime
+
+- For uploads, use the platform-native file input type expected by the SDK.
+- Validate bucket IDs, file IDs, MIME type assumptions, and permissions before writing code.
+- Subscribe to realtime channels narrowly. Unsubscribe on teardown or component unmount.
+- Do not subscribe to broad wildcard channels unless the user asks and the blast radius is clear.
+
+## Functions
+
+- Treat function executions as server-side side effects.
+- Inspect payload shape, timeout assumptions, and auth context before invoking a function.
+- Do not deploy or execute production functions without explicit user approval.
+
+## Implementation Checklist
+
+- Confirm endpoint, project ID, database ID, table ID, bucket ID, and function ID sources.
+- Preserve existing SDK package versions and code style where possible.
+- Use environment variables for secrets and update local examples with placeholders only.
+- Add error handling around Appwrite SDK calls so API errors surface with useful context.

--- a/plugins/appwrite/skills/appwrite-swift-sdk/SKILL.md
+++ b/plugins/appwrite/skills/appwrite-swift-sdk/SKILL.md
@@ -1,0 +1,488 @@
+---
+name: appwrite-swift-sdk
+description: Appwrite Swift SDK skill. Use when building native Apple-platform apps or server-side Swift applications with Appwrite. Covers auth, database queries, uploads, realtime, and server-side admin via API keys.
+---
+
+
+# Appwrite Swift SDK
+
+## Cline Safety
+
+- Do not run install, deploy, push, delete, migration, or project mutation commands unless the user asks for that action and confirms the exact target.
+- Keep Appwrite API keys, JWTs, session secrets, endpoint-specific credentials, and .env values out of source control, logs, summaries, and chat unless the user explicitly asks to inspect a redacted form.
+- Prefer least-privilege API keys for server-side examples and keep client-side examples limited to endpoint plus project ID.
+
+
+## Installation
+
+```swift
+// Swift Package Manager -- Package.swift
+.package(url: "https://github.com/appwrite/sdk-for-swift", branch: "main")
+```
+
+## Setting Up the Client
+
+### Client-side (Apple platforms)
+
+```swift
+import Appwrite
+
+let client = Client()
+    .setEndpoint("https://<REGION>.cloud.appwrite.io/v1")
+    .setProject("[PROJECT_ID]")
+```
+
+### Server-side (Swift)
+
+```swift
+import Appwrite
+
+let client = Client()
+    .setEndpoint("https://<REGION>.cloud.appwrite.io/v1")
+    .setProject(ProcessInfo.processInfo.environment["APPWRITE_PROJECT_ID"]!)
+    .setKey(ProcessInfo.processInfo.environment["APPWRITE_API_KEY"]!)
+```
+
+## Code Examples
+
+### Authentication (client-side)
+
+```swift
+let account = Account(client)
+
+// Signup
+let user = try await account.create(userId: ID.unique(), email: "user@example.com", password: "password123", name: "User Name")
+
+// Login
+let session = try await account.createEmailPasswordSession(email: "user@example.com", password: "password123")
+
+// OAuth
+try await account.createOAuth2Session(provider: .google)
+
+// Get current user
+let me = try await account.get()
+
+// Logout
+try await account.deleteSession(sessionId: "current")
+```
+
+### User Management (server-side)
+
+```swift
+let users = Users(client)
+
+// Create user
+let user = try await users.create(userId: ID.unique(), email: "user@example.com", password: "password123", name: "User Name")
+
+// List users
+let list = try await users.list(queries: [Query.limit(25)])
+
+// Get user
+let fetched = try await users.get(userId: "[USER_ID]")
+
+// Delete user
+try await users.delete(userId: "[USER_ID]")
+```
+
+### Database Operations
+
+> Note: Use `TablesDB` (not the deprecated `Databases` class) for all new code. Only use `Databases` if the existing codebase already relies on it or the user explicitly requests it.
+>
+> Tip: Prefer named parameters (e.g., `databaseId: "..."`) for all SDK method calls. Only use positional arguments if the existing codebase already uses them or the user explicitly requests it.
+
+```swift
+let tablesDB = TablesDB(client)
+
+// Create database (server-side only)
+let db = try await tablesDB.create(databaseId: ID.unique(), name: "My Database")
+
+// Create row
+let doc = try await tablesDB.createRow(databaseId: "[DATABASE_ID]", tableId: "[TABLE_ID]", rowId: ID.unique(), data: [
+    "title": "Hello",
+    "done": false
+])
+
+// Query rows
+let results = try await tablesDB.listRows(databaseId: "[DATABASE_ID]", tableId: "[TABLE_ID]", queries: [
+    Query.equal("done", value: false),
+    Query.limit(10)
+])
+
+// Get row
+let row = try await tablesDB.getRow(databaseId: "[DATABASE_ID]", tableId: "[TABLE_ID]", rowId: "[ROW_ID]")
+
+// Update row
+try await tablesDB.updateRow(databaseId: "[DATABASE_ID]", tableId: "[TABLE_ID]", rowId: "[ROW_ID]", data: ["done": true])
+
+// Delete row
+try await tablesDB.deleteRow(databaseId: "[DATABASE_ID]", tableId: "[TABLE_ID]", rowId: "[ROW_ID]")
+```
+
+#### String Column Types
+
+> Note: The legacy `string` type is deprecated. Use explicit column types for all new columns.
+
+| Type | Max characters | Indexing | Storage |
+|------|---------------|----------|---------|
+| `varchar` | 16,383 | Full index (if size <= 768) | Inline in row |
+| `text` | 16,383 | Prefix only | Off-page |
+| `mediumtext` | 4,194,303 | Prefix only | Off-page |
+| `longtext` | 1,073,741,823 | Prefix only | Off-page |
+
+- `varchar` is stored inline and counts towards the 64 KB row size limit. Prefer for short, indexed fields like names, slugs, or identifiers.
+- `text`, `mediumtext`, and `longtext` are stored off-page (only a 20-byte pointer lives in the row), so they don't consume the row size budget. `size` is not required for these types.
+
+```swift
+// Create table with explicit string column types
+try await tablesDB.createTable(
+    databaseId: "[DATABASE_ID]",
+    tableId: ID.unique(),
+    name: "articles",
+    columns: [
+        ["key": "title",    "type": "varchar",    "size": 255, "required": true],
+        ["key": "summary",  "type": "text",                    "required": false],
+        ["key": "body",     "type": "mediumtext",              "required": false],
+        ["key": "raw_data", "type": "longtext",                "required": false],
+    ]
+)
+```
+
+### Query Methods
+
+```swift
+// Filtering
+Query.equal("field", value: "value")          // == (or pass array for IN)
+Query.notEqual("field", value: "value")       // !=
+Query.lessThan("field", value: 100)           // <
+Query.lessThanEqual("field", value: 100)      // <=
+Query.greaterThan("field", value: 100)        // >
+Query.greaterThanEqual("field", value: 100)   // >=
+Query.between("field", start: 1, end: 100)    // 1 <= field <= 100
+Query.isNull("field")                         // is null
+Query.isNotNull("field")                      // is not null
+Query.startsWith("field", value: "prefix")    // starts with
+Query.endsWith("field", value: "suffix")      // ends with
+Query.contains("field", value: "sub")         // contains
+Query.search("field", value: "keywords")      // full-text search (requires index)
+
+// Sorting
+Query.orderAsc("field")
+Query.orderDesc("field")
+
+// Pagination
+Query.limit(25)                               // max rows (default 25, max 100)
+Query.offset(0)                               // skip N rows
+Query.cursorAfter("[ROW_ID]")                 // cursor pagination (preferred)
+Query.cursorBefore("[ROW_ID]")
+
+// Selection & Logic
+Query.select(["field1", "field2"])
+Query.or([Query.equal("a", value: 1), Query.equal("b", value: 2)])   // OR
+Query.and([Query.greaterThan("age", value: 18), Query.lessThan("age", value: 65)])  // AND (default)
+```
+
+### File Storage
+
+```swift
+let storage = Storage(client)
+
+// Upload file
+let file = try await storage.createFile(bucketId: "[BUCKET_ID]", fileId: ID.unique(), file: InputFile.fromPath("/path/to/file.png"))
+
+// List files
+let files = try await storage.listFiles(bucketId: "[BUCKET_ID]")
+
+// Delete file
+try await storage.deleteFile(bucketId: "[BUCKET_ID]", fileId: "[FILE_ID]")
+```
+
+#### InputFile Factory Methods
+
+```swift
+InputFile.fromPath("/path/to/file.png")                    // from filesystem path
+InputFile.fromData(data, filename: "file.png", mimeType: "image/png")  // from Data
+```
+
+### Teams
+
+```swift
+let teams = Teams(client)
+
+// Create team
+let team = try await teams.create(teamId: ID.unique(), name: "Engineering")
+
+// List teams
+let list = try await teams.list()
+
+// Create membership (invite user by email)
+let membership = try await teams.createMembership(
+    teamId: "[TEAM_ID]",
+    roles: ["editor"],
+    email: "user@example.com"
+)
+
+// List memberships
+let members = try await teams.listMemberships(teamId: "[TEAM_ID]")
+
+// Update membership roles
+try await teams.updateMembership(teamId: "[TEAM_ID]", membershipId: "[MEMBERSHIP_ID]", roles: ["admin"])
+
+// Delete team
+try await teams.delete(teamId: "[TEAM_ID]")
+```
+
+> Role-based access: Use `Role.team("[TEAM_ID]")` for all team members or `Role.team("[TEAM_ID]", "editor")` for a specific team role when setting permissions.
+
+### Real-time Subscriptions (client-side)
+
+```swift
+let realtime = Realtime(client)
+
+// Subscribe to row changes
+let subscription = try await realtime.subscribe(channels: [
+    Channel.tablesdb("[DATABASE_ID]").table("[TABLE_ID]").row()
+]) { response in
+    print(response.events)   // e.g. ["tablesdb.*.tables.*.rows.*.create"]
+    print(response.payload)  // the affected resource
+}
+
+// Subscribe to multiple channels
+let multi = try await realtime.subscribe(channels: [
+    Channel.tablesdb("[DATABASE_ID]").table("[TABLE_ID]").row(),
+    Channel.files(),
+]) { response in /* ... */ }
+
+// Cleanup
+try await subscription.close()
+```
+
+Available channels:
+
+| Channel | Description |
+|---------|-------------|
+| `account` | Changes to the authenticated user's account |
+| `tablesdb.[DB_ID].tables.[TABLE_ID].rows` | All rows in a table |
+| `tablesdb.[DB_ID].tables.[TABLE_ID].rows.[ROW_ID]` | A specific row |
+| `buckets.[BUCKET_ID].files` | All files in a bucket |
+| `buckets.[BUCKET_ID].files.[FILE_ID]` | A specific file |
+| `teams` | Changes to teams the user belongs to |
+| `teams.[TEAM_ID]` | A specific team |
+| `memberships` | The user's team memberships |
+| `functions.[FUNCTION_ID].executions` | Function execution updates |
+
+Response fields: `events` (array), `payload` (resource), `channels` (matched), `timestamp` (ISO 8601).
+
+### Serverless Functions (server-side)
+
+```swift
+let functions = Functions(client)
+
+// Execute function
+let execution = try await functions.createExecution(functionId: "[FUNCTION_ID]", body: "{\"key\": \"value\"}")
+
+// List executions
+let executions = try await functions.listExecutions(functionId: "[FUNCTION_ID]")
+```
+
+#### Writing a Function Handler (Swift runtime)
+
+```swift
+// Sources/main.swift -- Appwrite Function entry point
+func main(context: RuntimeContext) async throws -> RuntimeOutput {
+    // context.req.body        -- raw body (String)
+    // context.req.bodyJson    -- parsed JSON ([String: Any]?)
+    // context.req.headers     -- headers ([String: String])
+    // context.req.method      -- HTTP method
+    // context.req.path        -- URL path
+    // context.req.query       -- query params ([String: String])
+
+    context.log("Processing: \(context.req.method) \(context.req.path)")
+
+    if context.req.method == "GET" {
+        return context.res.json(["message": "Hello from Appwrite Function!"])
+    }
+
+    return context.res.json(["success": true])       // JSON
+    // context.res.text("Hello")                     // plain text
+    // context.res.empty()                           // 204
+    // context.res.redirect("https://...")            // 302
+}
+```
+
+### Server-Side Rendering (SSR) Authentication
+
+SSR apps using server-side Swift (Vapor, Hummingbird, etc.) use the server SDK to handle auth. You need two clients:
+
+- Admin client -- uses an API key, creates sessions, bypasses rate limits (reusable singleton)
+- Session client -- uses a session cookie, acts on behalf of a user (create per-request, never share)
+
+```swift
+import Appwrite
+
+// Admin client (reusable)
+let adminClient = Client()
+    .setEndpoint("https://<REGION>.cloud.appwrite.io/v1")
+    .setProject("[PROJECT_ID]")
+    .setKey(Environment.get("APPWRITE_API_KEY")!)
+
+// Session client (create per-request)
+let sessionClient = Client()
+    .setEndpoint("https://<REGION>.cloud.appwrite.io/v1")
+    .setProject("[PROJECT_ID]")
+
+if let session = req.cookies["a_session_[PROJECT_ID]"]?.string {
+    sessionClient.setSession(session)
+}
+```
+
+#### Email/Password Login (Vapor)
+
+```swift
+app.post("login") { req async throws -> Response in
+    let body = try req.content.decode(LoginRequest.self)
+    let account = Account(adminClient)
+    let session = try await account.createEmailPasswordSession(
+        email: body.email,
+        password: body.password
+    )
+
+    // Cookie name must be a_session_<PROJECT_ID>
+    let response = Response(status: .ok, body: .init(string: "{\"success\": true}"))
+    response.cookies["a_session_[PROJECT_ID]"] = HTTPCookies.Value(
+        string: session.secret,
+        isHTTPOnly: true,
+        isSecure: true,
+        sameSite: .strict,
+        path: "/"
+    )
+    return response
+}
+```
+
+#### Authenticated Requests
+
+```swift
+app.get("user") { req async throws -> Response in
+    guard let session = req.cookies["a_session_[PROJECT_ID]"]?.string else {
+        throw Abort(.unauthorized)
+    }
+
+    let sessionClient = Client()
+        .setEndpoint("https://<REGION>.cloud.appwrite.io/v1")
+        .setProject("[PROJECT_ID]")
+        .setSession(session)
+
+    let account = Account(sessionClient)
+    let user = try await account.get()
+    // Return user as JSON
+}
+```
+
+#### OAuth2 SSR Flow
+
+```swift
+// Step 1: Redirect to OAuth provider
+app.get("oauth") { req async throws -> Response in
+    let account = Account(adminClient)
+    let redirectUrl = try await account.createOAuth2Token(
+        provider: .github,
+        success: "https://example.com/oauth/success",
+        failure: "https://example.com/oauth/failure"
+    )
+    return req.redirect(to: redirectUrl)
+}
+
+// Step 2: Handle callback -- exchange token for session
+app.get("oauth", "success") { req async throws -> Response in
+    let userId = try req.query.get(String.self, at: "userId")
+    let secret = try req.query.get(String.self, at: "secret")
+
+    let account = Account(adminClient)
+    let session = try await account.createSession(userId: userId, secret: secret)
+
+    let response = Response(status: .ok, body: .init(string: "{\"success\": true}"))
+    response.cookies["a_session_[PROJECT_ID]"] = HTTPCookies.Value(
+        string: session.secret,
+        isHTTPOnly: true, isSecure: true, sameSite: .strict, path: "/"
+    )
+    return response
+}
+```
+
+> Cookie security: Always use `isHTTPOnly`, `isSecure`, and `sameSite: .strict` to prevent XSS. The cookie name must be `a_session_<PROJECT_ID>`.
+
+> Forwarding user agent: Call `sessionClient.setForwardedUserAgent(req.headers.first(name: .userAgent) ?? "")` to record the end-user's browser info for debugging and security.
+
+## Error Handling
+
+```swift
+import Appwrite
+// AppwriteException is included in the main module
+
+do {
+    let row = try await tablesDB.getRow(databaseId: "[DATABASE_ID]", tableId: "[TABLE_ID]", rowId: "[ROW_ID]")
+} catch let error as AppwriteException {
+    print(error.message)     // human-readable message
+    print(error.code)        // HTTP status code (Int)
+    print(error.type)        // error type (e.g. "document_not_found")
+    print(error.response)    // full response body
+}
+```
+
+Common error codes:
+
+| Code | Meaning |
+|------|---------|
+| `401` | Unauthorized -- missing or invalid session/API key |
+| `403` | Forbidden -- insufficient permissions |
+| `404` | Not found -- resource does not exist |
+| `409` | Conflict -- duplicate ID or unique constraint |
+| `429` | Rate limited -- too many requests |
+
+## Permissions & Roles (Critical)
+
+Appwrite uses permission strings to control access to resources. Each permission pairs an action (`read`, `update`, `delete`, `create`, or `write` which grants create + update + delete) with a role target. By default, no user has access unless permissions are explicitly set at the document/file level or inherited from the collection/bucket settings. Permissions are arrays of strings built with the `Permission` and `Role` helpers.
+
+```swift
+import Appwrite
+// Permission and Role are included in the main module import
+```
+
+### Database Row with Permissions
+
+```swift
+let doc = try await tablesDB.createRow(
+    databaseId: "[DATABASE_ID]",
+    tableId: "[TABLE_ID]",
+    rowId: ID.unique(),
+    data: ["title": "Hello World"],
+    permissions: [
+        Permission.read(Role.user("[USER_ID]")),     // specific user can read
+        Permission.update(Role.user("[USER_ID]")),   // specific user can update
+        Permission.read(Role.team("[TEAM_ID]")),     // all team members can read
+        Permission.read(Role.any()),                 // anyone (including guests) can read
+    ]
+)
+```
+
+### File Upload with Permissions
+
+```swift
+let file = try await storage.createFile(
+    bucketId: "[BUCKET_ID]",
+    fileId: ID.unique(),
+    file: InputFile.fromPath("/path/to/file.png"),
+    permissions: [
+        Permission.read(Role.any()),
+        Permission.update(Role.user("[USER_ID]")),
+        Permission.delete(Role.user("[USER_ID]")),
+    ]
+)
+```
+
+> When to set permissions: Set document/file-level permissions when you need per-resource access control. If all documents in a collection share the same rules, configure permissions at the collection/bucket level and leave document permissions empty.
+
+> Common mistakes:
+> - Forgetting permissions -- the resource becomes inaccessible to all users (including the creator)
+> - `Role.any()` with `write`/`update`/`delete` -- allows any user, including unauthenticated guests, to modify or remove the resource
+> - `Permission.read(Role.any())` on sensitive data -- makes the resource publicly readable

--- a/plugins/appwrite/skills/appwrite-tablesdb/SKILL.md
+++ b/plugins/appwrite/skills/appwrite-tablesdb/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: appwrite-tablesdb
+description: Use when designing or modifying Appwrite TablesDB databases, tables, rows, queries, permissions, indexes, and migrations.
+---
+
+# Appwrite TablesDB
+
+Use this skill for Appwrite database, table, row, query, schema, permission, and migration tasks.
+
+## API Choice
+
+- Prefer TablesDB for new work.
+- Use legacy Databases APIs only when the existing codebase already uses them or the user explicitly asks for legacy compatibility.
+- Do not mix TablesDB and legacy Databases patterns in the same feature unless migration requires it.
+
+## Schema Design
+
+- Identify database ID, table ID, row ID strategy, column names, column types, required flags, defaults, and relationships before writing code.
+- Use explicit string column types for new columns.
+- Prefer short indexed strings for identifiers, slugs, names, and enum-like values.
+- Use longer text column types for large unindexed content.
+- Avoid storing secrets, access tokens, or raw credentials in user-visible rows.
+
+## Queries
+
+- Keep query filters narrow and deterministic.
+- Add limits and pagination for list operations.
+- Prefer indexed fields for frequently filtered or sorted queries.
+- Preserve existing repository query helper style before introducing new abstractions.
+
+## Permissions
+
+- Be explicit about read, create, update, and delete permissions.
+- Do not make rows, tables, or buckets public by default.
+- Confirm whether access should be user-owned, team-owned, role-based, or admin-only.
+- For server-side admin code, keep API key usage on the server.
+
+## Migration Safety
+
+- Inspect existing schema and data access code before changing column names or types.
+- Plan backwards-compatible changes when production data may exist.
+- Avoid destructive table, column, index, or row changes without user confirmation.
+- When a migration script is needed, make it idempotent where practical and log what it changes without logging secrets.

--- a/plugins/appwrite/skills/appwrite-typescript-sdk/SKILL.md
+++ b/plugins/appwrite/skills/appwrite-typescript-sdk/SKILL.md
@@ -1,0 +1,712 @@
+---
+name: appwrite-typescript-sdk
+description: Appwrite TypeScript SDK skill. Use when building browser JavaScript/TypeScript apps, React Native mobile apps, or server-side Node.js/Deno backends with Appwrite. Covers client-side auth, database queries, file uploads, realtime subscriptions, and server-side admin via API keys.
+---
+
+
+# Appwrite TypeScript SDK
+
+## Cline Safety
+
+- Do not run install, deploy, push, delete, migration, or project mutation commands unless the user asks for that action and confirms the exact target.
+- Keep Appwrite API keys, JWTs, session secrets, endpoint-specific credentials, and .env values out of source control, logs, summaries, and chat unless the user explicitly asks to inspect a redacted form.
+- Prefer least-privilege API keys for server-side examples and keep client-side examples limited to endpoint plus project ID.
+
+
+## Installation
+
+```bash
+# Web
+npm install appwrite
+
+# React Native
+npm install react-native-appwrite
+
+# Node.js / Deno
+npm install node-appwrite
+```
+
+## Setting Up the Client
+
+### Client-side (Web / React Native)
+
+```typescript
+// Web
+import { Client, Account, TablesDB, Storage, ID, Query } from 'appwrite';
+
+// React Native
+import { Client, Account, TablesDB, Storage, ID, Query } from 'react-native-appwrite';
+
+const client = new Client()
+    .setEndpoint('https://<REGION>.cloud.appwrite.io/v1')
+    .setProject('[PROJECT_ID]');
+```
+
+### Server-side (Node.js / Deno)
+
+```typescript
+import { Client, Users, TablesDB, Storage, Functions, ID, Query } from 'node-appwrite';
+
+const client = new Client()
+    .setEndpoint('https://<REGION>.cloud.appwrite.io/v1')
+    .setProject(process.env.APPWRITE_PROJECT_ID)
+    .setKey(process.env.APPWRITE_API_KEY);
+```
+
+## Code Examples
+
+### Authentication (client-side)
+
+```typescript
+const account = new Account(client);
+
+// Email signup
+await account.create({
+    userId: ID.unique(),
+    email: 'user@example.com',
+    password: 'password123',
+    name: 'User Name'
+});
+
+// Email login
+const session = await account.createEmailPasswordSession({
+    email: 'user@example.com',
+    password: 'password123'
+});
+
+// OAuth login (Web)
+account.createOAuth2Session({
+    provider: OAuthProvider.Github,
+    success: 'https://example.com/success',
+    failure: 'https://example.com/fail',
+    scopes: ['repo', 'user'] // optional -- provider-specific scopes
+});
+
+// Get current user
+const user = await account.get();
+
+// Logout
+await account.deleteSession({ sessionId: 'current' });
+```
+
+### OAuth 2 Login (React Native)
+
+> Important: `createOAuth2Session()` does not work on React Native. You must use `createOAuth2Token()` with deep linking instead.
+
+#### Setup
+
+Install the required dependencies:
+
+```bash
+npx expo install react-native-appwrite react-native-url-polyfill
+npm install expo-auth-session expo-web-browser expo-linking
+```
+
+Set the URL scheme in your `app.json`:
+
+```json
+{
+  "expo": {
+    "scheme": "appwrite-callback-[PROJECT_ID]"
+  }
+}
+```
+
+#### OAuth Flow
+
+```typescript
+import { Client, Account, OAuthProvider } from 'react-native-appwrite';
+import { makeRedirectUri } from 'expo-auth-session';
+import * as WebBrowser from 'expo-web-browser';
+
+const client = new Client()
+    .setEndpoint('https://<REGION>.cloud.appwrite.io/v1')
+    .setProject('[PROJECT_ID]');
+
+const account = new Account(client);
+
+async function oauthLogin(provider: OAuthProvider) {
+    // Create deep link that works across Expo environments
+    const deepLink = new URL(makeRedirectUri({ preferLocalhost: true }));
+    const scheme = `${deepLink.protocol}//`; // e.g. 'exp://' or 'appwrite-callback-[PROJECT_ID]://'
+
+    // Get the OAuth login URL
+    const loginUrl = await account.createOAuth2Token({
+        provider,
+        success: `${deepLink}`,
+        failure: `${deepLink}`,
+    });
+
+    // Open browser and listen for the scheme redirect
+    const result = await WebBrowser.openAuthSessionAsync(`${loginUrl}`, scheme);
+
+    if (result.type !== 'success') return;
+
+    // Extract credentials from the redirect URL
+    const url = new URL(result.url);
+    const secret = url.searchParams.get('secret');
+    const userId = url.searchParams.get('userId');
+
+    // Create session with the OAuth credentials
+    await account.createSession({ userId, secret });
+}
+
+// Usage
+await oauthLogin(OAuthProvider.Github);
+await oauthLogin(OAuthProvider.Google);
+```
+
+### User Management (server-side)
+
+```typescript
+const users = new Users(client);
+
+// Create user
+const user = await users.create({
+    userId: ID.unique(),
+    email: 'user@example.com',
+    password: 'password123',
+    name: 'User Name'
+});
+
+// List users
+const list = await users.list({ queries: [Query.limit(25)] });
+
+// Get user
+const fetched = await users.get({ userId: '[USER_ID]' });
+
+// Delete user
+await users.delete({ userId: '[USER_ID]' });
+```
+
+### Database Operations
+
+> Note: Use `TablesDB` (not the deprecated `Databases` class) for all new code. Only use `Databases` if the existing codebase already relies on it or the user explicitly requests it.
+>
+> Tip: Prefer the object-params calling style (e.g., `{ databaseId: '...' }`) for all SDK method calls. Only use positional arguments if the existing codebase already uses them or the user explicitly requests it.
+
+```typescript
+const tablesDB = new TablesDB(client);
+
+// Create database (server-side only)
+const db = await tablesDB.create({ databaseId: ID.unique(), name: 'My Database' });
+
+// Create table (server-side only)
+const col = await tablesDB.createTable({
+    databaseId: '[DATABASE_ID]',
+    tableId: ID.unique(),
+    name: 'My Table'
+});
+
+// Create row
+const doc = await tablesDB.createRow({
+    databaseId: '[DATABASE_ID]',
+    tableId: '[TABLE_ID]',
+    rowId: ID.unique(),
+    data: { title: 'Hello World', content: 'Example content' }
+});
+
+// List rows with query
+const results = await tablesDB.listRows({
+    databaseId: '[DATABASE_ID]',
+    tableId: '[TABLE_ID]',
+    queries: [Query.equal('status', 'active'), Query.limit(10)]
+});
+
+// Get row
+const row = await tablesDB.getRow({
+    databaseId: '[DATABASE_ID]',
+    tableId: '[TABLE_ID]',
+    rowId: '[ROW_ID]'
+});
+
+// Update row
+await tablesDB.updateRow({
+    databaseId: '[DATABASE_ID]',
+    tableId: '[TABLE_ID]',
+    rowId: '[ROW_ID]',
+    data: { title: 'Updated Title' }
+});
+
+// Delete row
+await tablesDB.deleteRow({
+    databaseId: '[DATABASE_ID]',
+    tableId: '[TABLE_ID]',
+    rowId: '[ROW_ID]'
+});
+```
+
+#### String Column Types
+
+> Note: The legacy `string` type is deprecated. Use explicit column types for all new columns.
+
+| Type | Max characters | Indexing | Storage |
+|------|---------------|----------|---------|
+| `varchar` | 16,383 | Full index (if size <= 768) | Inline in row |
+| `text` | 16,383 | Prefix only | Off-page |
+| `mediumtext` | 4,194,303 | Prefix only | Off-page |
+| `longtext` | 1,073,741,823 | Prefix only | Off-page |
+
+- `varchar` is stored inline and counts towards the 64 KB row size limit. Prefer for short, indexed fields like names, slugs, or identifiers.
+- `text`, `mediumtext`, and `longtext` are stored off-page (only a 20-byte pointer lives in the row), so they don't consume the row size budget. `size` is not required for these types.
+
+```typescript
+// Create table with explicit string column types
+await tablesDB.createTable({
+    databaseId: '[DATABASE_ID]',
+    tableId: ID.unique(),
+    name: 'articles',
+    columns: [
+        { key: 'title',    type: 'varchar',    size: 255, required: true  },  // inline, fully indexable
+        { key: 'summary',  type: 'text',                  required: false },  // off-page, prefix index only
+        { key: 'body',     type: 'mediumtext',            required: false },  // up to ~4 M chars
+        { key: 'raw_data', type: 'longtext',              required: false },  // up to ~1 B chars
+    ]
+});
+```
+
+#### TypeScript Generics
+
+```typescript
+import { Models } from 'appwrite';
+// Server-side: import from 'node-appwrite'
+
+// Define a typed interface for your row data
+interface Todo {
+    title: string;
+    done: boolean;
+    priority: number;
+}
+
+// listRows returns Models.DocumentList<Models.Document> by default
+// Cast or use generics for typed results
+const results = await tablesDB.listRows({
+    databaseId: '[DATABASE_ID]',
+    tableId: '[TABLE_ID]',
+    queries: [Query.equal('done', false)]
+});
+
+// Each document includes built-in fields alongside your data
+const doc = results.documents[0];
+doc.$id;            // string -- unique row ID
+doc.$createdAt;     // string -- ISO 8601 creation timestamp
+doc.$updatedAt;     // string -- ISO 8601 update timestamp
+doc.$permissions;   // string[] -- permission strings
+doc.$databaseId;    // string
+doc.$collectionId;  // string
+
+// Common model types
+// Models.User<Preferences>  -- user account
+// Models.Session             -- auth session
+// Models.File                -- storage file metadata
+// Models.Team                -- team object
+// Models.Execution           -- function execution result
+// Models.DocumentList<T>     -- paginated list with total count
+```
+
+### Query Methods
+
+```typescript
+// Filtering
+Query.equal('field', 'value')           // field == value (or pass array for IN)
+Query.notEqual('field', 'value')        // field != value
+Query.lessThan('field', 100)            // field < value
+Query.lessThanEqual('field', 100)       // field <= value
+Query.greaterThan('field', 100)         // field > value
+Query.greaterThanEqual('field', 100)    // field >= value
+Query.between('field', 1, 100)          // 1 <= field <= 100
+Query.isNull('field')                   // field is null
+Query.isNotNull('field')                // field is not null
+Query.startsWith('field', 'prefix')     // string starts with prefix
+Query.endsWith('field', 'suffix')       // string ends with suffix
+Query.contains('field', 'substring')    // string/array contains value
+Query.search('field', 'keywords')       // full-text search (requires full-text index)
+
+// Sorting
+Query.orderAsc('field')                 // sort ascending
+Query.orderDesc('field')                // sort descending
+
+// Pagination
+Query.limit(25)                         // max rows returned (default 25, max 100)
+Query.offset(0)                         // skip N rows
+Query.cursorAfter('[ROW_ID]')           // paginate after this row ID (preferred for large datasets)
+Query.cursorBefore('[ROW_ID]')          // paginate before this row ID
+
+// Selection
+Query.select(['field1', 'field2'])      // return only specified fields
+
+// Logical
+Query.or([Query.equal('a', 1), Query.equal('b', 2)])   // OR condition
+Query.and([Query.greaterThan('age', 18), Query.lessThan('age', 65)])  // explicit AND (queries are AND by default)
+```
+
+### File Storage
+
+```typescript
+const storage = new Storage(client);
+
+// Upload file (client-side -- from file input)
+const file = await storage.createFile({
+    bucketId: '[BUCKET_ID]',
+    fileId: ID.unique(),
+    file: document.getElementById('file-input').files[0]
+});
+
+// Upload file (server-side -- from path)
+import { InputFile } from 'node-appwrite/file';
+
+const file2 = await storage.createFile({
+    bucketId: '[BUCKET_ID]',
+    fileId: ID.unique(),
+    file: InputFile.fromPath('/path/to/file.png', 'file.png')
+});
+
+// List files
+const files = await storage.listFiles({ bucketId: '[BUCKET_ID]' });
+
+// Get file preview (image)
+const preview = storage.getFilePreview({
+    bucketId: '[BUCKET_ID]',
+    fileId: '[FILE_ID]',
+    width: 300,
+    height: 300
+});
+
+// Download file
+const download = await storage.getFileDownload({
+    bucketId: '[BUCKET_ID]',
+    fileId: '[FILE_ID]'
+});
+
+// Delete file
+await storage.deleteFile({ bucketId: '[BUCKET_ID]', fileId: '[FILE_ID]' });
+```
+
+#### InputFile Factory Methods (server-side)
+
+```typescript
+import { InputFile } from 'node-appwrite/file';
+
+InputFile.fromPath('/path/to/file.png', 'file.png')          // from filesystem path
+InputFile.fromBuffer(buffer, 'file.png')                       // from Buffer
+InputFile.fromStream(readableStream, 'file.png', size)         // from ReadableStream (size in bytes required)
+InputFile.fromPlainText('Hello world', 'hello.txt')            // from string content
+```
+
+### Teams
+
+```typescript
+const teams = new Teams(client);
+
+// Create team
+const team = await teams.create({ teamId: ID.unique(), name: 'Engineering' });
+
+// List teams
+const list = await teams.list();
+
+// Create membership (invite a user by email)
+const membership = await teams.createMembership({
+    teamId: '[TEAM_ID]',
+    roles: ['editor'],
+    email: 'user@example.com',
+});
+
+// List memberships
+const members = await teams.listMemberships({ teamId: '[TEAM_ID]' });
+
+// Update membership roles
+await teams.updateMembership({
+    teamId: '[TEAM_ID]',
+    membershipId: '[MEMBERSHIP_ID]',
+    roles: ['admin'],
+});
+
+// Delete team
+await teams.delete({ teamId: '[TEAM_ID]' });
+```
+
+> Role-based access: Use `Role.team('[TEAM_ID]')` for all team members or `Role.team('[TEAM_ID]', 'editor')` for a specific team role when setting permissions.
+
+### Real-time Subscriptions (client-side)
+
+```typescript
+import { Realtime, Channel } from 'appwrite';
+
+const realtime = new Realtime(client);
+
+// Subscribe to row changes
+const subscription = await realtime.subscribe(
+    Channel.tablesdb('[DATABASE_ID]').table('[TABLE_ID]').row(),
+    (response) => {
+        console.log(response.events);   // e.g. ['tablesdb.*.tables.*.rows.*.create']
+        console.log(response.payload);  // the affected resource
+    }
+);
+
+// Subscribe to a specific row
+await realtime.subscribe(
+    Channel.tablesdb('[DATABASE_ID]').table('[TABLE_ID]').row('[ROW_ID]'),
+    (response) => { /* ... */ }
+);
+
+// Subscribe to multiple channels
+await realtime.subscribe([
+    Channel.tablesdb('[DATABASE_ID]').table('[TABLE_ID]').row(),
+    Channel.bucket('[BUCKET_ID]').file(),
+], (response) => { /* ... */ });
+
+// Unsubscribe
+await subscription.close();
+```
+
+Available channels:
+
+| Channel | Description |
+|---------|-------------|
+| `account` | Changes to the authenticated user's account |
+| `tablesdb.[DB_ID].tables.[TABLE_ID].rows` | All rows in a table |
+| `tablesdb.[DB_ID].tables.[TABLE_ID].rows.[ROW_ID]` | A specific row |
+| `buckets.[BUCKET_ID].files` | All files in a bucket |
+| `buckets.[BUCKET_ID].files.[FILE_ID]` | A specific file |
+| `teams` | Changes to teams the user belongs to |
+| `teams.[TEAM_ID]` | Changes to a specific team |
+| `memberships` | Changes to the user's team memberships |
+| `memberships.[MEMBERSHIP_ID]` | A specific membership |
+| `functions.[FUNCTION_ID].executions` | Execution updates for a function |
+
+The `response` object includes: `events` (array of event strings), `payload` (the affected resource), `channels` (channels matched), and `timestamp` (ISO 8601).
+
+### Serverless Functions (server-side)
+
+```typescript
+const functions = new Functions(client);
+
+// Execute function
+const execution = await functions.createExecution({
+    functionId: '[FUNCTION_ID]',
+    body: JSON.stringify({ key: 'value' })
+});
+
+// List executions
+const executions = await functions.listExecutions({ functionId: '[FUNCTION_ID]' });
+```
+
+#### Writing a Function Handler (Node.js runtime)
+
+When deploying your own Appwrite Function, the entry point file must export a default async function:
+
+```typescript
+// src/main.js (or src/main.ts)
+export default async ({ req, res, log, error }) => {
+    // Request properties
+    // req.body        -- raw request body (string)
+    // req.bodyJson    -- parsed JSON body (object, or undefined if not JSON)
+    // req.headers     -- request headers (object)
+    // req.method      -- HTTP method (GET, POST, PUT, DELETE, PATCH)
+    // req.path        -- URL path (e.g. '/hello')
+    // req.query       -- parsed query parameters (object)
+    // req.queryString -- raw query string
+
+    log('Processing request: ' + req.method + ' ' + req.path);
+
+    if (req.method === 'GET') {
+        return res.json({ message: 'Hello from Appwrite Function!' });
+    }
+
+    const data = req.bodyJson;
+    if (!data?.name) {
+        error('Missing name field');
+        return res.json({ error: 'Name is required' }, 400);
+    }
+
+    // Response methods
+    return res.json({ success: true });                    // JSON (sets Content-Type automatically)
+    // return res.text('Hello');                           // plain text
+    // return res.empty();                                 // 204 No Content
+    // return res.redirect('https://example.com');         // 302 Redirect
+    // return res.send('data', 200, { 'X-Custom': '1' }); // custom body, status, headers
+};
+```
+
+### Server-Side Rendering (SSR) Authentication
+
+SSR apps (Next.js, SvelteKit, Nuxt, Remix, Astro) use the server SDK (`node-appwrite`) to handle auth. You need two clients:
+
+- Admin client -- uses an API key, creates sessions, bypasses rate limits (reusable singleton)
+- Session client -- uses a session cookie, acts on behalf of a user (create per-request, never share)
+
+```typescript
+import { Client, Account, OAuthProvider } from 'node-appwrite';
+
+// Admin client (reusable)
+const adminClient = new Client()
+    .setEndpoint('https://<REGION>.cloud.appwrite.io/v1')
+    .setProject('[PROJECT_ID]')
+    .setKey(process.env.APPWRITE_API_KEY);
+
+// Session client (create per-request)
+const sessionClient = new Client()
+    .setEndpoint('https://<REGION>.cloud.appwrite.io/v1')
+    .setProject('[PROJECT_ID]');
+
+const session = req.cookies['a_session_[PROJECT_ID]'];
+if (session) {
+    sessionClient.setSession(session);
+}
+```
+
+#### Email/Password Login
+
+```typescript
+app.post('/login', async (req, res) => {
+    const account = new Account(adminClient);
+    const session = await account.createEmailPasswordSession({
+        email: req.body.email,
+        password: req.body.password,
+    });
+
+    // Cookie name must be a_session_<PROJECT_ID>
+    res.cookie('a_session_[PROJECT_ID]', session.secret, {
+        httpOnly: true,
+        secure: true,
+        sameSite: 'strict',
+        expires: new Date(session.expire),
+        path: '/',
+    });
+
+    res.json({ success: true });
+});
+```
+
+#### Authenticated Requests
+
+```typescript
+app.get('/user', async (req, res) => {
+    const session = req.cookies['a_session_[PROJECT_ID]'];
+    if (!session) return res.status(401).json({ error: 'Unauthorized' });
+
+    // Create a fresh session client per request
+    const sessionClient = new Client()
+        .setEndpoint('https://<REGION>.cloud.appwrite.io/v1')
+        .setProject('[PROJECT_ID]')
+        .setSession(session);
+
+    const account = new Account(sessionClient);
+    const user = await account.get();
+    res.json(user);
+});
+```
+
+#### OAuth2 SSR Flow
+
+```typescript
+// Step 1: Redirect to OAuth provider
+app.get('/oauth', async (req, res) => {
+    const account = new Account(adminClient);
+    const redirectUrl = await account.createOAuth2Token({
+        provider: OAuthProvider.Github,
+        success: 'https://example.com/oauth/success',
+        failure: 'https://example.com/oauth/failure',
+    });
+    res.redirect(redirectUrl);
+});
+
+// Step 2: Handle callback -- exchange token for session
+app.get('/oauth/success', async (req, res) => {
+    const account = new Account(adminClient);
+    const session = await account.createSession({
+        userId: req.query.userId,
+        secret: req.query.secret,
+    });
+
+    res.cookie('a_session_[PROJECT_ID]', session.secret, {
+        httpOnly: true, secure: true, sameSite: 'strict',
+        expires: new Date(session.expire), path: '/',
+    });
+    res.json({ success: true });
+});
+```
+
+> Cookie security: Always use `httpOnly`, `secure`, and `sameSite: 'strict'` to prevent XSS. The cookie name must be `a_session_<PROJECT_ID>`.
+
+> Forwarding user agent: Call `sessionClient.setForwardedUserAgent(req.headers['user-agent'])` to record the end-user's browser info for debugging and security.
+
+## Error Handling
+
+```typescript
+import { AppwriteException } from 'appwrite';
+// Server-side: import from 'node-appwrite'
+
+try {
+    const doc = await tablesDB.getRow({
+        databaseId: '[DATABASE_ID]',
+        tableId: '[TABLE_ID]',
+        rowId: '[ROW_ID]',
+    });
+} catch (err) {
+    if (err instanceof AppwriteException) {
+        console.log(err.message);   // human-readable error message
+        console.log(err.code);      // HTTP status code (number)
+        console.log(err.type);      // Appwrite error type string (e.g. 'document_not_found')
+        console.log(err.response);  // full response body (object)
+    }
+}
+```
+
+Common error codes:
+
+| Code | Meaning |
+|------|---------|
+| `401` | Unauthorized -- missing or invalid session/API key |
+| `403` | Forbidden -- insufficient permissions for this action |
+| `404` | Not found -- resource does not exist |
+| `409` | Conflict -- duplicate ID or unique constraint violation |
+| `429` | Rate limited -- too many requests, retry after backoff |
+
+## Permissions & Roles (Critical)
+
+Appwrite uses permission strings to control access to resources. Each permission pairs an action (`read`, `update`, `delete`, `create`, or `write` which grants create + update + delete) with a role target. By default, no user has access unless permissions are explicitly set at the document/file level or inherited from the collection/bucket settings. Permissions are arrays of strings built with the `Permission` and `Role` helpers.
+
+```typescript
+import { Permission, Role } from 'appwrite';
+// Server-side: import from 'node-appwrite'
+```
+
+### Database Row with Permissions
+
+```typescript
+const doc = await tablesDB.createRow({
+    databaseId: '[DATABASE_ID]',
+    tableId: '[TABLE_ID]',
+    rowId: ID.unique(),
+    data: { title: 'Hello World' },
+    permissions: [
+        Permission.read(Role.user('[USER_ID]')),     // specific user can read
+        Permission.update(Role.user('[USER_ID]')),   // specific user can update
+        Permission.read(Role.team('[TEAM_ID]')),     // all team members can read
+        Permission.read(Role.any()),                 // anyone (including guests) can read
+    ]
+});
+```
+
+### File Upload with Permissions
+
+```typescript
+const file = await storage.createFile({
+    bucketId: '[BUCKET_ID]',
+    fileId: ID.unique(),
+    file: document.getElementById('file-input').files[0],
+    permissions: [
+        Permission.read(Role.any()),
+        Permission.update(Role.user('[USER_ID]')),
+        Permission.delete(Role.user('[USER_ID]')),
+    ]
+});
+```
+
+> When to set permissions: Set document/file-level permissions when you need per-resource access control. If all documents in a collection share the same rules, configure permissions at the collection/bucket level and leave document permissions empty.
+
+> Common mistakes:
+> - Forgetting permissions -- the resource becomes inaccessible to all users (including the creator)
+> - `Role.any()` with `write`/`update`/`delete` -- allows any user, including unauthenticated guests, to modify or remove the resource
+> - `Permission.read(Role.any())` on sensitive data -- makes the resource publicly readable


### PR DESCRIPTION
# Appwrite

Adds an Appwrite plugin for Cline users building and operating Appwrite-backed applications across web, mobile, backend, and server-side runtimes.

The plugin gives users Appwrite docs lookup by default and only enables authenticated project operations when the user has explicitly provided Appwrite MCP credentials through environment variables. It also includes guided deployment commands and safety rules for live project operations.

## Cline Primitives

- `mcp`: registers `appwrite-docs` as a Streamable HTTP docs MCP server at `https://mcp-for-docs.appwrite.io` for Appwrite reference lookup.
- `mcp`: conditionally registers `appwrite-api` as a stdio MCP server using `uvx mcp-server-appwrite` when `APPWRITE_ENDPOINT`, `APPWRITE_PROJECT_ID`, and `APPWRITE_API_KEY` are present in the plugin environment. Without those values, users still get the docs MCP and skills.
- `skills`: bundles 15 Appwrite skills: CLI guidance, a general SDK router, language-specific SDK skills for TypeScript/JavaScript, Dart, Kotlin, Swift, Python, Ruby, Go, Rust, .NET, and PHP, plus TablesDB, deployment, and MCP usage skills.
- `commands`: adds `/appwrite-deploy-function` and `/appwrite-deploy-site` to start guarded deployment-preparation workflows without immediately running live deployment commands.
- `rules`: adds an Appwrite safety rule for project mutations, deployments, deletes, permission changes, auth provider changes, function executions, schema migrations, API keys, session secrets, and credential-bearing config.

## Requirements

Users need a Cline build with plugin MCP registration support. The docs MCP needs network access to the Appwrite docs MCP endpoint. The API MCP needs `uvx`, an Appwrite endpoint, project ID, and least-privilege API key available as environment variables before install or reinstall. Deployment workflows need the Appwrite CLI and an initialized project.

## Trust Boundaries

The Appwrite API MCP can access and mutate project data according to the API key scopes. The plugin keeps `appwrite-api` disabled unless credentials are present, and the bundled skills/rule require confirmation before deployments, deletes, pushes, force operations, permission changes, auth provider changes, function executions, migrations, or other irreversible operations.

The skills also keep browser and mobile SDK examples limited to endpoint plus project ID, steer API keys into trusted server-side code or user-managed environment variables, and warn Cline not to print, commit, or log API keys, JWTs, session secrets, `.env` values, or credential-bearing `appwrite.config.json` content.
