### PR TITLE
feat: add atomic agents plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Each plugin lives in `plugins/<slug>`. The directory name is the install keyword
 | --- | --- |
 | `agent-browser` | Web and Electron browser automation via the agent-browser CLI skill. |
 | `agents-squad` | Background subagents with presets, skills, and shared handoffs. |
+| `atomic-agents` | Skills for building, exploring, and reviewing Python apps that use the Atomic Agents framework. |
 | `background-terminal` | Long-running shell jobs with polling and cleanup tools. |
 | `branch-protector` | A hook that blocks protected branch pushes unless explicitly allowed. |
 | `bundled-skills-demo` | A package plugin that proves bundled skill discovery works. |

--- a/plugins/atomic-agents/README.md
+++ b/plugins/atomic-agents/README.md
@@ -1,0 +1,48 @@
+# atomic-agents
+
+Skills for building, exploring, and reviewing Python applications that use the Atomic Agents framework.
+
+## What It Adds
+
+- `atomic-agents-framework` for core framework concepts, imports, provider wiring, and project structure.
+- `atomic-agents-new-app` for scaffolding a small runnable project.
+- `atomic-agents-create-schema`, `atomic-agents-create-agent`, `atomic-agents-create-tool`, and `atomic-agents-create-context-provider` for common authoring workflows.
+- `atomic-agents-explore-codebase` for mapping existing Atomic Agents projects with file references.
+- `atomic-agents-review-code` for framework-specific review of schemas, agents, tools, providers, memory, hooks, and orchestration.
+
+## Install
+
+```bash
+cline plugin install atomic-agents
+```
+
+For local development from this repository:
+
+```bash
+cline plugin install ./plugins/atomic-agents --cwd .
+```
+
+## Example Usage
+
+After installation, ask Cline:
+
+```text
+Review this Atomic Agents project for framework-specific issues before I open a PR.
+```
+
+or:
+
+```text
+Scaffold a new Atomic Agents app for classifying support tickets.
+```
+
+## Requirements
+
+- Python 3.12 or newer for Atomic Agents projects that use current generic syntax.
+- The `atomic-agents`, `instructor`, and provider SDK packages in the target project.
+- Provider credentials only when running live agent calls or integration tests.
+- `uv` or a Python virtual environment tool when scaffolding or installing a new app.
+
+## Trust Boundaries
+
+The plugin itself only installs skills. The skills may ask Cline to create project files, install Python dependencies, run tests, or call live LLM providers as part of the user's requested workflow. They require confirmation before creating a new project scaffold, running dependency installs, executing integration tests against a real provider, or using provider API keys.

--- a/plugins/atomic-agents/index.ts
+++ b/plugins/atomic-agents/index.ts
@@ -1,0 +1,10 @@
+import type { AgentPlugin } from "@cline/sdk"
+
+const plugin: AgentPlugin = {
+	name: "atomic-agents",
+	manifest: {
+		capabilities: ["skills"],
+	},
+}
+
+export default plugin

--- a/plugins/atomic-agents/package.json
+++ b/plugins/atomic-agents/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "atomic-agents",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Cline skills for Atomic Agents Python framework projects.",
+  "cline": {
+    "plugins": [
+      {
+        "paths": [
+          "./index.ts"
+        ],
+        "capabilities": [
+          "skills"
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/atomic-agents/skills/atomic-agents-create-agent/SKILL.md
+++ b/plugins/atomic-agents/skills/atomic-agents-create-agent/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: atomic-agents-create-agent
+description: Use when creating, wiring, or modifying an AtomicAgent with AgentConfig, provider clients, schemas, prompts, history, hooks, or context providers.
+---
+
+# Create Atomic Agent
+
+Use this skill when the user wants to add an `AtomicAgent`, wire a provider client, or turn schemas into a runnable LLM-backed component.
+
+## Clarify
+
+Bundle missing questions into one message:
+
+- What the agent should do in one sentence.
+- Whether the input and output are free-form chat or custom structured schemas.
+- Which provider and model the project uses.
+- Whether the agent is conversational or stateless.
+- Whether it needs tools, context providers, hooks, or streaming.
+
+## Plan
+
+State the target file, schema names, provider, history choice, and prompt sections before editing. Use existing project conventions when present.
+
+## Implementation Rules
+
+- Define or import schemas before constructing the agent.
+- Use `AtomicAgent[InputSchema, OutputSchema]` with explicit generic parameters.
+- Wrap the chat client with the appropriate Instructor factory before passing it to `AgentConfig.client`.
+- Use `SystemPromptGenerator(background=..., steps=..., output_instructions=...)` for non-trivial behavior.
+- Add `ChatHistory()` only when multi-turn memory is needed.
+- Keep provider-specific settings in `model_api_parameters`.
+- For Gemini, set `assistant_role="model"` and match the Instructor mode.
+- For providers that use JSON mode, keep the Instructor factory mode and `AgentConfig.mode` aligned.
+
+## Skeleton
+
+```python
+import os
+import instructor
+import openai
+from atomic_agents import AgentConfig, AtomicAgent, BasicChatInputSchema, BasicChatOutputSchema
+from atomic_agents.context import ChatHistory, SystemPromptGenerator
+
+
+def build_agent() -> AtomicAgent[BasicChatInputSchema, BasicChatOutputSchema]:
+    client = instructor.from_openai(
+        openai.OpenAI(api_key=os.environ["OPENAI_API_KEY"])
+    )
+
+    return AtomicAgent[BasicChatInputSchema, BasicChatOutputSchema](
+        config=AgentConfig(
+            client=client,
+            model=os.environ.get("OPENAI_MODEL", "gpt-5-mini"),
+            history=ChatHistory(),
+            system_prompt_generator=SystemPromptGenerator(
+                background=["You are the application's assistant."],
+                steps=[
+                    "Read the request.",
+                    "Use available context and tools when needed.",
+                    "Return the answer in the output schema.",
+                ],
+                output_instructions=["Be concise and explicit about uncertainty."],
+            ),
+            model_api_parameters={"temperature": 0.2},
+        )
+    )
+```
+
+## Verify
+
+Run import checks first. Do not run a live provider call unless the user expects it and credentials are configured.
+
+```bash
+python -c "from <module> import build_agent; agent = build_agent(); print(type(agent).__name__)"
+```

--- a/plugins/atomic-agents/skills/atomic-agents-create-context-provider/SKILL.md
+++ b/plugins/atomic-agents/skills/atomic-agents-create-context-provider/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: atomic-agents-create-context-provider
+description: Use when adding an Atomic Agents BaseDynamicContextProvider to inject current time, user state, retrieved docs, cached schemas, session state, or other dynamic prompt context.
+---
+
+# Create Atomic Agents Context Provider
+
+Use this skill when an agent needs runtime context in its system prompt.
+
+## Clarify
+
+Ask only for missing details:
+
+- What information should appear in the prompt.
+- Where the information comes from.
+- How fresh it needs to be.
+- Which agents should receive it.
+- Whether the context may contain secrets or private data.
+
+## Rules
+
+- Subclass `BaseDynamicContextProvider`.
+- Set a clear, unique `title` in `super().__init__(title=...)`.
+- Implement `get_info(self) -> str`.
+- Keep `get_info()` synchronous, cheap, and deterministic.
+- Do not perform HTTP, DB, or file I/O inside `get_info()`.
+- Refresh slow data outside `get_info()` and store a cached string or data object.
+- Never include API keys, tokens, passwords, or unnecessary private content in the returned context.
+- Register the provider on each agent before any `run()` that depends on it.
+
+## Simple Provider
+
+```python
+from datetime import datetime, timezone
+from atomic_agents.context import BaseDynamicContextProvider
+
+
+class TimeContext(BaseDynamicContextProvider):
+    def __init__(self):
+        super().__init__(title="Current Time")
+
+    def get_info(self) -> str:
+        return datetime.now(timezone.utc).isoformat()
+```
+
+## Cached Provider
+
+```python
+from atomic_agents.context import BaseDynamicContextProvider
+
+
+class RetrievedDocsContext(BaseDynamicContextProvider):
+    def __init__(self):
+        super().__init__(title="Retrieved Documents")
+        self._docs: list[tuple[str, str]] = []
+
+    def set_docs(self, docs: list[tuple[str, str]]) -> None:
+        self._docs = docs
+
+    def get_info(self) -> str:
+        if not self._docs:
+            return "No documents retrieved."
+        return "\n\n".join(f"[{source}]\n{text}" for source, text in self._docs)
+```
+
+## Registration
+
+```python
+docs_context = RetrievedDocsContext()
+agent.register_context_provider("retrieved_docs", docs_context)
+
+docs_context.set_docs(search(query))
+result = agent.run(input_schema)
+```
+
+## Verify
+
+Check that the provider returns a string and that the agent registers it before use. For code review, look for slow I/O or secrets in `get_info()`.

--- a/plugins/atomic-agents/skills/atomic-agents-create-schema/SKILL.md
+++ b/plugins/atomic-agents/skills/atomic-agents-create-schema/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: atomic-agents-create-schema
+description: Use when creating or modifying Atomic Agents BaseIOSchema input or output contracts, including field descriptions, validators, typed errors, and schemas for agents or tools.
+---
+
+# Create Atomic Agents Schema
+
+Use this skill when the user wants a schema for an Atomic Agents agent, tool, router, extractor, classifier, or structured output.
+
+## Clarify
+
+Ask only for missing information:
+
+- Whether the schema is for an agent, a tool, or shared data.
+- Input, output, or both.
+- Required fields, optional fields, defaults, and constraints.
+- Whether failure is expected and should be represented as a typed result.
+
+## Rules
+
+- Inherit from `BaseIOSchema`, not `pydantic.BaseModel`.
+- Add a non-empty class docstring to every schema.
+- Put `description=` on every `Field(...)`.
+- Prefer `Literal[...]` for small closed sets.
+- Add validators for cross-field rules or normalization that the type system cannot express.
+- Give `Optional[T]` fields an explicit default, usually `None`.
+- Use typed error variants for routine failures.
+
+## Template
+
+```python
+from typing import Literal
+from pydantic import Field, model_validator
+from atomic_agents import BaseIOSchema
+
+
+class TicketInput(BaseIOSchema):
+    """A support ticket that needs classification."""
+
+    title: str = Field(..., description="Short ticket title from the user.")
+    body: str = Field(..., description="Full ticket body or transcript.")
+
+
+class TicketClassification(BaseIOSchema):
+    """Classification result for a support ticket."""
+
+    status: Literal["ok", "error"] = Field(..., description="Whether classification succeeded.")
+    category: Literal["billing", "bug", "question", "other"] | None = Field(
+        default=None,
+        description="Ticket category when status is ok.",
+    )
+    confidence: float | None = Field(
+        default=None,
+        ge=0,
+        le=1,
+        description="Model confidence from 0 to 1 when status is ok.",
+    )
+    error: str | None = Field(
+        default=None,
+        description="Reason classification failed when status is error.",
+    )
+
+    @model_validator(mode="after")
+    def validate_status_fields(self) -> "TicketClassification":
+        if self.status == "ok" and self.category is None:
+            raise ValueError("category is required when status is ok")
+        if self.status == "error" and not self.error:
+            raise ValueError("error is required when status is error")
+        return self
+```
+
+## Verify
+
+Run an import and schema check:
+
+```bash
+python -c "from <module> import TicketInput; print(TicketInput.model_json_schema()['title'])"
+```
+
+If the import fails because a schema has no docstring, add the docstring. If JSON Schema lacks useful descriptions, add or improve `Field(description=...)` text.

--- a/plugins/atomic-agents/skills/atomic-agents-create-tool/SKILL.md
+++ b/plugins/atomic-agents/skills/atomic-agents-create-tool/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: atomic-agents-create-tool
+description: Use when creating or modifying an Atomic Agents BaseTool with typed input/output schemas, BaseToolConfig, run or run_async, env-driven credentials, and typed failure results.
+---
+
+# Create Atomic Agents Tool
+
+Use this skill when the user wants to wrap an API, database call, local computation, search, or service as a tool an Atomic Agent can invoke.
+
+## Clarify
+
+Ask for missing details in one message:
+
+- Tool purpose.
+- Input and output fields.
+- External dependencies and credentials.
+- Sync, async, or both.
+- Expected failure modes such as not found, rate limit, timeout, or invalid input.
+
+## Rules
+
+- Use `BaseTool[InputSchema, OutputSchema]` with explicit generic parameters.
+- Keep schemas as `BaseIOSchema` classes with docstrings and field descriptions.
+- Use `BaseToolConfig` for API keys, base URLs, timeouts, and retry settings.
+- Read credentials from environment variables or injected config, never hardcode them.
+- Add timeouts to HTTP and database calls.
+- Return an output schema instance, never a raw dict.
+- Model routine failures as typed outputs. Raise only for programmer errors.
+- If async is needed, implement `run_async`, not `arun`.
+
+## Skeleton
+
+```python
+import os
+from typing import Literal
+import httpx
+from pydantic import Field
+from atomic_agents import BaseIOSchema, BaseTool, BaseToolConfig
+
+
+class SearchConfig(BaseToolConfig):
+    api_key: str = Field(
+        default_factory=lambda: os.environ.get("SEARCH_API_KEY", ""),
+        description="Search API key.",
+    )
+    base_url: str = Field(
+        default="https://api.example.com",
+        description="Search API base URL.",
+    )
+    timeout_seconds: float = Field(default=15, ge=1, le=120, description="HTTP timeout.")
+
+
+class SearchInput(BaseIOSchema):
+    """Search request."""
+
+    query: str = Field(..., description="User search query.")
+
+
+class SearchOutput(BaseIOSchema):
+    """Search result or typed failure."""
+
+    status: Literal["ok", "error"] = Field(..., description="Outcome code.")
+    results: list[str] = Field(default_factory=list, description="Search results.")
+    error: str | None = Field(default=None, description="Failure reason when status is error.")
+
+
+class SearchTool(BaseTool[SearchInput, SearchOutput]):
+    """Search an external service."""
+
+    def __init__(self, config: SearchConfig | None = None):
+        super().__init__(config or SearchConfig())
+
+    def run(self, params: SearchInput) -> SearchOutput:
+        cfg: SearchConfig = self.config
+        if not cfg.api_key:
+            return SearchOutput(status="error", error="SEARCH_API_KEY is not set")
+
+        try:
+            response = httpx.get(
+                f"{cfg.base_url}/search",
+                params={"q": params.query},
+                headers={"Authorization": f"Bearer {cfg.api_key}"},
+                timeout=cfg.timeout_seconds,
+            )
+            response.raise_for_status()
+        except httpx.HTTPError as error:
+            return SearchOutput(status="error", error=str(error))
+
+        data = response.json()
+        return SearchOutput(status="ok", results=[item["title"] for item in data["items"]])
+```
+
+## Verify
+
+Unit-test the tool without live services where possible. For live tests, ask before using credentials or making network calls.

--- a/plugins/atomic-agents/skills/atomic-agents-explore-codebase/SKILL.md
+++ b/plugins/atomic-agents/skills/atomic-agents-explore-codebase/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: atomic-agents-explore-codebase
+description: Use when mapping, explaining, tracing, or understanding an existing Python codebase that imports atomic_agents, including agents, schemas, tools, context providers, memory, and orchestration.
+---
+
+# Explore Atomic Agents Codebase
+
+Use this skill when the user asks how an existing Atomic Agents project works.
+
+## Discovery
+
+Read narrowly and cite file lines. Start with:
+
+- `pyproject.toml` for package layout and dependencies.
+- Entry points such as `main.py`, `__main__.py`, API handlers, CLI scripts, or workflow modules.
+- Imports from `atomic_agents`.
+- `AtomicAgent[` construction sites.
+- `BaseIOSchema` subclasses.
+- `BaseTool[` subclasses.
+- `BaseDynamicContextProvider` subclasses.
+- `SystemPromptGenerator`, `ChatHistory`, and `register_hook` usage.
+
+Use `rg -n` before opening large files.
+
+## Capture
+
+For each component, record:
+
+- Purpose.
+- File and line.
+- Input and output schema names.
+- Provider and model wiring when visible.
+- History behavior.
+- Registered tools.
+- Registered context providers.
+- Hook registrations.
+- Orchestration pattern.
+
+## Output Shape
+
+Return a concise map:
+
+```md
+## Codebase Map: <scope>
+
+### Overview
+<two or three sentences>
+
+### Entry Points
+- `<path>:<line>` - <role>
+
+### Agents
+- `<path>:<line>` - <name or variable>. In=<schema>, Out=<schema>, history=<yes/no/shared>, tools=<names>.
+
+### Tools
+- `<path>:<line>` - <tool>, external dependencies, sync/async behavior.
+
+### Schemas
+- `<path>:<line>` - <schema>, role, notable fields.
+
+### Context Providers
+- `<path>:<line>` - <title>, data source, registered on <agent>.
+
+### Orchestration
+<pipeline, router, parallel fan-out, supervisor, or other pattern>
+
+### Essential Reading
+- `<path>:<line>` - <why this file matters>
+```
+
+## Boundaries
+
+- Describe what exists before proposing changes.
+- Do not run the app just to inspect it.
+- Do not install dependencies unless the user asks.
+- Flag interesting anomalies separately from confirmed bugs.

--- a/plugins/atomic-agents/skills/atomic-agents-framework/SKILL.md
+++ b/plugins/atomic-agents/skills/atomic-agents-framework/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: atomic-agents-framework
+description: Use when working in a Python project that imports atomic_agents, or when the user asks about Atomic Agents schemas, agents, tools, context providers, prompts, providers, memory, hooks, testing, or orchestration.
+---
+
+# Atomic Agents Framework
+
+Use this skill to orient Cline around Atomic Agents framework conventions before editing or reviewing an Atomic Agents project.
+
+## Core Model
+
+Atomic Agents applications are built around typed boundaries:
+
+- `BaseIOSchema` describes every agent and tool input or output.
+- `AtomicAgent[InputSchema, OutputSchema]` transforms a typed input into a typed output.
+- `AgentConfig` wires the provider client, model, prompt, history, hooks, and provider-specific API parameters.
+- `BaseTool[InputSchema, OutputSchema]` exposes deterministic capabilities to agents.
+- `BaseDynamicContextProvider` injects runtime context into the system prompt.
+- `ChatHistory` stores multi-turn conversation state.
+- `SystemPromptGenerator` keeps the prompt split into background, steps, and output instructions.
+
+## Canonical Imports
+
+Prefer current top-level imports:
+
+```python
+from atomic_agents import (
+    AgentConfig,
+    AtomicAgent,
+    BaseIOSchema,
+    BaseTool,
+    BaseToolConfig,
+    BasicChatInputSchema,
+    BasicChatOutputSchema,
+)
+from atomic_agents.context import (
+    BaseDynamicContextProvider,
+    ChatHistory,
+    SystemPromptGenerator,
+)
+from instructor import Mode
+```
+
+Avoid legacy paths such as `atomic_agents.lib.base.*` or `atomic_agents.agents.base_agent`.
+
+## Minimum Agent Shape
+
+```python
+import os
+import instructor
+import openai
+from atomic_agents import AgentConfig, AtomicAgent, BasicChatInputSchema, BasicChatOutputSchema
+from atomic_agents.context import ChatHistory, SystemPromptGenerator
+
+client = instructor.from_openai(openai.OpenAI(api_key=os.environ["OPENAI_API_KEY"]))
+
+agent = AtomicAgent[BasicChatInputSchema, BasicChatOutputSchema](
+    config=AgentConfig(
+        client=client,
+        model=os.environ.get("OPENAI_MODEL", "gpt-5-mini"),
+        history=ChatHistory(),
+        system_prompt_generator=SystemPromptGenerator(
+            background=["You are a concise assistant for this application."],
+            steps=["Read the user request.", "Answer using the provided context."],
+            output_instructions=["Return a direct answer."],
+        ),
+    )
+)
+```
+
+Use the project's existing provider, model, and configuration style when one exists.
+
+## Routing
+
+Use the more specific skills when the user is building a concrete component:
+
+- `atomic-agents-create-schema` for `BaseIOSchema` contracts.
+- `atomic-agents-create-agent` for `AtomicAgent` wiring.
+- `atomic-agents-create-tool` for `BaseTool` implementations.
+- `atomic-agents-create-context-provider` for dynamic prompt context.
+- `atomic-agents-new-app` for a fresh scaffold.
+- `atomic-agents-explore-codebase` for mapping an existing codebase.
+- `atomic-agents-review-code` for framework-specific review.
+
+## Defaults
+
+- Design schemas first. Field descriptions are part of the LLM prompt.
+- Use explicit generic parameters on `AtomicAgent` and `BaseTool`.
+- Wrap chat clients with the matching `instructor.from_*` factory before passing them into `AgentConfig.client`.
+- Keep provider-specific knobs in `AgentConfig.model_api_parameters`.
+- Use typed error outputs for routine failures instead of throwing through agent/tool execution.
+- Keep `BaseDynamicContextProvider.get_info()` cheap, synchronous, and free of secrets.
+- Avoid shared `ChatHistory` across concurrent agents.
+
+## Verification
+
+For edits, run the smallest relevant check:
+
+```bash
+python -m compileall <package>
+python -c "from <module> import <SchemaOrAgent>; print('ok')"
+```
+
+For tests, prefer offline unit tests first. Ask before running installs, live provider calls, or integration tests that need API keys.

--- a/plugins/atomic-agents/skills/atomic-agents-new-app/SKILL.md
+++ b/plugins/atomic-agents/skills/atomic-agents-new-app/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: atomic-agents-new-app
+description: Use when scaffolding a new Atomic Agents Python project with pyproject.toml, environment template, package layout, first agent, and runnable entry point.
+---
+
+# New Atomic Agents App
+
+Use this skill when the user wants to start a new Atomic Agents project from scratch.
+
+## Confirm First
+
+Before creating files, confirm:
+
+- Project name.
+- Provider choice.
+- Agent purpose.
+- Whether to use `uv` or a virtual environment.
+- Target directory.
+
+Do not create files or run installs until the user approves the scaffold plan.
+
+## Scaffold Shape
+
+Use this layout unless the user asks otherwise:
+
+```text
+<project-name>/
+  pyproject.toml
+  .env.example
+  .gitignore
+  README.md
+  <package_name>/
+    __init__.py
+    main.py
+```
+
+Use Python `>=3.12`. Include `atomic-agents`, `instructor`, `python-dotenv`, `rich`, and the chosen provider SDK or Instructor extra. Include `pytest` and `ruff` as development dependencies.
+
+## Entry Point
+
+The starter `main.py` should:
+
+- Load `.env`.
+- Create an Instructor-wrapped provider client.
+- Build an `AtomicAgent[BasicChatInputSchema, BasicChatOutputSchema]`.
+- Use `ChatHistory` for a simple REPL.
+- Keep API keys in environment variables.
+- Exit cleanly on empty input, `quit`, or `exit`.
+
+## Safety
+
+- Write `.env.example`, not `.env`, unless the user explicitly asks.
+- Never write real API keys into files.
+- Ask before running `uv sync`, `pip install`, or any live provider call.
+- Unit-check imports before attempting integration tests.
+
+## Verify
+
+After writing files, run a no-network import check if dependencies are already available:
+
+```bash
+python -m compileall <package_name>
+```
+
+If dependencies are not installed, tell the user the install command instead of running it without approval.
+
+## Hand Off
+
+End with:
+
+- How to install dependencies.
+- Which environment variable to set.
+- How to run the app.
+- Suggested next skill for the next step, such as `atomic-agents-create-schema` or `atomic-agents-create-tool`.

--- a/plugins/atomic-agents/skills/atomic-agents-review-code/SKILL.md
+++ b/plugins/atomic-agents/skills/atomic-agents-review-code/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: atomic-agents-review-code
+description: Use when reviewing or auditing Python code that imports atomic_agents for framework-specific correctness around schemas, agents, tools, providers, context, memory, hooks, tests, and orchestration.
+---
+
+# Review Atomic Agents Code
+
+Use this skill for framework-specific review. It complements normal code review; it should not report generic Python style issues unless they create an Atomic Agents correctness or safety problem.
+
+## Scope
+
+Review the user's requested diff, files, or module. If scope is unclear, ask for it. Prefer changed code over broad project scans.
+
+## Checklist
+
+### Schemas
+
+- Inherit from `BaseIOSchema`.
+- Have non-empty class docstrings.
+- Every field has a useful `description=`.
+- Closed sets use `Literal` or another constrained type.
+- Optional fields have defaults.
+- Typed failure cases are explicit when routine failure is expected.
+
+### Agents
+
+- Use explicit `AtomicAgent[InputSchema, OutputSchema]` generics.
+- Pass an Instructor-wrapped client into `AgentConfig.client`.
+- Set provider mode and assistant role consistently.
+- Include provider-required parameters in `model_api_parameters`.
+- Use `ChatHistory` only when memory is needed.
+
+### Tools
+
+- Use explicit `BaseTool[InputSchema, OutputSchema]` generics.
+- Return output schema instances.
+- Use `run_async` for async tools.
+- Read credentials from config or environment.
+- Add timeouts for external I/O.
+- Return typed failure outputs for routine failures.
+
+### Context Providers
+
+- `get_info()` returns a string.
+- `get_info()` does not perform slow I/O.
+- Titles are unique.
+- Secrets are not injected into prompts.
+- Providers are registered before agent runs that depend on them.
+
+### Orchestration And Memory
+
+- Parallel agents do not share one `ChatHistory`.
+- Router agents return structured variants, not free-text topics.
+- Supervisor loops have iteration caps.
+- Pipeline stages use compatible schemas or typed adapters.
+
+### Hooks And Tests
+
+- Hook handlers do not raise.
+- Error handling uses framework hooks where appropriate.
+- Unit tests do not call live providers by default.
+- Integration tests are gated by explicit environment variables and token limits.
+
+## Reporting
+
+Report only high-confidence issues. For each issue include:
+
+- Severity.
+- File and line.
+- The Atomic Agents rule being violated.
+- A concrete fix.
+
+Keep clean reviews short. If no framework-specific issues are found, say that and note any review scope limits.


### PR DESCRIPTION
# atomic-agents

Adds an Atomic Agents plugin for Cline users building Python LLM applications with typed schemas, tools, context providers, and multi-agent orchestration.

## Cline Primitives

- Skills: installs `atomic-agents-framework` as the general framework guide, plus focused authoring skills for schemas, agents, tools, context providers, and new app scaffolding.
- Skills: installs `atomic-agents-explore-codebase` and `atomic-agents-review-code` so Cline can map existing Atomic Agents projects and review framework-specific correctness without adding a separate agent runtime dependency.

## Requirements

Users need Python 3.12 or newer for projects that use current Atomic Agents generic syntax. Target projects need the `atomic-agents`, `instructor`, and relevant provider SDK packages installed. Live agent calls and integration tests require the user's provider credentials. New app scaffolding expects either `uv` or a Python virtual environment workflow.

## Trust Boundaries

This plugin only installs skills; it does not register MCP servers, run background processes, or call external services on install. The skills can guide Cline to create project files, install Python dependencies, run tests, or call live LLM providers as part of a user-requested workflow. They require confirmation before creating a scaffold, running dependency installs, executing integration tests against a real provider, or using provider API keys.
