### PR TITLE
feat: add aws serverless plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Each plugin lives in `plugins/<slug>`. The directory name is the install keyword
 | --- | --- |
 | `agent-browser` | Web and Electron browser automation via the agent-browser CLI skill. |
 | `agents-squad` | Background subagents with presets, skills, and shared handoffs. |
+| `aws-serverless` | AWS Serverless MCP plus skills for Lambda, API Gateway, SAM, CDK, durable functions, and Lambda Managed Instances workflows. |
 | `background-terminal` | Long-running shell jobs with polling and cleanup tools. |
 | `branch-protector` | A hook that blocks protected branch pushes unless explicitly allowed. |
 | `bundled-skills-demo` | A package plugin that proves bundled skill discovery works. |

--- a/plugins/aws-serverless/README.md
+++ b/plugins/aws-serverless/README.md
@@ -1,0 +1,56 @@
+# AWS Serverless
+
+Build, review, and operate AWS Lambda, API Gateway, Step Functions, SAM, CDK, durable functions, and Lambda Managed Instances workflows from Cline.
+
+## What It Adds
+
+- Registers `aws-serverless-mcp`, a local AWS Serverless MCP server launched with `uvx`.
+- Bundles `aws-serverless-lambda` for Lambda event sources, orchestration, observability, optimization, and troubleshooting.
+- Bundles `aws-serverless-api-gateway` for REST, HTTP, and WebSocket API design and operations.
+- Bundles `aws-serverless-deployment` for SAM, CDK, IaC review, deployment planning, and explicit template validation.
+- Bundles `aws-serverless-durable-functions` for long-running Lambda workflows with checkpoints, retries, callbacks, and replay-safe code.
+- Bundles `aws-serverless-managed-instances` for evaluating and migrating predictable Lambda workloads to Lambda Managed Instances.
+
+## Install
+
+```bash
+cline plugin install aws-serverless
+```
+
+For local development from this repository:
+
+```bash
+cline plugin install ./plugins/aws-serverless --cwd .
+```
+
+## Example Usage
+
+After installation, ask Cline:
+
+```text
+Review this SAM app for production readiness, then help me add a Lambda-backed HTTP API endpoint.
+```
+
+Cline can use the bundled skills to choose an AWS serverless design, consult the MCP server for serverless project helpers, and produce SAM or CDK changes with explicit approval before local validation, deployment, log access, or live AWS mutations.
+
+## Cline Primitives
+
+- MCP: `aws-serverless-mcp` exposes AWS Serverless tools for SAM project initialization, web app deployment helpers, Lambda testing, EventBridge schema workflows, and serverless guidance.
+- Skills: five prefixed `aws-serverless-*` skills cover the main workflow lanes without requiring automatic hooks.
+
+## Requirements
+
+- `uvx` available on PATH.
+- First launch may download and execute the pinned `awslabs.aws-serverless-mcp-server@0.1.19` package through `uvx`.
+- Python 3.10 or newer available to `uvx`.
+- AWS credentials configured through the AWS CLI, IAM Identity Center, or environment variables for live account operations.
+- AWS SAM CLI, AWS CDK, Docker or a compatible container runtime, and AWS CLI as needed by the workflow.
+- IAM permissions scoped to the requested Lambda, API Gateway, Step Functions, EventBridge, CloudFormation, S3, CloudFront, Route 53, ACM, IAM, CloudWatch, and related resources.
+
+## Trust Boundaries
+
+The MCP server is registered with `--allow-write` because project scaffolding, SAM deployment, web app deployment, EventBridge template generation, and domain configuration are core serverless workflows. Cline must still ask before running MCP tools or shell commands that create files, deploy stacks, change DNS or certificates, invoke Lambda functions, start or inspect Step Functions executions, read logs, mutate AWS resources, adjust IAM, change networking, invalidate caches, or incur cost.
+
+Sensitive data access is not enabled. This plugin does not pass `--allow-sensitive-data-access`; users who need log-reading MCP tools should configure that intentionally in their own MCP settings and understand what data may be exposed.
+
+This plugin does not run automatic post-edit hooks. SAM template validation is an explicit workflow step, not a command that runs after every file edit.

--- a/plugins/aws-serverless/index.ts
+++ b/plugins/aws-serverless/index.ts
@@ -3,7 +3,7 @@ import type { AgentPlugin } from "@cline/sdk"
 const plugin: AgentPlugin = {
 	name: "aws-serverless",
 	manifest: {
-		capabilities: ["mcp", "skills"],
+		capabilities: ["mcp", "skills", "rules"],
 	},
 
 	setup(api) {
@@ -17,6 +17,13 @@ const plugin: AgentPlugin = {
 			env: {
 				FASTMCP_LOG_LEVEL: "ERROR",
 			},
+		})
+
+		api.registerRule({
+			id: "aws-serverless-safety",
+			source: "aws-serverless",
+			content:
+				"When working with AWS Serverless through the aws-serverless plugin, plan and inspect before acting. Ask for explicit user approval before installing or updating CLIs, creating or editing projects, running MCP tools or shell commands that write files, deploying stacks, invoking Lambda functions or Step Functions, reading CloudWatch logs or traces, changing IAM, DNS, certificates, custom domains, networking, EventBridge schemas, S3/CloudFront assets, or any AWS resource, deleting resources, invalidating caches, enabling sensitive-data access, or incurring cost. Never paste AWS credentials, API keys, tokens, customer data, request or response bodies, log excerpts, or other sensitive data into chat, generated files, shell history, or MCP queries unless the user explicitly provides and approves that exact use.",
 		})
 	},
 }

--- a/plugins/aws-serverless/index.ts
+++ b/plugins/aws-serverless/index.ts
@@ -1,0 +1,24 @@
+import type { AgentPlugin } from "@cline/sdk"
+
+const plugin: AgentPlugin = {
+	name: "aws-serverless",
+	manifest: {
+		capabilities: ["mcp", "skills"],
+	},
+
+	setup(api) {
+		api.registerMcpServer({
+			name: "aws-serverless-mcp",
+			transport: {
+				type: "stdio",
+				command: "uvx",
+				args: ["awslabs.aws-serverless-mcp-server@0.1.19", "--allow-write"],
+			},
+			env: {
+				FASTMCP_LOG_LEVEL: "ERROR",
+			},
+		})
+	},
+}
+
+export default plugin

--- a/plugins/aws-serverless/package.json
+++ b/plugins/aws-serverless/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "aws-serverless",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Cline plugin that bundles AWS serverless workflow skills and registers the AWS Serverless MCP server.",
+  "cline": {
+    "plugins": [
+      {
+        "paths": [
+          "./index.ts"
+        ],
+        "capabilities": [
+          "mcp",
+          "skills"
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/aws-serverless/package.json
+++ b/plugins/aws-serverless/package.json
@@ -12,7 +12,8 @@
         ],
         "capabilities": [
           "mcp",
-          "skills"
+          "skills",
+          "rules"
         ]
       }
     ]

--- a/plugins/aws-serverless/skills/aws-serverless-api-gateway/SKILL.md
+++ b/plugins/aws-serverless/skills/aws-serverless-api-gateway/SKILL.md
@@ -1,33 +1,208 @@
 ---
 name: aws-serverless-api-gateway
-description: Design, implement, secure, and troubleshoot Amazon API Gateway REST APIs, HTTP APIs, and WebSocket APIs backed by Lambda or AWS service integrations.
+description: >
+  Build, manage, and operate APIs with Amazon API Gateway (REST, HTTP, and WebSocket).
+  Triggers on phrases like: API Gateway, REST API, HTTP API, WebSocket API, custom domain, Lambda authorizer, usage plan, throttling, CORS, VPC link, private API.
+  Also covers troubleshooting API Gateway errors (4xx, 5xx, timeout, CORS failures) and IaC templates containing API Gateway resources.
+  For general REST API design unrelated to AWS, do not trigger.
+metadata:
+  tags: [api-gateway, serverless, aws, rest-api, http-api, websocket]
 ---
 
-# AWS Serverless API Gateway
+# Amazon API Gateway Development
 
-Use this skill for Amazon API Gateway work involving REST APIs, HTTP APIs, WebSocket APIs, Lambda authorizers, JWT auth, Cognito, custom domains, CORS, throttling, usage plans, private APIs, VPC links, service integrations, or API Gateway troubleshooting.
+Expert guidance for building, managing, governing, and operating APIs with Amazon API Gateway. Covers REST APIs (v1), HTTP APIs (v2), and WebSocket APIs.
 
-## Workflow
+## How to Use This Skill
 
-1. Classify the API type first:
-   - Use HTTP API for lightweight, low-latency Lambda or HTTP proxy APIs with simpler auth and lower cost.
-   - Use REST API when the user needs usage plans, API keys, request validation, caching, resource policies, private endpoints, WAF at the API layer, or canary deployments.
-   - Use WebSocket API for persistent bidirectional connections.
-2. Gather endpoint shape, auth requirements, tenancy model, latency expectations, client locations, traffic profile, compliance needs, and deployment environments.
-3. Prefer IaC examples using the repository's existing framework. If no framework exists, recommend SAM for compact serverless apps or CDK for larger typed infrastructure.
-4. Configure access logs for every API. Add execution logs only where the API type supports them and only at an appropriate level.
-5. Treat CORS as a security configuration, not a wildcard default. Reflect the actual allowed origins, headers, credentials mode, and methods.
-6. For custom domains, account for certificate region, Route 53 ownership, base path mappings, CloudFront behavior, and rollout or rollback.
-7. For private APIs or VPC links, verify DNS, security groups, route tables, endpoint policies, and resource policies before changing infrastructure.
+When answering API Gateway questions:
 
-## MCP Use
+1. Read the relevant reference file(s) before responding, do not rely solely on this summary
+2. For tasks spanning multiple concerns (e.g., "private API with mTLS and custom domain"), read all relevant references
+3. When the user needs IaC templates, consult `references/sam-cloudformation.md` or `references/sam-service-integrations.md` and provide complete, working SAM/CloudFormation YAML
+4. Always mention relevant pitfalls and limits that affect the user's design
 
-Use `aws-serverless-mcp` for serverless API templates, deployment guidance, and Lambda-backed API workflow helpers when they add value.
+## Quick Decision: Which API Type?
 
-Before MCP calls, narrow inputs to the API design question or the relevant IaC snippet. Do not send tokens, credentials, private request payloads, customer data, or unrelated application code.
+Choose the right API type first. This decision affects every downstream choice.
 
-## Safety
+REST API is the full-featured API management platform for enterprises. It provides the governance, security, monetization, and operational controls that organizations need to build, publish, and manage APIs at scale, including usage plans with per-consumer throttling and quotas, API keys, request validation, WAF integration, resource policies, caching, canary deployments, and private endpoints.
 
-Ask before deploying APIs, configuring domains, creating certificates, changing DNS, adding IAM permissions, changing VPC links, invalidating caches, invoking live endpoints with private payloads, or reading API Gateway or Lambda logs.
+HTTP API is the lightweight, low-cost proxy optimized for simpler API workloads. It offers ~70% lower cost and lower latency but trades away the API management features. Choose HTTP API when you need a fast, lightweight proxy to Lambda or HTTP backends and don't require the enterprise controls above.
 
-When troubleshooting production traffic, ask for sanitized examples and prefer targeted identifiers over raw request bodies.
+| Factor                    | REST API (v1)                          | HTTP API (v2)                                  | WebSocket API                  |
+| ------------------------- | -------------------------------------- | ---------------------------------------------- | ------------------------------ |
+| Positioning           | Full API management                | Low-cost proxy                             | Real-time bidirectional    |
+| Cost                      | Higher                                 | ~70% cheaper                                   | Per-message pricing            |
+| Latency                   | Higher                                 | Lower                                          | Persistent connection          |
+| Max timeout               | 50ms-29s (up to 300s Regional/Private) | 30s hard limit                                 | 29s                            |
+| Payload                   | 10 MB                                  | 10 MB                                          | 128 KB message / 32 KB frame   |
+| API Management        |                                        |                                                |                                |
+| Usage plans/API keys      | Yes                                    | No                                             | No                             |
+| Request validation        | Yes (JSON Schema draft 4)              | No                                             | No                             |
+| Caching                   | Yes (0.5-237 GB)                       | No                                             | No                             |
+| Custom gateway responses  | Yes                                    | No                                             | No                             |
+| VTL mapping templates     | Yes                                    | No (parameter mapping only)                    | Yes                            |
+| Security & Governance |                                        |                                                |                                |
+| WAF                       | Yes                                    | No (use CloudFront + WAF)                      | No                             |
+| Resource policies         | Yes                                    | No                                             | No                             |
+| Private endpoints         | Yes                                    | No                                             | No                             |
+| mTLS                      | Yes (Regional custom domain only)      | Yes (Regional custom domain only)              | Via CloudFront viewer mTLS     |
+| Auth                  |                                        |                                                |                                |
+| Lambda authorizer         | Yes (TOKEN + REQUEST)                  | Yes (REQUEST only, simple + IAM policy format) | Yes (REQUEST on $connect only) |
+| JWT authorizer            | No (use Cognito authorizer)            | Yes (native)                                   | No                             |
+| Cognito authorizer        | Yes (native)                           | Use JWT authorizer                             | No                             |
+| Operations            |                                        |                                                |                                |
+| Canary deployments        | Yes                                    | No                                             | No                             |
+| Response streaming        | Yes                                    | No                                             | No                             |
+| X-Ray tracing             | Yes                                    | No                                             | No                             |
+| Execution logging         | Yes                                    | No                                             | Yes                            |
+| Custom domain sharing     | Not with WebSocket                     | Not with WebSocket                             | Not with REST/HTTP             |
+
+Use REST API when: you are building APIs for external consumers, partners, or multi-tenant platforms; need to enforce per-consumer rate limits and quotas; require request validation, caching, or WAF at the API layer; need private endpoints, resource policies, or canary deployments; or are building an API product with monetization and governance requirements.
+
+Use HTTP API when: you are building lightweight APIs or simple backend proxies; cost and latency are the primary concerns; you don't need per-consumer throttling, request validation, caching, or WAF at the API layer; and native JWT authorization with OIDC/OAuth 2.0 meets your auth needs. Accept the hard 30s timeout and lack of API management features. For WAF, edge caching, or edge compute, place a CloudFront distribution in front of the HTTP API.
+
+Use WebSocket API when you need: persistent bidirectional connections for real-time use cases (chat, notifications, live dashboards).
+
+## Instructions
+
+### Step 1: Design the API
+
+Before implementation, gather requirements systematically. Consult `references/requirements-gathering.md` for the full requirements workflow covering endpoints, auth, data models, performance, security, and deployment needs.
+
+Key design decisions:
+
+1. API type: Use the decision table above
+2. Endpoint type: Edge-optimized (default for global clients; optimizes TCP connections via CloudFront POPs but does not cache at the edge), Regional (same-region clients, or global clients needing their own CloudFront distribution for edge caching, edge compute, granular WAF control, or geo-based routing), Private (VPC-only access, REST API only)
+3. Topology: Centralized (single domain, path-based routing) vs Distributed (subdomains per service)
+4. Authentication: See `references/authentication.md` for the decision tree
+
+### Step 2: Implement the API
+
+Consult these references based on what you're building:
+
+- Architecture patterns: `references/architecture-patterns.md`: topology, multi-tenant SaaS, hybrid workloads, private APIs, multi-region, streaming
+- WebSocket API: `references/websocket.md`: route selection, @connections management, session management, client resilience, SAM templates, limits, multi-region
+- Service integrations: `references/service-integrations.md`: direct AWS service integrations (EventBridge, SQS, SNS, DynamoDB, Kinesis, Step Functions, S3), HTTP proxy, mock, VTL mapping templates, binary media types, Lambda sync/async invocation
+- Custom domains and routing: `references/custom-domains-routing.md`: base path mappings, routing rules, header-based versioning
+- Security: `references/security.md`: mTLS (API Gateway native + CloudFront viewer mTLS), TLS policies, resource policies, WAF, HttpOnly cookies, CRL checks
+- SAM/CloudFormation: `references/sam-cloudformation.md`: IaC patterns, OpenAPI extensions, VTL reference, binary data
+- SAM service integration templates: `references/sam-service-integrations.md`: EventBridge, SQS, DynamoDB CRUD, Kinesis, Step Functions (REST + WebSocket) templates
+
+### Step 3: Configure Performance and Scaling
+
+- Throttling: Account-level default is 10,000 rps / 5,000 burst (adjustable; request increases via AWS Support). Configure stage-level and method-level throttling via usage plans. See `references/performance-scaling.md`
+- Caching (REST only): Default TTL 300s, max 3600s. Only GET methods cached by default. Max cached response 1 MB
+- Edge caching (all API types): For edge caching, place a self-managed CloudFront distribution in front of a Regional API. CloudFront reduces latency, backend load, AND cost (cached responses never reach API Gateway). Also enables edge compute (CloudFront Functions, Lambda@Edge) and granular cache behaviors per path. Use a Regional endpoint, not edge-optimized, when pairing with your own CloudFront distribution
+- Scaling: API Gateway scales automatically but plan the entire stack (Lambda concurrency, DynamoDB capacity)
+
+### Step 4: Set Up Observability
+
+Always configure access logging. For REST and WebSocket APIs, also enable execution logging (ERROR level for production, INFO only for debugging). HTTP API does not support execution logging; use access logs with enhanced observability variables instead.
+
+Before running live AWS commands or MCP tools for logging, deployment, DNS, certificates, custom domains, WAF, resource policies, cache invalidation, or API changes, explain the affected account/resources and ask for explicit approval.
+
+Consult the observability references based on what you need:
+
+- Logging setup, log formats, retention: `references/observability-logging.md`
+- Metrics, alarms, metric filters, X-Ray tracing: `references/observability-metrics-alarms.md`
+- Log analysis and insights, analytics pipeline, cross-account, control plane logs: `references/observability-analytics.md`
+
+### Step 5: Deploy
+
+- Use Infrastructure as Code (SAM, CDK, CloudFormation, Terraform) for production
+- Canary deployments (REST only): Route a percentage of traffic to test new versions
+- Blue/green deployments: Use custom domain API mappings to switch between environments with zero downtime
+- Routing rules (preferred for new domains): Declarative header/path-based routing on custom domains for versioning, A/B testing, gradual rollouts, and cell-based routing
+- See `references/deployment.md` for detailed patterns
+
+### Step 6: Apply Governance
+
+For organization-wide API standards, see `references/governance.md` covering:
+
+- Preventative controls (SCPs, IAM policies)
+- Proactive controls (CloudFormation Hooks, Guard rules)
+- Detective controls (AWS Config rules, EventBridge)
+- Specific enforcement examples for security, observability, and management
+
+## Response Format
+
+When responding to API Gateway questions, structure your answer as:
+
+1. Recommendation: Lead with the recommended approach and why
+2. Code: Include SAM/CloudFormation YAML or code when the user needs implementation (always read the relevant reference file first)
+3. Pitfalls: Warn about relevant gotchas from the pitfalls below or from `references/pitfalls.md`
+4. Limits: Mention any service limits that constrain the design
+
+## Troubleshooting Quick Reference
+
+When diagnosing API Gateway errors, consult `references/troubleshooting.md` for detailed resolution steps. Here are the most common issues:
+
+| Error                  | Most Common Cause                                                                                                       | Quick Fix                                                                                         |
+| ---------------------- | ----------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------- |
+| 400 Bad Request        | Protocol mismatch (HTTP/HTTPS) with ALB                                                                                 | Match protocol to listener type                                                                   |
+| 401 Unauthorized       | Wrong token type (ID vs access) or missing identity sources                                                             | Check token type matches scope config; verify all identity sources sent                           |
+| 403 Missing Auth Token | Stage name in URL when using custom domain                                                                              | Remove stage name from URL path                                                                   |
+| 403 from VPC           | Private DNS on VPC endpoint intercepts ALL API calls                                                                    | Use custom domain names for public APIs                                                           |
+| 403 Access Denied      | Resource policy + auth type mismatch or missing redeployment                                                            | Review policy, check auth type, redeploy API                                                      |
+| 403 mTLS               | Certificate issuer not in truststore or weak signature algorithm                                                        | Verify CA in truststore, use SHA-256+                                                             |
+| 429 Too Many Requests  | Account/stage/method throttle limits exceeded                                                                           | Implement jittered exponential backoff; request limit increase                                    |
+| 500 Internal Error     | Missing Lambda invoke permission (especially with stage variables)                                                      | Add resource-based policy to Lambda function                                                      |
+| 502 Bad Gateway        | Lambda response not in required proxy format                                                                            | Return `{statusCode, headers, body}` from Lambda                                                  |
+| 504 Timeout            | Backend exceeds 29s (REST, increasable) or 30s (HTTP, hard). HTTP API body says "Service Unavailable" but status is 504 | Optimize backend, request timeout increase (REST Regional/Private), or switch to async invocation |
+| CORS errors            | Missing CORS headers on Gateway Responses (4XX/5XX)                                                                     | Add CORS headers to DEFAULT_4XX and DEFAULT_5XX gateway responses                                 |
+| SSL/PKIX errors        | Incomplete certificate chain on backend                                                                                 | Provide full cert chain; use `insecureSkipVerification` only for testing                          |
+
+## Critical Pitfalls
+
+1. REST API default timeout is 29 seconds (increasable up to 300s for Regional/Private endpoints via quota request). Lambda continues running but client gets 504. Request a timeout increase, or consider async patterns (SQS, EventBridge) for better user experience on long operations
+2. HTTP API hard timeout is 30 seconds. Returns `{"message":"Service Unavailable"}` while Lambda continues
+3. `/ping` and `/sping` are reserved paths. Do not use for API resources
+4. Execution log events truncated at 1,024 bytes. Use access logs for complete data
+5. 413 `REQUEST_TOO_LARGE` is the only gateway response that cannot be customized. Use DEFAULT_4XX as a catch-all to add CORS headers for all 4xx errors including 413
+6. `maxItems`/`minItems` not validated in REST API request validation
+7. Root-level `security` in OpenAPI is ignored. Must set per-operation
+8. JWT authorizer public keys cached 2 hours. Account for this in key rotation
+9. Management API rate limit: 10 rps / 40 burst. Heavy automation can hit this
+10. Always redeploy REST API after configuration changes. Changes don't take effect until deployed
+11. Edge-optimized endpoints do NOT cache at the edge -- they only optimize TCP connections via CloudFront POPs. If you need edge caching, edge compute (CloudFront Functions, Lambda@Edge), or granular CloudFront control, use a Regional API with your own CloudFront distribution instead
+
+For additional pitfalls (header handling, URL encoding, caching charges, canary deployments, usage plans), see `references/pitfalls.md`.
+
+## IaC Framework Selection
+
+Default: CDK TypeScript
+
+Override syntax:
+
+- "use SAM" -> Generate SAM/CloudFormation YAML templates
+- "use CloudFormation" -> Generate CloudFormation YAML templates
+- "use Terraform" -> Generate Terraform HCL
+
+When not specified, ALWAYS use CDK TypeScript.
+
+## Error Scenarios
+
+### MCP Server Unavailable
+
+- Inform user: "AWS Serverless MCP not responding"
+- Ask: "Proceed without MCP support?"
+- DO NOT continue without user confirmation
+
+## Service Limits Quick Reference
+
+See `references/service-limits.md` for the complete table. Most numeric quotas below are default values and adjustable; check with your AWS account team and the [latest quotas page](https://docs.aws.amazon.com/apigateway/latest/developerguide/limits.html) before using them for architectural decisions. Key limits:
+
+| Resource                 | REST API                                 | HTTP API | WebSocket           |
+| ------------------------ | ---------------------------------------- | -------- | ------------------- |
+| Payload size             | 10 MB                                    | 10 MB    | 128 KB              |
+| Integration timeout      | 50ms-29s (up to 300s Regional/Private)   | 30s hard | 29s                 |
+| APIs per region          | 600 Regional/Private; 120 Edge-optimized | 600      | 600                 |
+| Stages per API           | 10                                       | 10       | 10                  |
+| Routes/resources per API | 300                                      | 300      | 300                 |
+| Custom domains (public)  | 120                                      | 120      | 120                 |
+| Account throttle         | 10,000 rps / 5,000 burst                 | Same     | Same (shared quota) |
+| API keys per region      | 10,000                                   | N/A      | N/A                 |
+| Usage plans per region   | 300                                      | N/A      | N/A                 |
+| Cache sizes              | 0.5 GB - 237 GB                          | N/A      | N/A                 |

--- a/plugins/aws-serverless/skills/aws-serverless-api-gateway/SKILL.md
+++ b/plugins/aws-serverless/skills/aws-serverless-api-gateway/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: aws-serverless-api-gateway
+description: Design, implement, secure, and troubleshoot Amazon API Gateway REST APIs, HTTP APIs, and WebSocket APIs backed by Lambda or AWS service integrations.
+---
+
+# AWS Serverless API Gateway
+
+Use this skill for Amazon API Gateway work involving REST APIs, HTTP APIs, WebSocket APIs, Lambda authorizers, JWT auth, Cognito, custom domains, CORS, throttling, usage plans, private APIs, VPC links, service integrations, or API Gateway troubleshooting.
+
+## Workflow
+
+1. Classify the API type first:
+   - Use HTTP API for lightweight, low-latency Lambda or HTTP proxy APIs with simpler auth and lower cost.
+   - Use REST API when the user needs usage plans, API keys, request validation, caching, resource policies, private endpoints, WAF at the API layer, or canary deployments.
+   - Use WebSocket API for persistent bidirectional connections.
+2. Gather endpoint shape, auth requirements, tenancy model, latency expectations, client locations, traffic profile, compliance needs, and deployment environments.
+3. Prefer IaC examples using the repository's existing framework. If no framework exists, recommend SAM for compact serverless apps or CDK for larger typed infrastructure.
+4. Configure access logs for every API. Add execution logs only where the API type supports them and only at an appropriate level.
+5. Treat CORS as a security configuration, not a wildcard default. Reflect the actual allowed origins, headers, credentials mode, and methods.
+6. For custom domains, account for certificate region, Route 53 ownership, base path mappings, CloudFront behavior, and rollout or rollback.
+7. For private APIs or VPC links, verify DNS, security groups, route tables, endpoint policies, and resource policies before changing infrastructure.
+
+## MCP Use
+
+Use `aws-serverless-mcp` for serverless API templates, deployment guidance, and Lambda-backed API workflow helpers when they add value.
+
+Before MCP calls, narrow inputs to the API design question or the relevant IaC snippet. Do not send tokens, credentials, private request payloads, customer data, or unrelated application code.
+
+## Safety
+
+Ask before deploying APIs, configuring domains, creating certificates, changing DNS, adding IAM permissions, changing VPC links, invalidating caches, invoking live endpoints with private payloads, or reading API Gateway or Lambda logs.
+
+When troubleshooting production traffic, ask for sanitized examples and prefer targeted identifiers over raw request bodies.

--- a/plugins/aws-serverless/skills/aws-serverless-api-gateway/references/architecture-patterns.md
+++ b/plugins/aws-serverless/skills/aws-serverless-api-gateway/references/architecture-patterns.md
@@ -1,0 +1,189 @@
+# Architecture Patterns
+
+## Topology Patterns
+
+Three topology patterns:
+
+1. Single AWS account: Simplest. All APIs in one account with routing rules or base path mappings
+2. Separate AWS accounts per domain/application: Better isolation. Each account owns a subdomain (e.g., `orders.example.com`, `shipping.example.com`) and can contain multiple microservices behind it. No cross-account base path mappings, so subdomain-per-account is the routing mechanism
+3. Central API account: Central account owns the custom domain and routes to backend APIs in other accounts. Centralized governance, throttling, metering, and observability
+
+### API Gateway as Single Entry Point
+
+- Both single AWS account or central API account scenarios
+- Map different custom domain subdomains to the same API with routing rules or different base path mappings
+- Route different paths (`/service1`, `/service2`, `/docs`) to different backends
+
+Endpoint type selection:
+
+- Regional (default): API deployed in a single region. Best when clients are in the same region or when using your own CloudFront distribution for edge caching/WAF control. Supports custom domains with ACM certificates in the same region
+- Edge-optimized: Routes requests through CloudFront POPs for optimized TCP connections to global clients. Does NOT cache at the edge. For actual edge caching, use a self-managed CloudFront distribution with a Regional API. ACM certificate must be in `us-east-1`
+- Private: Accessible only from within a VPC via `execute-api` VPC endpoint. REST API only. See Private API Endpoints section below
+
+Trade-offs with central account:
+
+- X-Ray traces can span accounts using CloudWatch cross-account observability (source/monitoring account linking), but require explicit setup
+- Usage plans cannot track across accounts without aggregation
+- CloudWatch dashboards require aggregation in central account
+
+## Multi-Tenant SaaS Specific Concerns
+
+- Tiered usage plans (free/pro/enterprise or bronze/silver/gold)
+- Lambda authorizer validates JWT from external IdP, extracts tenant ID, retrieves per-tenant API key from DynamoDB, returns it in `usageIdentifierKey` for transparent per-tenant throttling (see `references/authentication.md` for full flow)
+- Set `ApiKeySourceType: AUTHORIZER` so API Gateway reads the key from the authorizer response, so tenants never see or manage API keys
+- Onboarding automation: create tenant in IdP + API key in API Gateway + mapping in DynamoDB + associate key with usage plan tier
+- Forward tenant identification as custom header to backend for tenant-specific logic
+- Lambda tenant isolation mode: For compute-level tenant isolation beyond throttling, create Lambda functions with `--tenancy-config '{"TenantIsolationMode": "PER_TENANT"}'`. Lambda isolates execution environments per tenant: each environment is reused only for invocations from the same tenant, preventing cross-tenant data access via in-memory or `/tmp` storage. API Gateway maps the tenant ID to the `X-Amz-Tenant-Id` header on the Lambda integration request (e.g., from a Lambda authorizer context value via `context.authorizer.tenantId`, or from a client request header via `method.request.header.x-tenant-id` mapped to `integration.request.header.X-Amz-Tenant-Id`). Tenant ID is available in the handler context object (`context.tenantId` in Node.js, `context.tenant_id` in Python). Must be set at function creation time (cannot be changed later). Expect more cold starts since execution environments are not shared across tenants. All tenants share the function's execution role; for fine-grained per-tenant permissions, propagate tenant-scoped credentials from upstream components
+
+## Integration Patterns
+
+API Gateway supports five integration types: `AWS`, `AWS_PROXY`, `HTTP`, `HTTP_PROXY`, and `MOCK`. See `references/service-integrations.md` for detailed configuration of each pattern.
+
+Lambda integrations (`AWS_PROXY` / `AWS`), the most common integration type. `AWS_PROXY` (Lambda proxy) is the recommended default: API Gateway passes the full request to Lambda and returns the Lambda response directly, no mapping templates needed. `AWS` (Lambda non-proxy) allows VTL request/response transformation but requires more setup.
+
+Direct AWS service integrations: integrate directly with AWS services without Lambda. Two implementation approaches:
+
+- REST API and WebSocket API use `Type: AWS` with VTL mapping templates for full request/response transformation. Supports most of AWS services' actions
+- HTTP API uses first-class integrations (`Type: AWS_PROXY` with `IntegrationSubtype`) with parameter mapping instead of VTL. Supported services: EventBridge (`PutEvents`), SQS (`SendMessage`, `ReceiveMessage`, `DeleteMessage`, `PurgeQueue`), Kinesis (`PutRecord`), Step Functions (`StartExecution`, `StartSyncExecution`, `StopExecution`), and AppConfig (`GetConfiguration`). DynamoDB, SNS, and S3 are not available as HTTP API first-class integrations; use Lambda proxy instead
+
+Most commonly used service integrations (REST API `Type: AWS` can integrate with any AWS service that has an HTTP API; the list below covers the most popular patterns; see `references/service-integrations.md` for details):
+
+- EventBridge: event ingestion
+- SQS: async message buffering
+- SNS: fan-out pub/sub to multiple subscribers (REST/WebSocket only)
+- DynamoDB: full CRUD with optional Streams for async processing (REST/WebSocket only)
+- Kinesis Data Streams: high-throughput ordered data ingestion
+- Step Functions: workflow orchestration (sync Express or async Standard).
+- S3: file upload/download proxy with binary media type support (REST/WebSocket only)
+
+HTTP integrations (`HTTP` / `HTTP_PROXY`): proxy to any HTTP endpoint (ALB, NLB, ECS, EC2, on-premises, external APIs). Use VPC Link for private backends. Available on REST and HTTP APIs. API Gateway is a valid choice for east-west (service-to-service) traffic when API management capabilities are needed beyond what load balancing provides (throttling, usage plans, request validation, authentication, and centralized observability). For internal calls that do not need these controls, prefer direct invocation (ALB, service mesh, or Lambda-to-Lambda) for lower latency and cost.
+
+Mock integrations (`Type: MOCK`): responses without any backend (health checks, CORS preflight, prototyping)
+
+Common patterns across all integrations: IAM execution roles, request validation, response mapping, Lambda sync/async invocation, backend bypass prevention (zero trust), and binary media type handling. Security note for direct service integrations: Use VTL mapping templates and API Gateway request validators. Every field that reaches the AWS service must be explicitly constructed in the mapping template. Never pass user input directly into service parameters without validation. Scope the IAM execution role to minimum required actions and specific resource ARNs (e.g., a single SQS queue, a single DynamoDB table). For S3 integrations, hardcode the bucket and validate key patterns to prevent path traversal.
+
+## Hybrid / On-Premises Workloads
+
+Connect API Gateway to on-premises or edge applications:
+
+1. VPC with connectivity to on-prem (VPN/Direct Connect/Transit Gateway)
+2. NLB/ALB with target group using IP addresses to register on-prem server IPs
+3. VPC Link to the NLB/ALB
+4. API Gateway with `VPC_LINK` integration type
+
+AWS Outposts: Workloads running on Outposts (EC2, ECS, ALB) can also serve as integration targets. Outposts extend the VPC into the on-premises environment, so the same VPC Link + NLB/ALB pattern applies. Register Outposts instance IPs in the NLB target group
+
+Connectivity considerations: This pattern assumes stable, low-latency connectivity to the on-premises location. AWS Direct Connect provides the most reliable path. Site-to-Site VPN connections are inherently less stable; tunnel flaps cause NLB/ALB targets to become unreachable. With default NLB/ALB health check settings (30s interval, 3 failures), there is a ~90-second window where API Gateway sends traffic to unreachable targets, resulting in integration timeouts. Tune NLB health check intervals (10s, 2 failures) and set API Gateway integration timeouts to match your SLA. Implement a `/health` endpoint on the on-premises target that validates downstream dependencies. Monitor NLB/ALB `UnHealthyHostCount` and alarm on it
+
+## Private API Endpoints (not accessible from the public Internet)
+
+- REST API only, accessible via VPC interface endpoint for `execute-api`
+- Resource policy must allow access from VPC endpoint or VPC
+- Deploy VPC endpoints across multiple AZs for high availability
+- `disableExecuteApiEndpoint: true` forces traffic through custom domain only
+
+### Private API as External API Proxy
+
+- Private APIs can proxy external/third-party APIs for workloads in isolated VPCs (no NAT gateway or internet access needed)
+- API Gateway is a managed service in an AWS-managed VPC; it has internet connectivity even when your VPC does not
+- Pattern: Private API (VPC endpoint) -> HTTP_PROXY integration -> external API
+- Adds centralized logging, throttling, and access control to external API calls
+- Security warning: This pattern effectively grants internet egress to an isolated VPC through API Gateway. Lock down the HTTP_PROXY integration to specific allowed external domains. Do not use parameterized URLs that callers can control. Apply a resource policy restricting which VPC endpoints can invoke the API. Enable full access logging. This egress path does not appear in VPC flow logs or network firewall logs, so security teams must be aware of it as a potential data exfiltration vector
+
+### Private API Cross-Account Access
+
+- Pattern 1: VPC endpoint in consumer account + resource policy in producer account allowing `aws:SourceVpce`. Combine with IAM authorization (SigV4) or Lambda authorizer for defense in depth. The resource policy controls network-level access, but without authentication any workload in the consumer VPC that can reach the VPC endpoint can invoke the API
+- Pattern 2: PrivateLink between accounts with VPC endpoint
+- Pattern 3: Transit Gateway connecting VPCs across accounts (one of them with VPC endpoint )
+
+### Custom Domains for Private APIs
+
+- Private custom domain names (`AWS::ApiGateway::DomainNameV2`), dualstack only
+- Share cross-account via AWS RAM using domain name access associations
+- Route 53 private hosted zone with alias record pointing to VPC endpoint regional DNS
+
+### Enforcing CloudFront as Sole Entry Point
+
+To prevent clients from bypassing CloudFront and hitting API Gateway directly (skipping WAF, caching, geo-restrictions):
+
+- Private API approach: Make the API Gateway endpoint private (VPC endpoint only), place CloudFront in front with VPC Origins: CloudFront -> VPC Origin (internal ALB) -> execute-api VPC endpoint -> private API. All traffic stays within AWS private network and the API is unreachable from the public internet without CloudFront
+- Regional API + restrictions (defense-in-depth, not a security boundary): Keep a regional endpoint but restrict direct access. Use a custom header from CloudFront (via origin custom headers) and validate it in a Lambda authorizer. Combine with disabling the default `execute-api` endpoint to force traffic through the custom domain fronted by CloudFront. Caveat: The header value is a static secret. If leaked through logs, source code, or developer machines, attackers can bypass CloudFront. Rotate the value regularly, store it in AWS Secrets Manager, and treat it as a credential.
+
+### On-Premises Access to Private APIs
+
+- AWS Direct Connect or Site-to-Site VPN to reach VPC with VPC endpoint
+- Route 53 Resolver inbound endpoints for on-premises DNS resolution of VPC endpoint DNS names or private custom domain
+
+## VPC Links
+
+VPC Links enable API Gateway to reach private integration targets inside a VPC that are not publicly accessible. API Gateway creates a private connection to the VPC without exposing the backend to the internet.
+
+- VPC Link v2 (`AWS::ApiGatewayV2::VpcLink`): Supported by REST and HTTP APIs, targets ALB, NLB, and Cloud Map (for HTTP APIs) services. One VPC link per VPC can serve multiple backends. Prefer v2 for new integrations
+- VPC Link v1 (`AWS::ApiGateway::VpcLink`): Used by WebSocket API (and legacy REST API integrations), targets NLB only
+- Not the same as private endpoints: A _private API endpoint_ restricts who can call the API (only from within a VPC via `execute-api` VPC endpoint). A _VPC Link_ controls where the API forwards requests to (private backends in a VPC). These are independent: a public API can use VPC Links to reach private backends, and a private API can call public HTTP endpoints without VPC Links
+
+## Multi-Region
+
+### Foundational Setup
+
+- API Gateway custom domain names are regional resources. Create the same custom domain name (e.g., `api.example.com`) independently in each region
+- Each region requires its own ACM certificate for the domain. ACM certificates are also regional. Request or import in every region where the API is deployed
+- Route 53 alias records point to each region's API Gateway regional domain name (the `d-xxxxxx.execute-api.{region}.amazonaws.com` target provided when creating the custom domain)
+- Deploy the full stack (API Gateway, Lambda, DynamoDB, etc.) independently per region; there is no cross-region replication of API Gateway configuration
+- Use IaC (SAM/CDK/Terraform) with parameterized region to ensure consistent deployments across regions
+
+### Active-Passive Failover
+
+- Route 53 failover routing policy with health checks on the primary region
+- Health checks monitor a `/health` endpoint or a CloudWatch alarm (e.g., on 5XX error rate or backend availability)
+- On primary failure, Route 53 automatically routes all traffic to the secondary region
+- Route 53 Application Recovery Controller (ARC) for manual failover switches when automated routing is insufficient (e.g., data corruption in one region)
+- RPO/RTO trade-off: Health check interval (10s or 30s) + failover propagation (~60-120s DNS TTL) determines theoretical failover speed. In practice, plan for 3-10 minutes, as many clients cache DNS aggressively beyond TTL (Java caches successful lookups indefinitely by default, mobile SDKs and corporate resolvers vary). Set Route 53 record TTL to 60s, but do not size SLAs around sub-minute failover. For faster failover, use Global Accelerator (anycast IP, no DNS propagation delay) or CloudFront with origin failover (seconds, not minutes)
+
+### Active-Active
+
+- Route 53 latency-based or geo-based routing to nearest region
+- All regions serve traffic simultaneously; both must be fully provisioned, not just on standby
+- Data sovereignty: Latency-based routing may route EU users to US regions (or vice versa) if latency is lower, potentially violating GDPR or other data residency requirements. Use geo-based routing (combined with tenant locality verification) when data sovereignty is a concern. Note that DynamoDB Global Tables replicate data to all configured regions regardless of routing, so do not add regions that would violate data residency constraints
+
+### Resilient Private APIs (Multi-Region)
+
+- Private API in each region + VPC endpoint + Custom Domain Name
+- Route 53 private hosted zone with latency-based or failover routing
+- Transit Gateway with inter-Region peering for VPC connectivity
+- Health checks must be CloudWatch alarm-based: Route 53 health checkers run from the public internet and cannot reach private API endpoints. Create CloudWatch alarms on NLB `UnHealthyHostCount`, API Gateway `5XXError` rate, or custom health metrics, then associate them with Route 53 health checks. Monitor Transit Gateway peering status separately; if inter-region peering fails, failover routing becomes critical
+
+## Response Streaming
+
+- Still a request/response pattern: client sends a request and receives a streamed response. The connection is one-directional (server to client) and closes when the response completes. For bidirectional real-time communication, use WebSocket API (see `references/websocket.md`)
+- REST API only; not available for HTTP API or WebSocket API
+- Set `responseTransferMode: "STREAM"` on integration
+- Supports HTTP_PROXY, Lambda proxy, and private integrations (ALB/NLB/Cloud Map backends via VPC Link)
+- Lambda integrations: Use `awslambda.streamifyResponse()` and `HttpResponseStream.from()`
+- HTTP integrations: Backend sends a chunked transfer-encoded response (`Transfer-Encoding: chunked`); API Gateway streams chunks to the client as they arrive, with no Lambda required
+- First 10 MB unrestricted; beyond 10 MB bandwidth limited to 2 MB/s
+- Max streaming session: 15 minutes, removing the 10 MB buffered response limit
+- Idle timeouts: 5 min (Regional/Private), 30 sec (edge-optimized)
+- Billing: each 10 MB of response (rounded up) = 1 request
+- Limitations: No VTL response transformation, no caching, no content encoding with streaming
+- Key use cases: LLM chatbot implementations that stream sentence-by-sentence for better UX; large payload delivery beyond the 10 MB buffered response limit (up to 15 minutes of streaming); real-time data feeds (logs, metrics, event streams) where partial results are useful before the full response completes; file downloads from backend services where the client can begin processing immediately
+
+## Designing APIs for AI Agent Consumption
+
+As AI agents become API consumers, design considerations change:
+
+- Rich documentation: API descriptions must be detailed enough for LLMs to understand intent, not just for humans
+- Descriptive error messages: AI agents need enough context in error responses to retry with corrective information
+- Minimize round-trips: Consider how many requests are needed to perform one action. Batch operations and intent-based APIs (e.g., "manage user" vs. separate GET/PUT/DELETE) reduce agent complexity
+- Machine-friendly pagination: Use cursor-based pagination that machine consumers can follow automatically
+- Resource-based vs intent-based: Consider whether traditional CRUD or intent-based endpoints better serve AI consumers
+- Non-deterministic cost: AI-backed APIs have variable processing cost per request (LLM token usage varies). Factor this into monetization and usage plan design
+
+## Reducing Backend Load
+
+- Request validation at the front door: Use API Gateway validators (headers, query strings, JSON schema) to reject bad requests before they reach the backend
+- WAF rules: Block traffic from regions with no customers
+- Add pagination and filters: Reduce response data volume
+- Batch operations: Combine multiple small actions into single requests
+- Async processing: Acknowledge request immediately, queue for backend processing at its own pace. Better for constrained backend resources
+- Caching strategy: Use CloudFront caching first (reduces load, latency, AND cost, since the request never reaches API Gateway). Use API Gateway cache as fallback (reduces load and latency but NOT cost, as the request is still counted by API Gateway). See `references/performance-scaling.md` for cache sizing, TTL configuration, and multi-layer caching details

--- a/plugins/aws-serverless/skills/aws-serverless-api-gateway/references/authentication.md
+++ b/plugins/aws-serverless/skills/aws-serverless-api-gateway/references/authentication.md
@@ -1,0 +1,114 @@
+# Authentication and Authorization
+
+## Decision Tree
+
+```
+Is this a WebSocket API?
+  YES -> Lambda Authorizer (REQUEST type only on $connect; TOKEN type not
+         supported; cached policy applies for entire connection, must
+         cover all routes) or IAM (SigV4)
+  NO ->
+Is the consumer an AWS service or resource?
+  YES -> IAM Authorization (SigV4)
+  NO -> Is the consumer a browser-based app?
+    YES -> Do you use Cognito?
+      YES -> REST API: Cognito User Pool Authorizer
+             HTTP API: JWT Authorizer (Cognito issuer)
+      NO  -> Do you use another OIDC provider?
+        YES -> HTTP API: JWT Authorizer
+               REST API: Lambda Authorizer (validate JWT)
+        NO  -> Lambda Authorizer (custom logic)
+    NO -> Is this machine-to-machine (M2M)?
+      YES -> Do you need certificate-based auth?
+        YES -> mTLS (Regional custom domain + S3 truststore)
+        NO  -> OAuth 2.0 Client Credentials Grant (Cognito + JWT/Cognito authorizer)
+      NO -> Lambda Authorizer (most flexible)
+```
+
+## IAM Authorization (SigV4)
+
+- Works for REST, HTTP, and WebSocket APIs (WebSocket: evaluated on `$connect` only)
+- Caller signs requests with AWS Signature Version 4
+- Best for: AWS-to-AWS service calls, Cognito identity pools, resources already integrated with IAM
+- Cross-account REST API: Requires BOTH IAM policy (caller account) AND resource policy (API account)
+- Cross-account HTTP API: No resource policies; use `sts:AssumeRole` to assume a role in the API account
+- Multi-region: SigV4 signatures are region-specific: the signing region must match the region receiving the request. In multi-region deployments with Route 53 failover or latency-based routing, clients signing for one region will get auth failures if routed to another. SigV4a (multi-region signing) is not supported by API Gateway. Workarounds: use a region-agnostic auth mechanism (Lambda authorizer, JWT) for multi-region APIs, or implement client-side retry logic that re-signs for the correct region on auth failure
+
+## Lambda Authorizers
+
+### REST API
+
+- TOKEN type: Receives a single header value (typically `Authorization`) as input. Returns IAM policy document. If the identity source header is missing, API Gateway returns 401 immediately without invoking the Lambda; the authorizer function never gets the chance to handle missing tokens
+- REQUEST type: Receives headers, query strings, stage variables, and context variables as input. Returns IAM policy document. When caching is enabled and identity sources are specified, a request missing any identity source returns 401 without invoking the Lambda
+- Both types must return `principalId` (string identifying the caller) alongside the policy document. Missing `principalId` causes 500 Internal Server Error
+- Response limits: IAM policy document max ~8 KB. Exceeding this or returning a malformed response causes 500 Internal Server Error (not 401/403), a common debugging pitfall
+- Caching: TTL default 300s, max 3600s. Cache key is the token value (TOKEN type) or identity sources (REQUEST type). When caching is enabled, the IAM policy returned by the first request is reused for subsequent requests with the same cache key. If that policy only covers specific resources (e.g., the path of the initial request), subsequent requests to other paths will be denied by the cached partial policy, causing hard-to-troubleshoot failures where clients intermittently cannot access parts of the API. Always generate IAM policies that cover the entire API when caching is enabled
+
+### HTTP API
+
+- Simple response format: Returns `{isAuthorized: true/false, context: {...}}`, much simpler than IAM policy
+- IAM policy format: Also supported for more complex authorization. When using IAM policy format with caching, the same full-API policy guidance from REST API applies; see REST API caching note above
+- Identity sources: `$request.header.X`, `$request.querystring.X`, `$context.X`, `$stageVariables.X`
+- Caching: Disabled by default (TTL=0), unlike REST API (TTL=300s). Add `$context.routeKey` to identity sources to cache per-route when enabling caching
+- Timeout: 10,000ms max
+
+## JWT Authorizers (HTTP API Only)
+
+- Validates: `iss`, `aud`/`client_id`, `exp`, `nbf` (must be before current time), `iat` (must be before current time), `scope`/`scp` (against route-configured scopes). Uses `kid` for JWKS key lookup. Request is denied if any validation fails
+- Only RSA-based algorithms supported (RS256, RS384, RS512). ECDSA (ES256, ES384, ES512) is not supported. If your IdP signs tokens with ECDSA, use a Lambda authorizer instead
+- Public key cached for 2 hours; account for this in key rotation
+- Token validation runs on every request (no result caching); only the JWKS public keys are cached (2 hours). This differs from REST API Cognito authorizer which caches the validation result
+- JWKS endpoint timeout: 1,500ms
+- Max audiences per authorizer: 50. Max scopes per route: 10
+- Use access tokens with scopes for authorization. ID tokens also work when no scopes are configured on the route, but access tokens are preferred for API authorization
+- Only supports self-contained JWTs; opaque access tokens are not supported. If your IdP issues opaque tokens by default, use a Lambda authorizer instead
+- Works natively with Cognito, Auth0, Okta, and any OIDC-compliant provider
+
+## Cognito User Pools (REST API)
+
+- Native authorizer type for REST APIs
+- When no OAuth scopes configured on the method: use ID token
+- When scopes configured: use access token
+- Set up: Create user pool, app client, configure scopes on resource server
+- Token revocation not enforced: The Cognito authorizer validates tokens locally (signature + claims) and does not check revocation status with Cognito. Revoked tokens (`GlobalSignOut`, `AdminUserGlobalSignOut`) are accepted until the token's `exp` time, as revocation is invisible to local validation regardless of caching. Separately, caching (default TTL 300s) means expired tokens may be accepted for up to the TTL duration after `exp`. For immediate revocation, use a Lambda authorizer with token introspection instead
+- M2M auth: OAuth 2.0 Client Credentials Grant (confidential app client with client ID + secret, custom resource server scopes). Also works with HTTP API JWT authorizer using Cognito as issuer
+
+## Resource Policies (REST API Only)
+
+Four key use cases:
+
+1. Cross-account access: Allow specific AWS accounts by specifying the account principal in the `Principal` field
+2. IP filtering: Allow/deny CIDR ranges via `aws:SourceIp` (public) or `aws:VpcSourceIp` (private/VPC)
+3. VPC restriction: Restrict to specific VPCs via `aws:SourceVpc`
+4. VPC endpoint restriction: Restrict to specific VPC endpoints via `aws:SourceVpce`
+
+### Policy Evaluation
+
+Evaluation depends on which auth type is combined with the resource policy:
+
+- Same account + IAM or Lambda authorizer: OR logic. If the auth mechanism allows, access is granted even if the resource policy has no matching statement (silent). An explicit Deny in the resource policy still wins
+- Same account + Cognito: AND logic. Both the Cognito authorizer and the resource policy must allow
+- Resource policy alone (no other auth): Must explicitly allow, otherwise request is denied
+- Cross-account: AND logic. BOTH resource policy AND caller auth must explicitly allow. A silent resource policy results in implicit deny. This applies regardless of auth type (IAM, Cognito, Lambda authorizer)
+- An explicit Deny always wins regardless of combination
+- Always redeploy the API after changing the resource policy
+
+## Mutual TLS (mTLS)
+
+- Truststore in S3 (PEM-encoded, max 1,000 certs, max 1 MB). Certificate chain max 4 levels deep; minimum SHA-256 signature, RSA-2048 or ECDSA-256 key strength
+- S3 bucket must be in the same region as API Gateway; enable versioning for rollback
+- Works with Regional custom domain names for REST and HTTP APIs. Edge-optimized custom domains do not support mTLS
+- WebSocket APIs do not support native mTLS; use CloudFront viewer mTLS instead (see `references/security.md`)
+- ACM certificate required for the API Gateway domain (ACM-issued or imported) for server-side TLS. Truststore accepts CA certificates from any source (ACM Private CA, commercial CA, self-signed root); just needs PEM format
+- Private APIs do not natively support mTLS. Use ALB as a reverse proxy in front: Client -> ALB (mTLS verify with trust store) -> VPC endpoint -> Private API Gateway -> backend. The ALB terminates the mTLS handshake, validates the client certificate, and forwards the request to the private API via the execute-api VPC endpoint
+- Disable default endpoint: Always set `disableExecuteApiEndpoint: true` when using mTLS; otherwise clients can bypass mTLS entirely by calling the default `execute-api` URL directly
+- CRL checks: API Gateway does not check Certificate Revocation Lists. Implement via Lambda authorizer checking against CRL in DynamoDB/S3
+- Certificate propagation to backend: Use Lambda authorizer to extract subject, return in context, inject as custom header via `RequestParameters`
+
+## API Keys
+
+- Not a primary authorization mechanism (easily shared/exposed)
+- Use with usage plans for throttling/quota enforcement only
+- Max 10,000 API keys per region (adjustable). Imported key values must be 20-128 characters
+- Key source: `HEADER` (default, `x-api-key`) or `AUTHORIZER` (Lambda returns key in `usageIdentifierKey`)
+- REST API only. HTTP API does not support API keys or usage plans

--- a/plugins/aws-serverless/skills/aws-serverless-api-gateway/references/custom-domains-routing.md
+++ b/plugins/aws-serverless/skills/aws-serverless-api-gateway/references/custom-domains-routing.md
@@ -1,0 +1,117 @@
+# Custom Domains and Routing
+
+## Custom Domain Names
+
+### Setup by Endpoint Type
+
+- Edge-optimized: ACM certificate must be in `us-east-1`. Creates an internal, AWS-managed CloudFront distribution (not visible in your CloudFront console, not configurable). Does NOT cache at the edge. For actual edge caching, use a separate CloudFront distribution with a Regional API. DNS CNAME/alias to CloudFront domain
+- Regional: ACM certificate must be in same region as API. DNS CNAME/alias to regional domain name (`d-xxx.execute-api.region.amazonaws.com`)
+- Private: REST API only. Dualstack only (`AWS::ApiGateway::DomainNameV2`). Domain name access associations link the domain to VPC endpoints. Route 53 alias in private hosted zone pointing to VPC endpoint regional DNS. Cross-account sharing via AWS RAM domain name access associations. ACM certificate in the same region
+
+Certificate requirements:
+
+- Edge-optimized: ACM-issued public certificate or certificate imported into ACM. Must be in us-east-1. Imported certificates must be [manually rotated before expiration](https://docs.aws.amazon.com/apigateway/latest/developerguide/how-to-edge-optimized-custom-domain-name.html)
+- Regional and Private: ACM-issued public certificate or certificate imported into ACM. Private CA certificates (ACM Private CA) are only for mTLS truststores, not for the domain itself
+
+### Limits
+
+- Public custom domains: 120/region
+- Private custom domains: 50/region
+- API mappings per domain: 200
+- Base path max length: 300 characters
+
+### Common Issues
+
+- CNAMEAlreadyExists (edge-optimized only): CNAME already associated with another CloudFront distribution. Delete or update existing CNAME first, or use Regional endpoint type to avoid this
+- Wrong certificate returned: DNS record points to stage URL instead of API Gateway domain name target
+- Deletion quota: 1 per 30 seconds. Use exponential backoff
+- 403 "Missing Authentication Token": Stage name included in URL when using custom domain. Remove stage name from path
+
+## Base Path Mappings
+
+### Multi-Segment Paths
+
+- Paths can contain forward slashes: `/sales/reporting`, `/sales/reporting/v2`, `/corp/admin`
+- Each routes to a different API endpoint
+- Use `AWS::ApiGatewayV2::DomainName` and `AWS::ApiGatewayV2::ApiMapping` with `ApiMappingKey`
+- Works with both REST (v1) and HTTP (v2) APIs
+- Domain and APIs must be in same account and Region
+- Each sub-application deployed independently
+
+### Multi-Tenant White-Label
+
+White-label domain support allows SaaS providers to serve multiple external customers through customer-specific subdomains (e.g., `customer1.example.com`, `customer2.example.com`) while routing all traffic through a single API Gateway API. Based on the pattern described in [Using API Gateway as a Single Entry Point for Web Applications and API Microservices](https://aws.amazon.com/blogs/architecture/using-api-gateway-as-a-single-entry-point-for-web-applications-and-api-microservices/) (AWS Architecture Blog).
+
+Setup:
+
+1. Register a domain (e.g., `example.com`) and create CNAME records for each customer subdomain (`customer1.example.com`, `customer2.example.com`) via Route 53 or your DNS provider
+2. Create an ACM wildcard certificate (`*.example.com`), which covers one subdomain level only (`tenant1.example.com` matches, `a.tenant1.example.com` does not)
+3. Create a custom domain in API Gateway for each customer subdomain using the wildcard certificate. Each subdomain can have its own base path mappings or routing rules, or use a shared mapping with backend routing based on the forwarded Host header
+4. Point each subdomain's CNAME record to the API Gateway domain name target
+5. Forward the original `Host` header as a custom header to the backend so it can identify the customer:
+   - REST API: map `method.request.header.host` to `integration.request.header.Customer` via `RequestParameters`
+   - HTTP API: use parameter mapping: `overwrite` on `integration.request.header.Customer` from `$request.header.host`
+
+Key considerations:
+
+- The wildcard certificate applied to API Gateway allows multiple subdomains to be served by a single API endpoint
+- Each customer subdomain is created as a separate custom domain in API Gateway, enabling per-customer base path mappings or routing rules
+- Backend microservices use the forwarded customer header to apply customer-specific business logic
+- API Gateway's request/response transformation can insert or modify headers per customer
+- The 120 public custom domains per region quota limits the number of customer subdomains (request increase if needed)
+
+## Routing Rules (Preferred for New Domains)
+
+Routing rules are the recommended approach over base path mappings for new custom domains, offering header-based routing, priority-based evaluation, and simpler management. Supports public and private REST APIs only. HTTP API and WebSocket API do not support routing rules; use base path mappings instead.
+
+### Rule Structure
+
+- Conditions: Up to 2 `MatchHeaders` + 1 `MatchBasePaths` (AND logic)
+- Actions: Invoke any stage of any REST API in the same account and region
+- Priority: 1-1,000,000 (lower = higher precedence, no duplicates). Leave gaps between priorities (100, 200, 300) to allow inserting new rules later. Creating a rule with a duplicate priority fails with `ConflictException`
+- Header matching supports wildcards: `*latest` (matches values ending with "latest"), `alpha*` (matches values starting with "alpha"), `*v2*` (contains). Header names are case-insensitive; header values are case-sensitive
+
+### Routing Modes
+
+1. API mappings only (default): Traditional base path mapping behavior. Use if not adopting routing rules
+2. Routing rules then API mappings: Routing rules take precedence; unmatched requests fall back to base path mappings. Use for zero-downtime migration from base path mappings to routing rules
+3. Routing rules only: Recommended mode for new custom domains or after completing migration from base path mappings. Requests that match no routing rule receive a 404 response
+
+### Migration from Base Path Mappings
+
+1. Set routing mode to "Routing rules then API mappings" -- existing base path mappings continue as fallback
+2. Progressively create routing rules (e.g., start with a test header rule for controlled traffic). Include a catch-all rule (no conditions) at the lowest priority as a safety net; without this, unmatched requests will receive a 404 after switching modes in step 4
+3. Monitor with `$context.customDomain.routingRuleIdMatched` in access logs to verify routing behavior and confirm all expected traffic paths are covered by rules
+4. Once all traffic is covered by rules, switch to "Routing rules only" mode
+
+### Implementation
+
+- CloudFormation: `AWS::ApiGatewayV2::RoutingRule`
+- Observability: `$context.customDomain.routingRuleIdMatched` in access logs
+- No additional charges for routing rules; standard API Gateway request pricing applies
+- A rule with no conditions serves as a catch-all matching all requests
+
+### Use Cases
+
+- API versioning: Route by `Accept` or `X-API-Version` header to different API implementations
+- Gradual rollouts: Route a percentage of users to new version by adding a header in application code, then gradually increase
+- A/B testing: Route specific user cohorts by custom header (e.g., `x-test-group: beta-testers`)
+- Cell-based architecture: Route by tenant ID or hostname header to different cell backends
+- Dynamic backend selection: Route by cookie value, media type, or any custom header
+
+## Header-Based API Versioning
+
+Route API requests to different backend implementations based on a version header (REST APIs only).
+
+- Create a routing rule per version with `MatchHeaders` on the version header (e.g., `X-API-Version: v1`, `X-API-Version: v2`)
+- Each rule invokes the corresponding API/stage
+- Add a catch-all rule at the lowest priority to route unversioned requests to the default (latest stable) version
+- Monitor with `$context.customDomain.routingRuleIdMatched` in access logs to track version adoption
+- No additional infrastructure, no Lambda@Edge, no DynamoDB. Purely declarative
+
+## Host Header Forwarding
+
+- API Gateway overwrites Host header with integration endpoint hostname
+- Cannot forward original Host header directly
+- REST API workaround: Create custom header in Method Request, map in Integration Request: `method.request.header.host` -> `integration.request.header.my_host`
+- HTTP API workaround: Use parameter mapping to forward the host header: `overwrite` on `integration.request.header.X-Original-Host` from `$request.header.host`

--- a/plugins/aws-serverless/skills/aws-serverless-api-gateway/references/deployment.md
+++ b/plugins/aws-serverless/skills/aws-serverless-api-gateway/references/deployment.md
@@ -1,0 +1,137 @@
+# Deployment Strategies
+
+## Deployment Basics
+
+### Understanding Deployments
+
+A Deployment in API Gateway is an immutable snapshot of your API configuration, not an action. Think of it like a git commit: changes to your API (resources, methods, integrations, authorizers) are like commits to a main branch that cannot be invoked externally. To make changes callable, you create a Deployment (snapshot) and point a Stage to it.
+
+- Creating a Deployment = taking a snapshot of the current API state
+- Deploying to a Stage = updating a stage to point to that snapshot
+- Multiple stages can point to the same or different deployments
+- Console "Test Invoke" bypasses deployments: it always uses the current API state (not a deployed snapshot). Bypasses IAM auth, Lambda authorizers, Cognito authorizers, API key validation, throttling, WAF, resource policies, and mTLS. Use [`TestInvokeAuthorizer`](https://docs.aws.amazon.com/apigateway/latest/api/API_TestInvokeAuthorizer.html) to test authorizer logic separately. This is why "it works in console but not when invoked" is a common complaint
+
+### REST API
+
+- Explicit deployment required to make changes live. Each deployment is immutable
+- A stage cannot be created without a deployment (deploymentId is required in CreateStage)
+- A deployment can be created without deploying to a stage (stageName is optional in CreateDeployment)
+- Always redeploy after: changing resource policy, adding/modifying methods, updating integrations, configuring authorizers, modifying models or request validators
+- No redeployment needed for: throttling/usage plan changes, logging configuration, caching TTL (capacity changes take effect without redeployment but cause ~4 minutes of cache unavailability during resizing), stage variable values, client certificate changes, WAF association changes (propagation takes minutes). These take effect on the stage without a new deployment
+- Max 10 stages per API (adjustable via [Service Quotas](https://docs.aws.amazon.com/apigateway/latest/developerguide/limits.html))
+- Stage variables: max 100 per stage, referenced as `${stageVariables.variableName}` in integration URIs and `$stageVariables.variableName` in VTL mapping templates
+
+### HTTP API
+
+- A stage can be created without a deployment (then updated via UpdateStage)
+- Supports automatic deployments (AutoDeploy); changes deploy immediately
+- Explicit deployments also supported for manual control
+- AutoDeploy caveat: AutoDeploy is a security risk. It triggers a new deployment after each API management operation completes. When making multiple changes via separate API calls, intermediate states are briefly live. A new route may be deployed before its authorizer is attached, exposing an unauthenticated endpoint to the internet for seconds to minutes. Routes may also deploy before their integration or IAM role, causing 500 errors. With explicit deployments (or SAM/CDK), all configuration changes are made first, then a single deployment snapshot is created, avoiding intermediate states. Avoid AutoDeploy in production; it is a security and availability risk, not just an operational inconvenience
+
+### WebSocket API
+
+- A stage can be created without a deployment (then updated via UpdateStage)
+- Does not support automatic deployments (AutoDeploy); every change requires an explicit redeployment
+
+### Deployment Propagation
+
+Changes do not propagate to all API Gateway data plane hosts simultaneously. During propagation:
+
+- Some hosts serve the new deployment while others still serve the old one
+- If you delete a resource (e.g., Lambda function) that the old deployment references, requests hitting hosts still propagating will get 500 errors
+- Always retain old resources until propagation completes, then remove them in a subsequent deployment
+
+## Canary Deployments (REST API Only)
+
+Route a percentage of traffic to a canary deployment for testing API configuration changes (not code changes):
+
+1. Deploy new version to a canary
+2. Configure canary traffic percentage (e.g., 10%)
+3. Monitor via CloudWatch Logs (`API-Gateway-Execution-Logs_<api-id>/<stage>`)
+4. Promote: "Promote Canary" replaces the stage's deployment with the canary's deployment and removes all canary settings in a single operation. All traffic then uses the new configuration. Note: If `useStageCache: false` (canary used a separate cache), the canary cache is discarded on promotion, causing a cache miss spike. Consider flushing the stage cache or setting short TTLs during canary testing
+5. Rollback: Delete the canary release to revert all traffic to the base stage deployment. Setting the percentage to 0% merely stops canary traffic but does not remove canary settings, so it is not a proper rollback
+
+- Configure via `canarySettings` on a stage: `percentTraffic` (0.0-100.0), `useStageCache` (whether canary uses the stage cache or a separate one)
+- Canary releases test API Gateway configuration (new resources, integrations, mapping templates, authorizers), not Lambda code changes. For Lambda code canary, use Lambda aliases with weighted routing
+- Monitor `Latency`, `5XXError`, `4XXError` CloudWatch metrics filtered by canary stage to compare against the production baseline before promoting
+- SAM: Define canary settings programmatically with `sam deploy`
+- Stage variable overrides supported during canary period
+- For direct service integrations (DynamoDB, SQS, etc.): canary deployments are the only way to do gradual rollouts since there are no Lambda aliases involved
+
+## Manual Rollback via Deployment History (REST API)
+
+REST APIs retain a history of all deployments. The fastest rollback mechanism is to point the stage back to a previous deployment ID using `UpdateStage`:
+
+```
+aws apigateway update-stage --rest-api-id <api-id> --stage-name <stage> \
+  --patch-operations op=replace,path=/deploymentId,value=<previous-deployment-id>
+```
+
+- Near-instant -- no CloudFormation involved, no new deployment created
+- Use `GetDeployments` to list available deployment IDs with creation dates
+- This is the recommended emergency rollback path -- faster than CloudFormation rollback and avoids the drift risk (pitfall #4)
+- Does not affect Lambda code -- only reverts API Gateway configuration (routes, integrations, authorizers, mapping templates). For Lambda code rollback, update the alias to the previous version
+- CloudFormation drift warning: After manual rollback, the stage's deploymentId diverges from what CloudFormation tracks. The next `sam deploy` or stack update will overwrite your manual rollback with whatever deployment CloudFormation computes. Always follow up with a proper IaC deployment to re-synchronize state
+
+## Blue/Green Zero-Downtime Deployments
+
+Based on the blog https://aws.amazon.com/blogs/compute/zero-downtime-blue-green-deployments-with-amazon-api-gateway/
+
+Use custom domain API mapping to switch traffic between two environments:
+
+### Architecture
+
+1. Blue stack: Current production REST API (separate SAM stack)
+2. Green stack: New version REST API (separate SAM stack)
+3. Custom domain stack: Route 53 record + ACM certificate + API Gateway custom domain with API mapping
+
+### Workflow
+
+1. Deploy blue stack
+2. Deploy custom domain stack pointing to blue
+3. Deploy green stack
+4. Test green via its direct invoke URL
+5. Update custom domain stack to activate green stack
+6. Monitor and rollback by re-pointing to blue if needed (see notes on propagation below)
+7. Cleanup: Delete the inactive (old) API stack first (it receives no traffic). Keep the custom domain stack and active API stack running. Only delete the custom domain stack when decommissioning the entire service. Never delete the custom domain stack while APIs are still serving traffic, as this removes the production endpoint immediately
+
+### Notes
+
+- Propagation: API mapping changes propagate within minutes (no DNS change involved; the custom domain DNS record stays the same). During propagation, some API Gateway hosts serve the old mapping while others serve the new one
+- In-flight request risk: During the propagation window, clients may receive responses from either blue or green non-deterministically. API Gateway does not maintain request affinity. Both blue and green must be fully functional and backward-compatible during transition. Persist all state in the backend (DynamoDB, SQS, etc.); do not rely on in-memory state in Lambda, as a multi-step workflow may start on blue and complete on green. Verify propagation is complete by returning a version identifier from your integration and polling until 100% of responses show the new version
+- Rollback: Re-pointing to blue has the same propagation delay as the initial switch; it is not instant. Plan for minutes of mixed traffic during rollback
+- External custom domain URL never changes
+- Each environment is a complete, independent API deployment
+
+## Routing Rules for A/B Testing (REST API Only)
+
+- REST API only. HTTP API and WebSocket API do not support routing rules (use base path mappings instead)
+- Route specific users by header value to different API/stage combinations on a custom domain without Lambda
+- Configure via `AWS::ApiGatewayV2::RoutingRule` resources with conditions (headers, base paths) and actions (target API + stage)
+- Combine with stage variables for flexible targeting
+- Zero-downtime: Start in "Routing rules then API mappings" mode, existing mappings serve as fallback
+- See `references/custom-domains-routing.md` for rule structure, priority, and routing modes
+
+## Infrastructure as Code
+
+For IaC framework selection (SAM vs CDK), project setup, CI/CD pipelines, and environment management, see the [aws-serverless-deployment skill](../../aws-serverless-deployment/).
+
+API Gateway IaC best practices:
+
+- Embed OpenAPI specifications in IaC templates rather than defining APIs with IaC syntax directly
+- Export OpenAPI specs from development tools, import into API Gateway
+- Use IaC for all production deployments, not console
+
+## Deployment Pitfalls
+
+1. Changes not taking effect: Must create a new deployment for REST APIs after any change
+2. CloudFormation logical ID must change: `AWS::ApiGateway::Deployment` is immutable. If the logical ID stays the same, CloudFormation won't create a new deployment on subsequent stack updates. SAM and CDK auto-generate unique logical IDs by hashing the API definition, but if changes are made outside the API definition (e.g., only Lambda code changed), the hash stays the same and no new deployment is created. Fix: Change the API description or any definition field to force a new hash
+3. Deleting old resources causes 5XX during propagation: If CloudFormation deletes the old Lambda function (or role, alias, etc.) while API Gateway is still propagating the new deployment, hosts still pointing to the old snapshot will return 500. Fix: Use a two-phase deployment: (1) deploy the new resources alongside the old ones with `DeletionPolicy: Retain` on resources being replaced, (2) after propagation completes, deploy again to remove the old resources. For Lambda aliases, point the alias to the new version but keep the old version published until propagation is confirmed
+4. CloudFormation rollback creates new snapshot, not the original: When CloudFormation rolls back, it creates a new Deployment with the current API state; it does not restore the original deployment ID. If there's stack drift (e.g., manual console changes to the API), the rollback snapshots the _drifted_ state, not the last known-good state -- the operator believes they rolled back to safety but are running an untested configuration. Mitigations: Avoid manual/console changes to production APIs; run `aws cloudformation detect-stack-drift` before relying on rollback; set up drift detection alarms. For fastest recovery, use manual rollback via deployment history (see below) instead of CloudFormation rollback
+5. Limited deployment inspection: `GetDeployment` returns only ID, description, and date (not the API snapshot). However, you can use `GetExport` on a stage pointing to a deployment to retrieve the full API definition as OpenAPI. To diff two deployments, export from two stages pointing to different deployments and diff the exports. Track changes primarily through IaC version control
+6. `DeploymentStatus: DEPLOYED` is misleading: HTTP/WebSocket API reports `DEPLOYED` even for deployments never associated with any stage. The status means "snapshot created successfully", not "deployed to a stage"
+7. Stage variable Lambda permissions: When referencing Lambda via `${stageVariables.functionName}` in an integration URI, you must manually add a resource-based invoke permission -- SAM/CDK do NOT auto-generate these for stage-variable references (only for direct ARN references). Without it, every invocation returns a 500 "Internal server error" with no hint about the cause. Add permission with `aws lambda add-permission --function-name <function> --statement-id apigw-<stage> --action lambda:InvokeFunction --principal apigateway.amazonaws.com --source-arn "arn:aws:execute-api:<region>:<account>:<api-id>/<stage>/*"`. This must be repeated for every new stage and every new Lambda function referenced by stage variables
+8. Circular dependency: Never reference `ServerlessRestApi` or `ServerlessHttpApi` in Lambda environment variables, `Outputs`, IAM policy resources, or other resource properties -- all of these create circular dependencies. For request-handling Lambda functions, derive API URL at runtime from `event["requestContext"]`. For non-request contexts (callback URLs, webhook registrations), use SSM Parameter Store -- write the API URL via a post-deploy script, or use an explicit `AWS::Serverless::Api` resource which breaks the circular dependency
+9. YAML duplicate keys: Automated template patching can silently introduce duplicate keys. Validate: `sam validate` or `python3 -c "import yaml; yaml.safe_load(open('template.yaml'))"`
+10. Management API rate limit: Management API calls share an aggregate rate limit of 10 rps with 40-burst across all API Gateway operations in the account. Individual operations have stricter limits. `CreateDeployment` is limited to 1 request every 5 seconds (0.2 rps, fixed, not adjustable). CI/CD pipelines deploying many APIs in parallel will be throttled. CloudFormation reports a generic error, not a throttling message. Stagger parallel deployments or use a single pipeline with sequential stages
+11. Cache flush on redeployment: Creating a new deployment to a stage with caching enabled flushes the entire cache, causing a temporary spike in backend load ("thundering herd"). Mitigations: (a) ensure backend auto-scaling can handle full uncached load before deploying, (b) script synthetic requests to cached endpoints after deployment to pre-warm the cache, (c) use canary deployments to limit the blast radius of cache flush, (d) backends with cold-start issues (Lambda with VPC, containers scaling from zero) compound the thundering herd -- use provisioned concurrency on critical paths during deployment windows. See `references/performance-scaling.md`

--- a/plugins/aws-serverless/skills/aws-serverless-api-gateway/references/governance.md
+++ b/plugins/aws-serverless/skills/aws-serverless-api-gateway/references/governance.md
@@ -1,0 +1,226 @@
+# API Governance
+
+This document focuses on governance of REST APIs (API Gateway V1), as governance and compliance controls are primarily a concern in enterprise environments where REST APIs are the typical choice due to their full API management capabilities (usage plans, WAF, resource policies, request validation).
+
+## Governance Framework
+
+Four types of security controls:
+
+1. Preventative: Prevent unauthorized changes before they occur (IAM policies, SCPs)
+2. Proactive: Prevent noncompliant resources before deployment (CloudFormation Hooks, Guard rules)
+3. Detective: React to configuration changes after they happen (AWS Config rules, EventBridge)
+4. Responsive: Remediate adverse events (automated remediation via Lambda)
+
+## Governance Tools
+
+### Preventative Controls
+
+- IAM policies and permission boundaries: Fine-grained API Gateway control plane access
+- Service Control Policies (SCPs): Organization-wide guardrails using API Gateway condition keys. Policy examples below show statement bodies only. SCPs require a complete policy document with `Version`, `Statement` array, and `"Effect"`, while SCP statements implicitly apply to all principals (`"Principal": "*"` is not needed in SCPs but is required in resource-based policies)
+- Over 20 IAM condition keys available for API Gateway governance, split into two categories:
+  - `apigateway:Request/*`: Evaluates the new values being set in the request
+  - `apigateway:Resource/*`: Evaluates the current values on the existing resource being acted upon
+  - Both are preventative, evaluated at IAM authorization time before the action occurs
+- Key condition keys: `apigateway:Request/EndpointType`, `apigateway:Request/SecurityPolicy`, `apigateway:Resource/ApiKeyRequired`, `apigateway:Request/AuthorizationType`, `apigateway:Request/AccessLoggingDestination`, `apigateway:Request/MtlsTrustStoreUri`
+
+### Proactive Controls
+
+- CloudFormation Hooks: Evaluate resource configuration before deployment. Noncompliant resources block deploy or warn
+- AWS Control Tower: Preconfigured proactive controls for API Gateway
+- CloudFormation Guard: Open-source policy-as-code evaluation tool with declarative DSL. Managed rule set available for API Gateway
+- Limitation: CloudFormation-based proactive controls may not work with non-CloudFormation IaC tools (Terraform, Pulumi)
+
+### Detective Controls
+
+- AWS Config: Managed rules + custom rules (Guard DSL or Lambda). Key managed rules:
+  - `api-gw-xray-enabled`
+  - `api-gw-associated-with-waf`
+  - `api-gw-ssl-enabled`
+  - `api-gw-execution-logging-enabled`
+  - `api-gw-endpoint-type-check`
+- Amazon EventBridge: React to API Gateway events in real-time with Lambda
+- AWS Security Hub: Findings trigger EventBridge events for automated remediation
+- AWS Trusted Advisor: Service-level checks for optimization, performance, security
+
+## Enforcing Observability
+
+### Require X-Ray Tracing
+
+- Preventative: N/A (no IAM/SCP conditions)
+- Proactive: Custom CloudFormation Hook or Guard rule
+- Detective: AWS Config rule `api-gw-xray-enabled`
+
+### Require Access Logging
+
+- Preventative: SCP using `apigateway:Request/AccessLoggingDestination` and `apigateway:Request/AccessLoggingFormat`
+
+```json
+{
+  "Effect": "Deny",
+  "Action": ["apigateway:PATCH", "apigateway:POST", "apigateway:PUT"],
+  "Resource": ["arn:aws:apigateway:*::/restapis/*/stages/*"],
+  "Condition": { "StringLikeIfExists": { "apigateway:Request/AccessLoggingDestination": "" } }
+}
+```
+
+- Side effect: `StringLikeIfExists` means any stage update that does not explicitly include `AccessLoggingDestination` (e.g., updating cache settings or stage variables) will also be denied. This is intentionally strict; use detective controls instead if this is too restrictive
+- Detective: AWS Config custom Guard rule: `configuration.accessLogSettings.destinationArn is_string`
+
+### Require Execution Logging
+
+- Preventative: N/A (no IAM/SCP conditions)
+- Proactive: Custom CloudFormation Hook or Guard rule
+- Detective: AWS Config rule `api-gw-execution-logging-enabled`
+
+Caveat: Preventative/proactive controls may block first deployment via AWS Console (Console does not allow specifying these settings on new stage creation). IaC/CLI works fine.
+
+## Enforcing Security
+
+### Require WAF
+
+- Preventative: N/A
+- Proactive: Custom CloudFormation Hook
+- Detective: AWS Config rule `api-gw-associated-with-waf`
+
+### Require TLS 1.2+
+
+- Preventative: SCP denying `apigateway:Request/SecurityPolicy` value `TLS_1_0`
+- Detective: EventBridge rule or AWS Config custom rule
+
+### Require mTLS
+
+- Preventative: SCP requiring `apigateway:Request/MtlsTrustStoreUri` is present
+- Detective: EventBridge rule or AWS Config custom rule
+
+### Require Specific Authorizer Type
+
+- Preventative: SCP using `apigateway:Request/AuthorizationType` (valid values: `NONE`, `AWS_IAM`, `CUSTOM`, `COGNITO_USER_POOLS`)
+- Use `apigateway:Request/AuthorizerUri` to enforce a specific Lambda authorizer. Note: the URI is the full invocation path (`arn:aws:apigateway:REGION:lambda:path/2015-03-31/functions/FUNCTION_ARN/invocations`), not just the Lambda ARN. Use `StringLike` with wildcards for flexibility
+
+### Require API Key
+
+- Preventative: SCP with `apigateway:Resource/ApiKeyRequired` or `apigateway:Request/ApiKeyRequired`
+- Detective: EventBridge rule or AWS Config custom rule
+
+### Require Request Validation
+
+- Preventative: N/A
+- Proactive: Custom CloudFormation Hook
+- Detective: EventBridge rule or AWS Config custom rule
+
+### Restrict VPCs in Private API Resource Policy
+
+- Preventative: N/A
+- Proactive: Custom CloudFormation Hook
+- Detective: EventBridge rule or AWS Config custom rule
+
+### Audit Resource Policies for Overly Broad Access
+
+- Preventative: N/A (resource policy content is not exposed via IAM condition keys)
+- Proactive: Custom CloudFormation Hook to reject policies with `"Principal": "*"` without `Condition` constraints
+- Detective: AWS Config custom rule to flag resource policies granting unrestricted access (e.g., missing `aws:SourceVpce` or `aws:SourceIp` conditions on private APIs)
+
+## Enforcing Management Control
+
+### Freeze API Modifications by Tag
+
+```json
+{
+  "Effect": "Deny",
+  "Action": ["apigateway:DELETE", "apigateway:PATCH", "apigateway:POST", "apigateway:PUT"],
+  "Resource": "*",
+  "Condition": { "StringEquals": { "aws:ResourceTag/EnvironmentState": "frozen" } }
+}
+```
+
+- To lift freeze: temporarily disable the IAM policy. Note: the `frozen` tag itself cannot be removed while the policy is active (tag operations use `apigateway:PUT` which is denied)
+- Alternative: Freeze deployments by stage name using `apigateway:Request/StageName`
+
+### Prevent Custom Domains in Child Accounts
+
+```json
+{
+  "Effect": "Deny",
+  "Action": ["apigateway:DELETE", "apigateway:PUT", "apigateway:PATCH", "apigateway:POST"],
+  "Resource": ["arn:aws:apigateway:*::/domainnames", "arn:aws:apigateway:*::/domainnames/*"]
+}
+```
+
+### Prevent Public APIs in Non-Central Accounts
+
+- SCP denying `EDGE` or `REGIONAL` endpoint types in child accounts
+- Detective: AWS Config rule `api-gw-endpoint-type-check`
+
+### Require Tags
+
+```json
+{
+  "Effect": "Deny",
+  "Action": ["apigateway:POST"],
+  "Resource": ["arn:aws:apigateway:*::/restapis"],
+  "Condition": { "Null": { "aws:RequestTag/owner": "true" } }
+}
+```
+
+- Use `aws:RequestTag` for enforcing tags at creation time; use `aws:ResourceTag` for enforcing tags on updates to existing resources
+- REST API child resources of RestApi, DomainName, UsagePlan inherit parent tags
+
+### Require Documentation
+
+- Proactive: Custom CloudFormation Hook
+- Detective: AWS Config custom Guard rule: `configuration.documentationVersion is_string`
+
+### Require Compression
+
+- Proactive: Custom CloudFormation Hook
+- Detective: AWS Config custom Guard rule: `configuration.minimumCompressionSize >= 0`
+
+## Management Access Control
+
+### API Management (Control Plane)
+
+- IAM policy scoped to specific API ARN: `arn:aws:apigateway:region::/restapis/apiId/*`
+- Tip: Use `arn:aws:apigateway:region::/restapis/??????????/*` (10 question marks) to match any API ID. REST API IDs are observed to be exactly 10 alphanumeric characters. This scopes permissions to REST APIs without hardcoding specific IDs. Note: this length is not formally documented by AWS, but the risk of it changing is low given the installed base
+- This does NOT grant access to: custom domains, client certificates, VPC links, API keys, usage plans
+- IAM principals denied by default
+
+### Observability Access
+
+- Execution logs: IAM for CloudWatch Logs; use data protection policies to mask sensitive data
+- Access logs: IAM for CloudWatch Logs or Firehose; control access at both Firehose AND destination
+- Metrics: IAM for CloudWatch
+- Traces: IAM for X-Ray
+- CloudTrail: IAM for CloudTrail
+- Sensitive data protection: CloudWatch Logs data protection policies, Amazon Macie for S3-stored logs
+
+## API Lifecycle
+
+Design -> Build -> Manage -> Adoption
+
+1. Plan: Protocol selection, endpoint type, topology, standards
+2. Develop/Test: IaC, OpenAPI specs, integration testing
+3. Secure: Auth, WAF, mTLS, resource policies
+4. Deploy/Publish: CI/CD, canary, blue/green
+5. Scale: Quotas, caching, cell-based architecture
+6. Monitor: Metrics, logs, traces, dashboards
+7. Insights: CloudWatch Logs Insights, Contributor Insights, QuickSight
+8. Monetize: Usage plans, API segmentation, AWS Marketplace, AWS Data Exchange
+9. Discover: API Gateway Portal, Backstage, partner portals (Readme, Apiable, SmartBear)
+
+## Audit
+
+- CloudTrail: All REST API management calls captured as events
+- AWS Config: Record configuration changes, detect drift, enforce compliance
+- EventBridge: React to changes in real-time
+- Example EventBridge rule for stage updates:
+
+```json
+{
+  "detail": {
+    "eventSource": ["apigateway.amazonaws.com"],
+    "requestParameters": { "restApiId": ["abcd123456"], "stageName": ["prod"] },
+    "eventName": ["UpdateStage"],
+    "errorCode": [{ "exists": false }]
+  }
+}
+```

--- a/plugins/aws-serverless/skills/aws-serverless-api-gateway/references/observability-analytics.md
+++ b/plugins/aws-serverless/skills/aws-serverless-api-gateway/references/observability-analytics.md
@@ -1,0 +1,109 @@
+# Observability: Analytics and Operations
+
+## CloudWatch Logs Insights Queries
+
+### Find 5xx Errors
+
+```
+fields @timestamp, status, requestId, ip, resourcePath, integrationLatency
+| filter status >= 500
+| sort @timestamp desc
+| limit 100
+```
+
+### Latency Analysis
+
+```
+fields @timestamp, responseLatency, integrationLatency, resourcePath
+| stats avg(responseLatency) as avgLatency, max(responseLatency) as maxLatency,
+        avg(integrationLatency) as avgIntegration by resourcePath
+| sort avgLatency desc
+```
+
+### Top Talkers
+
+```
+fields ip
+| stats count(*) as requestCount by ip
+| sort requestCount desc
+| limit 20
+```
+
+### Per-Domain Analytics
+
+```
+filter domainName like /(?i)(api.example.com)/
+| stats count(*) as requests, avg(responseLatency) as avgLatency by resourcePath
+| sort requests desc
+```
+
+### Diagnose 403 Errors by Phase
+
+```
+fields @timestamp, requestId, ip, resourcePath
+| filter status = 403
+| stats count(*) as cnt
+    by coalesce(`waf-status`, "-") as waf,
+       coalesce(`authenticate-status`, "-") as authn,
+       coalesce(`authorizer-status`, "-") as authzr,
+       coalesce(`authorize-status`, "-") as authz
+| sort cnt desc
+```
+
+### Find Specific Gateway Response Types
+
+```
+fields @timestamp, requestId, `error-responseType`, `error-message`, status
+| filter ispresent(`error-responseType`)
+| stats count(*) as cnt by `error-responseType`
+| sort cnt desc
+```
+
+## Additional Monitoring Tools
+
+- CloudWatch Synthetics: Canaries for synthetic monitoring of endpoints on schedule
+- CloudWatch Application Insights: Automated dashboards for problem detection
+- CloudWatch Contributor Insights: Find top talkers and contributors; pre-built sample rules for API Gateway
+- CloudWatch Dashboards: Include dashboard definitions in IaC templates
+- CloudWatch ServiceLens: Integrates traces, metrics, logs, alarms, resource health
+
+## CloudWatch Embedded Metrics Format
+
+- Include metric data in structured logs sent to CloudWatch Logs
+- CloudWatch extracts metrics automatically (cheaper than PutMetricData API)
+- Use for custom business metrics (e.g., orders per minute, revenue per endpoint)
+- Include dashboard definitions in IaC templates with both operational and business metrics
+
+## AI-Assisted Operations
+
+- CloudWatch AI Operations: Specify a time window, it correlates logs across services and generates root cause hypothesis
+- Amazon Q CLI: Natural language troubleshooting ("Why do I see increased 500 errors from API Gateway in this stack?")
+- CloudWatch Logs Insights: Supports natural language to query translation and auto-generated pattern summaries
+
+## API Analytics Pipeline
+
+For deep analytics beyond CloudWatch dashboards:
+
+1. Stream access logs via Amazon Data Firehose
+2. Enrich with Lambda transformation (add business context, geo-IP lookup)
+3. Store in S3 (partitioned by date/API/stage)
+4. Query with Amazon Athena
+5. Visualize with Amazon QuickSight
+
+Cost tip: Firehose-to-S3 ingestion (~$0.029/GB) is significantly cheaper than CloudWatch Logs ingestion (~$0.50/GB). For high-volume APIs, stream access logs to Firehose instead of CloudWatch Logs and query with Athena. Use CloudWatch Logs for execution logs (lower volume) and real-time Logs Insights queries.
+
+## Cross-Account and Centralized Logging
+
+For multi-account AWS Organizations setups:
+
+1. CloudWatch cross-account observability: Use Observability Access Manager (OAM) to share metrics, logs, and traces from source accounts to a central monitoring account. Enables unified dashboards and alarms across all API Gateways
+2. Subscription filters: Stream access logs from each account to a central Kinesis Data Stream or Firehose in the monitoring account for aggregated analysis
+3. Consistent log group naming: Use a standard naming convention across accounts (e.g., `/aws/apigateway/<account-alias>/<api-name>/access-logs`) to simplify cross-account queries and cost attribution
+
+## CloudTrail
+
+- Captures all API Gateway management calls as control plane events
+- Does NOT log data plane events (actual API requests); use access logs for that
+- Determines: request made, IP address, who made it, when
+- Use for audit and compliance, not operational monitoring
+- Do not forget CloudTrail for control plane audit: who changed API configuration and when

--- a/plugins/aws-serverless/skills/aws-serverless-api-gateway/references/observability-logging.md
+++ b/plugins/aws-serverless/skills/aws-serverless-api-gateway/references/observability-logging.md
@@ -1,0 +1,246 @@
+# Observability: Logging
+
+## Execution Logging (REST API and WebSocket)
+
+- Full request/response logs including mapping template output, integration request/response, authorizer output
+- Levels: OFF, ERROR, INFO
+- Log events truncated at 1,024 bytes; use access logs for complete data
+- Log group: `API-Gateway-Execution-Logs_<apiId>/<stageName>` (both REST and WebSocket)
+- HTTP API does NOT support execution logging
+- Cost warning: INFO-level execution logging generates many log events per request (10-60+ depending on API complexity: authorizers, mapping templates, and integration details all add entries). At scale, CloudWatch Logs costs can exceed Lambda + API Gateway costs combined. Use ERROR level in production and enable INFO only for targeted debugging
+
+### What API Gateway Does NOT Log
+
+- 413 Request Entity Too Large
+- Excessive 429 throttling responses
+- 400 errors to unmapped custom domains
+- Internal 500 errors from API Gateway itself
+
+## Access Logging
+
+- Customizable log format using `$context` variables
+- Formats: CLF, JSON, XML, CSV
+- Access log template max: 3 KB
+- Destinations: CloudWatch Logs or Kinesis Data Firehose (REST only for Firehose)
+- HTTP API: Only access logging supported (no execution logging)
+- Delivery latency: Access logs can be delayed by several minutes. Use CloudWatch metrics (near-real-time) for dashboards and alarms; use access logs for investigation and deep analysis
+
+## Log Retention
+
+CloudWatch Logs default to Never Expire, which causes unbounded storage costs. Always set retention policies:
+
+- Execution logs (INFO): 3-7 days (debugging only, high volume)
+- Execution logs (ERROR): 14-30 days
+- Access logs: 30-90 days (or longer for compliance)
+- Compliance/audit logs: 1-3 years per organizational policy
+
+Define log groups explicitly in SAM/CloudFormation to control retention:
+
+```yaml
+ApiAccessLogGroup:
+  Type: AWS::Logs::LogGroup
+  Properties:
+    LogGroupName: !Sub "/aws/apigateway/${MyApi}/access-logs"
+    RetentionInDays: 90
+```
+
+## Recommended Access Log Format (REST API)
+
+Use this JSON format for maximum troubleshooting capability with enhanced observability variables:
+
+Note: This format is for REST APIs. HTTP API and WebSocket API use different `$context` variables; see the API-specific formats below.
+
+```json
+{
+  "requestId": "$context.requestId",
+  "extendedRequestId": "$context.extendedRequestId",
+  "ip": "$context.identity.sourceIp",
+  "caller": "$context.identity.caller",
+  "user": "$context.identity.user",
+  "accountId": "$context.identity.accountId",
+  "userAgent": "$context.identity.userAgent",
+  "requestTime": "$context.requestTime",
+  "requestTimeEpoch": "$context.requestTimeEpoch",
+  "httpMethod": "$context.httpMethod",
+  "resourcePath": "$context.resourcePath",
+  "path": "$context.path",
+  "status": "$context.status",
+  "protocol": "$context.protocol",
+  "responseLength": "$context.responseLength",
+  "responseLatency": "$context.responseLatency",
+  "integrationLatency": "$context.integrationLatency",
+  "domainName": "$context.domainName",
+  "apiId": "$context.apiId",
+  "stage": "$context.stage",
+  "error-message": "$context.error.message",
+  "error-responseType": "$context.error.responseType",
+  "waf-error": "$context.waf.error",
+  "waf-status": "$context.waf.status",
+  "waf-latency": "$context.waf.latency",
+  "waf-response": "$context.wafResponseCode",
+  "authenticate-error": "$context.authenticate.error",
+  "authenticate-status": "$context.authenticate.status",
+  "authenticate-latency": "$context.authenticate.latency",
+  "authorizer-error": "$context.authorizer.error",
+  "authorizer-status": "$context.authorizer.status",
+  "authorizer-latency": "$context.authorizer.latency",
+  "authorizer-integrationLatency": "$context.authorizer.integrationLatency",
+  "authorize-error": "$context.authorize.error",
+  "authorize-status": "$context.authorize.status",
+  "authorize-latency": "$context.authorize.latency",
+  "integration-error": "$context.integration.error",
+  "integration-status": "$context.integration.status",
+  "integration-latency": "$context.integration.latency",
+  "integration-requestId": "$context.integration.requestId",
+  "integration-integrationStatus": "$context.integration.integrationStatus"
+}
+```
+
+Key variables explained:
+
+- `requestTimeEpoch`: Epoch-millisecond timestamp. Use for programmatic analysis and Athena queries
+- `extendedRequestId`: Maps to `x-amz-apigw-id` header. Needed for AWS Support escalations
+- `accountId`: AWS account of the caller. Critical for IAM-authenticated and cross-account APIs
+- `error-message`: API Gateway's own error message (e.g., "Authorizer error", "Endpoint request timed out")
+- `error-responseType`: Gateway Response type triggered (e.g., `AUTHORIZER_FAILURE`, `INTEGRATION_TIMEOUT`, `THROTTLED`). Categorizes errors without execution logs
+- `integration-integrationStatus`: Status code from the Lambda service itself (usually 200 even when the function errors)
+- `integration-status`: Status code from your Lambda function code (for proxy integrations)
+
+## HTTP API Access Log Format
+
+HTTP API uses different `$context` variables. Key differences from REST API:
+
+- Uses `$context.routeKey` instead of `$context.resourcePath`
+- No WAF, authenticate, or authorize phase variables (HTTP API does not have these phases)
+- Authorizer variables are available (HTTP API supports JWT and Lambda authorizers)
+- No execution logging; access logs are the only log source
+
+```json
+{
+  "requestId": "$context.requestId",
+  "ip": "$context.identity.sourceIp",
+  "userAgent": "$context.identity.userAgent",
+  "requestTime": "$context.requestTime",
+  "requestTimeEpoch": "$context.requestTimeEpoch",
+  "routeKey": "$context.routeKey",
+  "path": "$context.path",
+  "status": "$context.status",
+  "protocol": "$context.protocol",
+  "responseLength": "$context.responseLength",
+  "responseLatency": "$context.responseLatency",
+  "integrationLatency": "$context.integrationLatency",
+  "domainName": "$context.domainName",
+  "apiId": "$context.apiId",
+  "stage": "$context.stage",
+  "error-message": "$context.error.message",
+  "authorizer-error": "$context.authorizer.error",
+  "integration-error": "$context.integration.error",
+  "integration-status": "$context.integration.status",
+  "integration-latency": "$context.integration.latency",
+  "integration-integrationStatus": "$context.integration.integrationStatus"
+}
+```
+
+## WebSocket API Access Log Format
+
+WebSocket APIs use connection-oriented variables instead of HTTP method/path:
+
+```json
+{
+  "requestId": "$context.requestId",
+  "extendedRequestId": "$context.extendedRequestId",
+  "connectionId": "$context.connectionId",
+  "eventType": "$context.eventType",
+  "routeKey": "$context.routeKey",
+  "connectedAt": "$context.connectedAt",
+  "requestTime": "$context.requestTime",
+  "requestTimeEpoch": "$context.requestTimeEpoch",
+  "ip": "$context.identity.sourceIp",
+  "userAgent": "$context.identity.userAgent",
+  "accountId": "$context.identity.accountId",
+  "status": "$context.status",
+  "domainName": "$context.domainName",
+  "apiId": "$context.apiId",
+  "stage": "$context.stage",
+  "error-message": "$context.error.message",
+  "error-responseType": "$context.error.responseType",
+  "authorizer-error": "$context.authorizer.error",
+  "authorizer-status": "$context.authorizer.status",
+  "authorizer-latency": "$context.authorizer.latency",
+  "authorizer-integrationLatency": "$context.authorizer.integrationLatency",
+  "integration-error": "$context.integration.error",
+  "integration-status": "$context.integration.status",
+  "integration-latency": "$context.integration.latency",
+  "integration-requestId": "$context.integration.requestId"
+}
+```
+
+Key WebSocket-specific variables:
+
+- `connectionId`: Unique ID for the persistent WebSocket connection
+- `eventType`: `CONNECT`, `MESSAGE`, or `DISCONNECT`
+- `routeKey`: The matched route (`$connect`, `$disconnect`, `$default`, or custom route keys)
+- `connectedAt`: Epoch timestamp when the connection was established
+
+## Enhanced Observability Variables
+
+API Gateway divides REST API requests into phases: WAF -> Authenticate -> Authorizer -> Authorize -> Integration
+
+Each phase exposes `$context.{phase}.status`, `$context.{phase}.latency`, and `$context.{phase}.error`.
+
+Note on authorizer phase: The authorizer has both `$context.authorizer.latency` (total authorizer latency) and `$context.authorizer.integrationLatency` (time spent in the authorizer Lambda/Cognito call). The difference is API Gateway overhead for the authorizer phase.
+
+Diagnosing 403 errors by phase:
+
+- `$context.waf.status: 403` = WAF blocked the request
+- `$context.authenticate.status: 403` = Invalid credentials (e.g., malformed SigV4)
+- `$context.authorizer.status: 403` = Lambda authorizer returned Deny policy
+- `$context.authorize.status: 403` with `$context.authorize.error: "The client is not authorized"` = Valid credentials but insufficient permissions (resource policy or IAM policy denied)
+
+Key distinction (Lambda proxy integration):
+
+- `$context.integration.integrationStatus`: Status code from the Lambda service (usually 200 even when the function throws an error)
+- `$context.integration.status`: Status code from your Lambda function code (the `statusCode` field in your function's response)
+
+## Additional Access Log Variables
+
+- `$context.identity.apiKey`: Track which API keys are making requests
+- `$context.identity.accountId`: Identify which AWS account is calling (IAM auth, cross-account)
+- `$context.domainName`: Differentiate traffic across custom domains
+- `$context.customDomain.routingRuleIdMatched`: Track routing rule matches
+- `$context.tlsVersion`, `$context.cipherSuite`: Monitor TLS migration
+- `$context.authorizer.principalId`: Principal from Lambda authorizer (for user-level tracing)
+- `$context.authorizer.claims.sub`: Cognito user pool subject claim (for Cognito-authenticated APIs)
+- Response streaming (REST only): `$context.integration.responseTransferMode`, `$context.integration.timeToAllHeaders`, `$context.integration.timeToFirstContent`
+
+## Setting Up Logging
+
+### Prerequisites for REST API and WebSocket
+
+1. Create IAM role with `AmazonAPIGatewayPushToCloudWatchLogs` managed policy
+2. Set CloudWatch log role ARN in API Gateway Settings (region-level, one-time configuration)
+3. Enable logging per stage
+
+### Prerequisites for HTTP API
+
+HTTP APIs do not use the account-level CloudWatch log role. Instead:
+
+1. Create the CloudWatch Logs log group
+2. Specify the log group ARN when configuring the stage's access logging
+3. API Gateway uses a service-linked role to write logs. Ensure the log group's resource-based policy allows `logs:CreateLogStream` and `logs:PutLogEvents` from the API Gateway service principal
+
+### Missing Logs Troubleshooting
+
+- IAM permissions incorrect (most common for REST/WebSocket)
+- Log group resource policy missing (most common for HTTP API)
+- Logging not enabled at stage level
+- Method-level override disabling logging
+- Log group does not exist (create it first or let API Gateway create it)
+
+## CloudTrail
+
+- Captures all API Gateway management calls as control plane events
+- Does NOT log data plane events (actual API requests); use access logs for that
+- Determines: request made, IP address, who made it, when
+- Use for audit and compliance, not operational monitoring
+- Do not forget CloudTrail for control plane audit: who changed API configuration and when

--- a/plugins/aws-serverless/skills/aws-serverless-api-gateway/references/observability-metrics-alarms.md
+++ b/plugins/aws-serverless/skills/aws-serverless-api-gateway/references/observability-metrics-alarms.md
@@ -1,0 +1,144 @@
+# Observability: Metrics, Alarms, and Tracing
+
+## CloudWatch Metrics
+
+| Metric               | Description                                                                                                             |
+| -------------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| `Count`              | Total API requests                                                                                                      |
+| `Latency`            | Time from API Gateway receiving the request to returning the response (does not include client-to-gateway network time) |
+| `IntegrationLatency` | Time spent in backend integration                                                                                       |
+| `4XXError` / `4xx`   | Client error count. REST API: `4XXError`; HTTP API: `4xx`                                                               |
+| `5XXError` / `5xx`   | Server error count. REST API: `5XXError`; HTTP API: `5xx`                                                               |
+| `CacheHitCount`      | Cache hits (REST only)                                                                                                  |
+| `CacheMissCount`     | Cache misses (REST only)                                                                                                |
+| `DataProcessed`      | Amount of data processed in bytes (HTTP API only)                                                                       |
+
+- Default: metrics per API stage
+- Detailed metrics: per method (enable on stage)
+- Use CloudWatch Embedded Metric Format for business-specific metrics
+
+## CloudWatch Alarms
+
+### Recommended Alarms
+
+Always configure these alarms for production APIs:
+
+Error rate alarms:
+
+- `5XXError` rate > 1% of total requests: server errors indicate backend or configuration problems
+- `4XXError` rate anomaly detection: spikes indicate breaking changes, auth failures, or abuse
+- `IntegrationLatency` p99 > SLA threshold: detect backend degradation before timeouts
+
+Throttling alarm:
+
+- `Count` approaching account throttle limit (10,000 rps default). Alert at 80% utilization to request limit increases proactively
+
+Cache alarms (REST API):
+
+- Cache hit ratio (`CacheHitCount / (CacheHitCount + CacheMissCount)`) drop below threshold: indicates cache invalidation issues or misconfiguration
+
+### Alarm Examples (CloudFormation)
+
+```yaml
+# REST API alarms: use ApiName dimension and 5XXError/4XXError metric names
+# HTTP API alarms: use ApiId dimension and 5xx/4xx metric names instead
+Api5xxAlarm:
+  Type: AWS::CloudWatch::Alarm
+  Properties:
+    AlarmName: !Sub "${AWS::StackName}-api-5xx-errors"
+    MetricName: 5XXError
+    Namespace: AWS/ApiGateway
+    Dimensions:
+      - Name: ApiName
+        Value: !Ref MyApi
+    Statistic: Sum
+    Period: 60
+    EvaluationPeriods: 3
+    Threshold: 5
+    ComparisonOperator: GreaterThanThreshold
+    TreatMissingData: notBreaching
+    AlarmActions:
+      - !Ref AlertSnsTopic
+
+ApiLatencyAlarm:
+  Type: AWS::CloudWatch::Alarm
+  Properties:
+    AlarmName: !Sub "${AWS::StackName}-api-p99-latency"
+    MetricName: Latency
+    Namespace: AWS/ApiGateway
+    Dimensions:
+      - Name: ApiName
+        Value: !Ref MyApi
+    ExtendedStatistic: p99
+    Period: 300
+    EvaluationPeriods: 3
+    Threshold: 5000
+    ComparisonOperator: GreaterThanThreshold
+    TreatMissingData: notBreaching
+    AlarmActions:
+      - !Ref AlertSnsTopic
+```
+
+### Composite Alarms
+
+Combine signals to reduce noise:
+
+- High 5xx AND high latency = likely backend failure (page on-call)
+- High 4xx only = likely client-side issue (lower priority)
+
+## CloudWatch Metric Filters
+
+Create custom CloudWatch metrics from access log patterns. Metric filters run on the log group and extract numeric values or count pattern matches.
+
+### Error Count by Response Type
+
+```
+{ $.[\"error-responseType\"] = \"THROTTLED\" }
+```
+
+Publishes a metric counting throttled requests. Useful since excessive 429s may not be logged by API Gateway itself.
+
+### Slow Requests
+
+```
+{ $.responseLatency > 5000 }
+```
+
+Counts requests exceeding 5 seconds. Can alarm on this custom metric for tighter latency SLOs than the built-in p99.
+
+### Requests by API Key
+
+Add `"apiKey": "$context.identity.apiKey"` to your log format first, then use:
+
+```
+{ $.apiKey != "-" }
+```
+
+Use with metric dimensions to track per-consumer request volumes.
+
+## X-Ray Tracing
+
+- REST API: Active tracing supported; enable per stage. API Gateway creates the trace segment and adds trace headers to integration requests
+- HTTP API: X-Ray tracing is [not supported](https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-vs-rest.html). For distributed tracing, enable X-Ray active tracing on downstream Lambda functions and correlate using the `$context.integration.requestId` access log variable
+- Configure sampling rules to control costs and recording criteria
+- Service map for latency visualization
+- Cross-account tracing requires CloudWatch Observability Access Manager (OAM) configuration between monitoring and source accounts
+
+### Enabling X-Ray in SAM/CloudFormation
+
+```yaml
+# REST API with SAM implicit API
+Globals:
+  Api:
+    TracingEnabled: true
+
+# Explicit REST API stage
+MyApiStage:
+  Type: AWS::ApiGateway::Stage
+  Properties:
+    TracingEnabled: true
+    StageName: prod
+    RestApiId: !Ref MyApi
+```
+
+For end-to-end distributed tracing, enable X-Ray in both API Gateway and downstream Lambda functions (`Tracing: Active` in SAM function properties). Use X-Ray Groups to filter traces by error, fault, or latency thresholds.

--- a/plugins/aws-serverless/skills/aws-serverless-api-gateway/references/performance-scaling.md
+++ b/plugins/aws-serverless/skills/aws-serverless-api-gateway/references/performance-scaling.md
@@ -1,0 +1,162 @@
+# Performance and Scaling
+
+## Throttling
+
+### Account-Level Defaults
+
+Note: Throttling values below are default quotas; most are adjustable via AWS Support or Service Quotas console. Do not use defaults for capacity planning without checking your account's current limits. See [latest quotas](https://docs.aws.amazon.com/apigateway/latest/developerguide/limits.html).
+
+- 10,000 requests per second steady-state across all REST APIs, HTTP APIs, WebSocket APIs, and WebSocket callback APIs in a region (shared quota)
+- 5,000 burst capacity (token bucket algorithm)
+- These are defaults; request increases via AWS Support or Service Quotas
+
+### Stage-Level and Method-Level
+
+- Stage/method-level default throttle: configure via MethodSettings on the stage (REST API)
+- Per-consumer throttle: configure via usage plans (REST API only)
+- Method-level throttling overrides stage-level
+- Max method-level throttle settings per stage: 20
+- Format: `resourcePath/httpMethod` (e.g., `/pets/GET`)
+
+### HTTP API Throttling
+
+- Route-level throttling only (no usage plans or API keys)
+- Configure via stage settings
+- Limits apply globally across all callers, with no per-consumer throttling. For per-consumer rate limiting on HTTP API, implement in a Lambda authorizer or backend
+
+### Usage Plans (REST API Only)
+
+- Quota: Requests per day, week, or month
+- Throttle: Rate (requests/second) + burst
+- RPS limits are per API key, not split across keys. If a usage plan allows 100 rps and has 10 keys, each key gets 100 rps (not 10 rps each)
+- Combine with API keys to track and limit per-consumer usage
+- Max 300 usage plans per region (adjustable), 10,000 API keys per region
+- API key source: `HEADER` (default, `x-api-key`) or `AUTHORIZER` (Lambda returns key in `usageIdentifierKey`)
+- Do not associate one API key with multiple usage plans that cover the same API stage; API Gateway picks one plan non-deterministically. One key per plan per stage is safe; a usage plan can have many keys
+
+### Token Bucket Algorithm
+
+- Bucket size = burst capacity (5,000 tokens). Refill rate = steady-state rate (10,000 tokens/second)
+- Each request consumes one token. If the bucket is empty, the request is throttled (429)
+- The burst capacity (5,000) is the maximum number of requests that can be served in a single instant. The steady-state rate (10,000 rps) is the maximum sustained throughput. Burst is lower than steady-state because the bucket refills faster (10,000/s) than it can be drained in one instant (5,000). Over any one-second window you can sustain 10,000 rps, but an instantaneous spike cannot exceed 5,000 concurrent requests
+- Throttled requests receive 429 Too Many Requests
+
+## Caching (REST API Only)
+
+### Configuration
+
+- Cache sizes: 0.5 GB, 1.6 GB, 6.1 GB, 13.5 GB, 28.4 GB, 58.2 GB, 118 GB, 237 GB
+- Default TTL: 300 seconds
+- Max TTL: 3,600 seconds
+- TTL=0: Disables caching
+- Max cached response size: 1,048,576 bytes (1 MB)
+- Only GET methods cached by default
+- Cache is best-effort, not guaranteed to cache every response
+- Cache charges apply per hour regardless of usage; only provision when you have a clear caching use case
+
+### Cache Keys
+
+- Default: resource path
+- Add headers, query strings, and path parameters as additional cache keys
+- More cache keys = more granular caching but lower hit rate
+- Include client identity into cache keys to avoid data leaks across clients
+
+### Cache Invalidation
+
+- Client sends `Cache-Control: max-age=0` header
+- Can require authorization for invalidation requests
+- Entire stage cache can be flushed via console or API
+- Automatic flush on redeployment: Creating a new deployment to a stage flushes the entire cache, causing a temporary backend load spike ("thundering herd"). See `references/deployment.md` for mitigations
+
+### Cache Encryption
+
+- Encryption at rest available as option when provisioning cache
+
+### Metrics
+
+- `CacheHitCount`, `CacheMissCount` in CloudWatch
+- Monitor miss rate to determine if cache size is adequate
+
+### Capacity Selection
+
+1. Run a load test against the API
+2. Monitor `CacheHitCount`, `CacheMissCount`, `Latency`
+3. Start with smaller cache, scale up based on miss rates
+4. Cache resizing takes time; plan ahead of peak traffic
+
+## Scaling Considerations
+
+### API Gateway Scales Automatically
+
+- Managed service, no capacity provisioning needed
+- Be aware of service quotas and request increases proactively
+
+### Scale the Entire Stack
+
+- No point having high API Gateway quotas if backend cannot handle the load
+- Consider: Lambda concurrency limits, DynamoDB provisioned capacity, RDS connection limits, ECS/EKS scaling policies
+- Automatic quota management via AWS Service Quotas for proactive adjustment
+
+### Strategies for Global Scale
+
+- Edge-optimized endpoints: Route to nearest CloudFront POP. Note: Edge-optimized endpoints do NOT cache at the edge; they only route through CloudFront POPs to optimize TCP connections. For edge caching, use a separate CloudFront distribution in front of a Regional API
+- Self-managed CloudFront distribution: More control over caching, WAF, and custom behaviors. This is the only way to get actual edge caching
+- Multi-region deployment: Active-active with Route 53 latency-based routing
+
+### Multi-Layer Caching Strategy
+
+For maximum performance, layer caches:
+
+1. CloudFront: Edge caching (reduces latency, load, AND cost, since the request never reaches API Gateway)
+2. API Gateway cache (REST only): Regional caching (reduces latency and load but NOT cost, as the request is still counted)
+3. Application-level cache: ElastiCache or DAX for database query caching
+
+- CloudFront caching should be the first choice, as it provides the most benefit
+
+### API Gateway Billing Notes
+
+- Lambda authorizer invocations are billed by Lambda even if the request is ultimately rejected by the authorizer or by throttling. This is the "Distributed Denial of Wallet" vector below
+
+### Load Shedding
+
+- Use API Gateway request validation to reject invalid requests early (before hitting backend)
+- Configure appropriate throttle limits per consumer tier
+- Use WAF rate-based rules for DDoS protection
+- "Distributed Denial of Wallet" risk: Without WAF, DDoS traffic invokes Lambda authorizers for every request, driving up Lambda costs (even though API Gateway itself doesn't charge for the rejected requests). WAF blocks malicious traffic before it reaches the authorizer
+
+### Cell-Based Architecture
+
+- Use multi-account approaches for blast radius control
+- Each cell has its own API Gateway, Lambda, and database
+- Route traffic to cells via custom domain and routing rules
+
+## Payload Compression
+
+### API Gateway Native Compression
+
+- `minimumCompressionSize`: Set the smallest payload size (in bytes) to compress automatically. Range: 0 bytes to 10 MB
+- Test with real payloads: compressing very small payloads can actually increase the final size. Find the optimal threshold for your data
+- Works bidirectionally: API Gateway decompresses incoming requests (client sends `Content-Encoding` header) before applying mapping templates, and compresses outgoing responses (client sends `Accept-Encoding: gzip`) after applying response mapping templates
+- Most effective for text-based formats (JSON, XML, HTML, YAML). Binary data (PDF, JPEG) compresses poorly
+- Set on the API level (REST API and HTTP API)
+- Benchmark: 1 MB JSON payload compressed to 220 KB (78% reduction), response latency improved by 110 ms
+
+### Compressed Passthrough to Lambda
+
+- With native compression, API Gateway decompresses payloads before delivering to Lambda, so the decompressed payload is still subject to Lambda's 6 MB synchronous invoke limit
+- To bypass this limit, configure `binaryMediaTypes: ["application/gzip"]` so API Gateway passes compressed payloads directly to Lambda without decompressing
+- Lambda then handles decompression in function code, enabling transport of payloads several times larger than the 6 MB limit
+- Lambda returns compressed responses with `isBase64Encoded: true` and `Content-Encoding: gzip` headers
+
+### Compression Trade-offs
+
+- Compression is CPU-intensive in Lambda, adding ~124 ms for 1 MB JSON on 1 GB ARM architecture
+- Always benchmark with payloads representative of your workload before enabling
+
+## Handling Large Payloads
+
+- 10 MB API Gateway limit (REST and HTTP): For payloads exceeding this, use S3 presigned URLs. Client uploads/downloads directly to S3, API returns the presigned URL
+- 6 MB Lambda synchronous invoke limit: Use compressed passthrough (binary media types) to transport larger payloads, or use S3 presigned URLs
+- Response streaming (REST API only): Supports up to 15-minute sessions, first 10 MB unrestricted then bandwidth-limited to 2 MB/s. Useful for LLM responses and large datasets
+- Lambda Function URLs: Response streaming removes the 6 MB buffered response limit; streamed responses can be much larger (subject to function timeout and bandwidth)
+- For SQS/EventBridge/Lambda async invocations (1 MB limit): Use compression or store payload in S3 and pass a reference in the message

--- a/plugins/aws-serverless/skills/aws-serverless-api-gateway/references/pitfalls.md
+++ b/plugins/aws-serverless/skills/aws-serverless-api-gateway/references/pitfalls.md
@@ -1,0 +1,37 @@
+# Additional API Gateway Pitfalls
+
+These supplement the critical pitfalls listed in the main skill file. Consult when designing or debugging API Gateway configurations.
+
+## Header Handling
+
+- API Gateway drops/remaps certain headers: `Authorization` conditionally dropped on requests (when containing SigV4 signature or using IAM auth), `Host` overwritten on requests with integration endpoint hostname, `Content-MD5` dropped on requests. Plan accordingly for header passthrough
+
+## URL Encoding
+
+- Pipe `|` and curly braces `{}` must be URL-encoded in REST API query strings. Semicolons `;` must be URL-encoded in HTTP and WebSocket API query strings (they cause data splitting)
+
+## Throttling
+
+- Throttle limits are best-effort, not hard guarantees. Brief spikes above limits may occur
+
+## Caching
+
+- Cache charges apply even when cache is empty. Only enable caching when you have a clear use case
+- Edge-optimized endpoints do NOT cache at the edge. They only route through CloudFront POPs for optimized TCP connections. For actual edge caching, use a separate CloudFront distribution with a Regional API
+
+## Usage Plans and API Keys
+
+- Do not associate one API key with multiple usage plans covering the same API stage; API Gateway picks one plan non-deterministically
+- Usage plan RPS limits are per API key: 100 rps with 10 keys means each key gets 100 rps, not 10 rps each
+
+## Logging Costs
+
+- Execution logging at INFO level generates many log events per request (10-60+ depending on API complexity). CloudWatch Logs costs can exceed Lambda + API Gateway combined at scale. Use ERROR level in production
+
+## Canary Deployments
+
+- Canary deployments test API Gateway deployment snapshots (resources, integrations, mapping templates, authorizers), not Lambda code directly. Stage variable overrides can route canary traffic to different Lambda aliases. For Lambda code canary without API changes, use Lambda aliases with weighted routing
+
+## Management API
+
+- Management API rate limit: 10 rps / 40 burst. Heavy automation can hit this

--- a/plugins/aws-serverless/skills/aws-serverless-api-gateway/references/requirements-gathering.md
+++ b/plugins/aws-serverless/skills/aws-serverless-api-gateway/references/requirements-gathering.md
@@ -1,0 +1,275 @@
+# API Requirements Gathering Guide
+
+When helping users define requirements for APIs built on Amazon API Gateway, guide them through a structured process. Ask one question at a time; do not overwhelm with lists of questions.
+
+## Workflow
+
+1. Start with API purpose and overview (including multi-tenancy, topology, cost)
+2. Determine the right API type (REST, HTTP, WebSocket) based on requirements
+3. Progress through each category systematically (skip WebSocket section if not applicable)
+4. Ask clarifying questions for gaps
+5. Generate a final requirements summary for confirmation
+
+## Requirements Categories
+
+### 1. API Purpose and Overview
+
+- What problem does the API solve?
+- Who are the primary consumers (browsers, mobile apps, other services, IoT devices, AI agents)?
+- Expected usage volume (requests per day/hour/second)?
+- Is this a public API, internal API, or partner API?
+- Will AI agents or LLMs consume this API? (Affects documentation depth, error message design, pagination style, and monetization; see architecture-patterns.md "Designing APIs for AI Agent Consumption")
+- Is this a multi-tenant API? (Affects throttling, isolation, and architecture; see architecture-patterns.md "Multi-Tenant SaaS")
+  - Per-tenant throttling tiers needed (bronze/silver/gold)? (Requires REST API usage plans)
+  - Tenant isolation level? (Throttling only, or compute isolation via Lambda `TenantIsolationMode: PER_TENANT`?)
+  - Noisy-neighbor prevention requirements?
+- Account topology? (Single account for all APIs, separate accounts per domain/application, or central API account with centralized governance? Affects cross-account access, observability aggregation, and custom domain management)
+- Cost sensitivity or budget constraints? (HTTP API is significantly cheaper than REST API but has fewer features: no caching, no WAF, no usage plans, no request validation, no VTL, hard 30s timeout. Choose based on feature needs vs cost)
+
+### 2. Endpoints and Operations
+
+- Resources to expose (users, orders, products, etc.)?
+- Operations per resource (GET, POST, PUT, DELETE, PATCH)?
+- URL paths and naming conventions?
+- Nested resources or relationships?
+- Query parameters for filtering, sorting, pagination?
+- API versioning strategy? (URL path `/v1/` is simplest; header-based `X-API-Version` via routing rules is cleanest for REST API; query parameter `?version=1` is least recommended)
+- How many concurrent API versions to support?
+- Deprecation and sunsetting plan for old versions?
+
+### 3. Request/Response Specifications
+
+- Data sent in request bodies?
+- Required or optional headers?
+- Query parameters needed?
+- Response format (JSON, XML, binary)?
+- Binary content types? (Images, PDFs, files require `binaryMediaTypes` configuration; avoid `*/*` wildcard as it breaks Lambda proxy JSON responses)
+- Expected response codes for success and error scenarios?
+- Need for multi-value query parameters or headers?
+
+### 4. Data Models and Schemas
+
+- Domain entities and their attributes?
+- Data types for each field?
+- Required vs optional fields?
+- Validation rules and constraints?
+- Enumerations or fixed value sets?
+- Need for request body validation? (REST API only supports JSON Schema draft 4)
+
+### 5. Authentication and Authorization
+
+- Authentication method?
+  - IAM (SigV4): Best for AWS-to-AWS service calls
+  - Lambda authorizer: Custom logic, third-party IdPs, bearer tokens
+  - JWT authorizer: HTTP API only, automatic OIDC/OAuth 2.0 validation
+  - Cognito user pools: REST API native, or JWT authorizer on HTTP API
+  - API keys: Not for primary auth; use for throttling/metering with usage plans
+  - mTLS: Certificate-based, good for B2B and IoT
+- Authorization model (RBAC, ABAC, resource-based)?
+- Different permission levels or user roles?
+- IP whitelisting or VPC restrictions needed?
+- Cross-account access requirements?
+
+### 6. Integration Requirements
+
+- Backend services (Lambda, DynamoDB, RDS, ECS/EKS, on-premises)?
+- Direct AWS service integrations without Lambda? REST API supports any AWS service via VTL mapping templates (SQS, EventBridge, Step Functions, S3, DynamoDB, etc.). HTTP API supports a subset via [first-class integrations](https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-aws-services.html) with parameter mapping (SQS, EventBridge, Step Functions, Kinesis, AppConfig)
+- VPC integrations for private resources? (VPC Link required; REST uses NLB, HTTP uses ALB/NLB/Cloud Map)
+- Does the API need to be completely private (VPC-only access)? (REST API only; requires `execute-api` VPC endpoint + resource policy)
+- Private API as proxy to external APIs? (Provides centralized logging, throttling, and access control for outbound calls from isolated VPCs without NAT gateway; security teams must be aware of this egress path)
+- On-premises integrations? (Requires VPN/Direct Connect + NLB + VPC Link. Consider connectivity stability and health check tuning)
+- Data transformations needed between request/response and backend?
+- Need for response streaming (large payloads, LLM responses)? (REST API only; max 15-minute sessions, first 10 MB unrestricted then 2 MB/s bandwidth limit. No VTL response transformation, no caching with streaming)
+- Binary data handling needed (images, PDFs, files)? (Configure `binaryMediaTypes`; avoid `*/*` wildcard as it breaks Lambda proxy JSON responses)
+- File upload/download requirements? (Direct through API Gateway up to 10 MB, or presigned S3 URLs for larger files)
+- Synchronous or asynchronous processing? (REST API default 29s timeout, increasable up to 300s for Regional/Private via quota request. HTTP API has hard 30s limit. For longer operations or better UX, consider async patterns: SQS, EventBridge, Step Functions)
+
+### 7. WebSocket Requirements (if WebSocket API selected)
+
+- Route selection expression? (e.g., `$request.body.action` for JSON messages)
+- Custom routes beyond `$connect`/`$disconnect`/`$default`?
+- Session management strategy? (Store connectionId with user ID in DynamoDB on `$connect`; GSI on user ID for targeted messaging)
+- Message patterns? (Request-response, server push/broadcast, targeted push to specific users)
+- Expected concurrent connections and message throughput?
+- Client resilience requirements? (Automatic reconnect with exponential backoff is mandatory; 2-hour max connection duration, 10-minute idle timeout require client-side handling)
+- Heartbeat/keep-alive strategy? (Send periodic messages every 5-9 minutes to prevent idle timeout)
+- Connection state recovery on reconnect? (Re-authenticate, re-subscribe to topics, restore application state)
+- Backend message delivery? (Lambda via `@connections` Management API; handle `GoneException` for stale connections)
+- Multi-region WebSocket? (ConnectionId is region-specific; cross-region message propagation via EventBridge or DynamoDB Streams)
+
+### 8. Performance and Scalability
+
+- Expected peak request rates (per second)? (Account default: 10,000 rps / 5,000 burst across all APIs in a region, adjustable via Service Quotas)
+- Latency requirements (target response time)?
+- Need for response caching? (REST API only, TTL 0-3600s, 0.5-237 GB)
+- Multi-layer caching strategy? (CloudFront edge -> API Gateway regional -> application-level)
+- Throttling requirements (rate limit, burst limit)?
+- Different throttling tiers for different consumers? (Requires REST API usage plans for per-API-key rate limits)
+- Expected payload sizes? (Max 10 MB for REST/HTTP, consider presigned S3 URLs for larger files, or compressed passthrough via binary media types to exceed Lambda's 6 MB limit)
+- Large payload strategy? (Presigned S3 URLs for >10 MB; response streaming for REST API up to 15-minute sessions; compressed passthrough for >6 MB Lambda payloads)
+- Need for payload compression? (`minimumCompressionSize` on REST API; reduces bandwidth, latency, and data transfer costs through NAT Gateway/VPC Endpoints)
+- Per-tenant or per-consumer throttling tiers? (Requires REST API usage plans; HTTP API has no per-consumer throttling natively)
+
+### 9. Error Handling
+
+- Custom error response format?
+- CORS headers needed on error responses?
+- Specific gateway response customizations?
+- How to communicate validation errors?
+
+### 10. Observability
+
+- Execution logging level (ERROR recommended for production, INFO for debugging)? (REST/WebSocket only; HTTP API does not support execution logging)
+- Custom access log format requirements? (Use enhanced observability variables for phase-level troubleshooting)
+- AWS X-Ray tracing needed? (REST API only)
+- Custom CloudWatch metrics? (Consider CloudWatch Embedded Metrics Format for business metrics)
+- Alerting requirements (latency thresholds, error rate, throttle count)?
+- API analytics pipeline needed? (Firehose -> S3 -> Athena -> QuickSight for deep analytics beyond CloudWatch)
+
+### 11. Security Requirements
+
+- AWS WAF needed? (REST API direct; HTTP API via CloudFront + WAF)
+- Which WAF managed rules? (Core Rule Set, SQL injection, Known Bad Inputs, IP Reputation at minimum)
+- CORS configuration (which origins, methods, headers)? Don't forget CORS headers on gateway error responses (DEFAULT_4XX, DEFAULT_5XX)
+- TLS version requirements (TLS 1.2 minimum recommended)?
+- mTLS for client certificate authentication? (REST/HTTP native on custom domain, or CloudFront viewer mTLS for any API type)
+- Certificate revocation checking needed? (Lambda authorizer + DynamoDB, or CloudFront Connection Functions + KeyValueStore)
+- Data encryption requirements? (Cache encryption at rest is off by default)
+- Compliance requirements (HIPAA, PCI-DSS, SOC2)?
+- Need to disable default execute-api endpoint? (Force traffic through custom domain)
+- DDoS protection considerations? (WAF rate-based rules, Shield)
+
+### 12. Deployment, Environment, and Testing
+
+- How many environments (dev, staging, production)?
+- Separate stacks per environment (full isolation) or stages within one API?
+- Canary deployment needed? (REST API only; tests API configuration, not Lambda code)
+- Blue/green deployment strategy? (Custom domain API mappings for zero-downtime switching)
+- Stage variables for environment-specific config?
+- CI/CD pipeline (CodePipeline, GitHub Actions, GitLab CI, etc.)?
+- IaC tool (SAM, CDK, CloudFormation, Terraform)?
+- Local testing approach? (`sam local start-api` supports Lambda proxy/non-proxy only; direct service integrations require a deployed dev stage or API Gateway console Test Invoke)
+- Integration testing strategy? (Deployed dev stage, contract testing, synthetic canaries)
+- Load/performance testing plans? (Identify bottlenecks before production; test full stack, not just API Gateway)
+
+### 13. Custom Domain and Routing
+
+- Custom domain name needed?
+- Endpoint type? Edge-optimized (default for global clients; optimizes TCP connections but does not cache at edge), Regional (same-region clients, or pair with own CloudFront distribution when edge caching, edge compute, granular WAF control, or geo-based routing is needed), Private (VPC-only access, REST API only)
+- Multiple APIs behind one domain? REST API: use routing rules (preferred, supports header-based routing) or base path mappings. HTTP API/WebSocket: use base path mappings (routing rules are REST API only)
+- Header-based routing needed? (API versioning, A/B testing, tenant routing; requires routing rules, REST API only)
+- Multi-region deployment? (Active-passive failover or active-active with Route 53 latency-based routing)
+- Data consistency requirements for multi-region? (DynamoDB Global Tables uses last-writer-wins; conditional writes do NOT prevent cross-region conflicts. For conflict-sensitive data, use single-region write routing or commutative operations. Data sovereignty concerns may require geo-based routing instead of latency-based)
+- Cross-account topology? (Central API account with shared domain, or per-team subdomains)
+
+### 14. Governance and Compliance
+
+- Organization-wide API standards to enforce? (SCPs for preventative, CloudFormation Hooks for proactive, AWS Config for detective controls)
+- Required tags on API resources?
+- Control plane access restrictions? (Who can create, modify, deploy APIs)
+- Audit requirements? (CloudTrail for control plane, access logs for data plane)
+- API documentation and developer portal needed?
+- API lifecycle management (versioning, deprecation, sunsetting)? See also "Endpoints and Operations" for versioning strategy details
+
+## Output Format
+
+```markdown
+# API Requirements Summary
+
+## Overview
+
+- API Name: [name]
+- API Type: [REST API / HTTP API / WebSocket API]
+- Endpoint Type: [Edge-optimized / Regional / Private]
+- Purpose: [description]
+- Target Consumers: [who]
+- Expected Volume: [requests/day, peak rps]
+- Multi-tenant: [yes/no, isolation level]
+- Account Topology: [single account / per-domain accounts / central API account]
+- Cost Sensitivity: [budget constraints, API type preference]
+
+## Endpoints
+
+| Resource | Method | Path | Description | Auth |
+| -------- | ------ | ---- | ----------- | ---- |
+| ...      | ...    | ...  | ...         | ...  |
+
+## API Versioning
+
+- Strategy: [URL path / header-based / query parameter]
+- Concurrent Versions: [number]
+- Deprecation Policy: [timeline, communication plan]
+
+## Authentication and Authorization
+
+- Method: [auth method]
+- Authorization Model: [model]
+- Roles/Permissions: [details]
+
+## Data Models
+
+[Entity definitions with attributes and types]
+
+## Binary Data and Large Payloads
+
+- Binary Media Types: [list or none]
+- File Upload/Download: [direct API / presigned S3 URLs]
+- Max Expected Payload Size: [size]
+
+## WebSocket Requirements (if applicable)
+
+- Route Selection Expression: [field]
+- Custom Routes: [list]
+- Session Management: [connection tracking strategy]
+- Message Patterns: [request-response / broadcast / targeted push]
+- Expected Concurrent Connections: [number]
+- Client Resilience: [reconnect, heartbeat strategy]
+
+## Performance Requirements
+
+- Target Latency: [ms]
+- Rate Limits: [requests/second]
+- Burst Limit: [requests]
+- Caching: [yes/no, TTL]
+- Per-Tenant Throttling: [yes/no, tier structure]
+
+## Security Requirements
+
+- WAF: [yes/no]
+- CORS: [origins, methods, headers]
+- TLS: [minimum version]
+- mTLS: [yes/no]
+- Compliance: [standards]
+
+## Observability
+
+- Execution Logging: [level]
+- Access Logging: [format]
+- X-Ray Tracing: [yes/no]
+- Key Metrics: [list]
+- Alarms: [list]
+
+## Deployment and Testing
+
+- Environments: [list]
+- Strategy: [canary/blue-green/direct]
+- IaC Tool: [SAM/CDK/CloudFormation/Terraform]
+- CI/CD: [pipeline tool]
+- Local Testing: [sam local / deployed dev stage]
+- Integration Testing: [approach]
+
+## Custom Domain and Routing
+
+- Domain: [domain name]
+- Endpoint Type: [edge-optimized/regional/private]
+- Routing: [routing rules (recommended) / base path mappings]
+- Header-Based Routing: [yes/no, use case]
+- Multi-region: [yes/no, strategy]
+- Data Consistency: [conflict resolution strategy]
+
+## Governance
+
+- Tag Requirements: [required tags]
+- Audit: [CloudTrail/Config requirements]
+- Standards Enforcement: [SCPs/Hooks/Config rules]
+```

--- a/plugins/aws-serverless/skills/aws-serverless-api-gateway/references/sam-cloudformation.md
+++ b/plugins/aws-serverless/skills/aws-serverless-api-gateway/references/sam-cloudformation.md
@@ -1,0 +1,229 @@
+# SAM and CloudFormation Patterns
+
+## Table of Contents
+
+- [OpenAPI Extensions](#openapi-extensions)
+- [Common SAM Patterns](#common-sam-patterns)
+  - [Custom Domain with Base Path Mapping](#custom-domain-with-base-path-mapping)
+- [Infrastructure Patterns](#infrastructure-patterns)
+  - [Private API with VPC Endpoint](#private-api-with-vpc-endpoint)
+  - [Gateway Responses with CORS Headers](#gateway-responses-with-cors-headers)
+  - [Response Streaming](#response-streaming)
+  - [Routing Rules](#routing-rules)
+- [Key Pitfalls](#key-pitfalls)
+- [VTL Mapping Templates (REST API)](#vtl-mapping-templates-rest-api)
+- [HTTP API Parameter Mapping](#http-api-parameter-mapping)
+- [Binary Data Handling](#binary-data-handling)
+
+For direct AWS service integration templates (EventBridge, SQS, DynamoDB, Kinesis, Step Functions), see `references/sam-service-integrations.md`.
+
+---
+
+## OpenAPI Extensions
+
+Define API Gateway configuration inline in OpenAPI specs:
+
+| Extension                                      | Purpose                                                      |
+| ---------------------------------------------- | ------------------------------------------------------------ |
+| `x-amazon-apigateway-integration`              | Integration configuration (Lambda, HTTP, AWS service, mock)  |
+| `x-amazon-apigateway-request-validators`       | Request validation rules                                     |
+| `x-amazon-apigateway-binary-media-types`       | Binary content type registration                             |
+| `x-amazon-apigateway-gateway-responses`        | Custom error responses                                       |
+| `x-amazon-apigateway-cors`                     | HTTP API CORS configuration                                  |
+| `x-amazon-apigateway-endpoint-configuration`   | Endpoint type, VPC endpoint IDs, `disableExecuteApiEndpoint` |
+| `x-amazon-apigateway-authorizer`               | Authorizer definitions                                       |
+| `x-amazon-apigateway-policy`                   | Embedded resource policy                                     |
+| `x-amazon-apigateway-minimum-compression-size` | Payload compression threshold                                |
+| `x-amazon-apigateway-integrations`             | Reusable integration components (HTTP API only)              |
+| `x-amazon-apigateway-importexport-version`     | OpenAPI 3.0 export format version                            |
+
+## Common SAM Patterns
+
+For basic Lambda proxy and auth SAM templates (JWT authorizer, Cognito authorizer, Lambda authorizer, API keys), see the [aws-serverless-lambda web-app-deployment reference](../../aws-serverless-lambda/references/web-app-deployment.md).
+
+### Custom Domain with Base Path Mapping
+
+```yaml
+MyDomain:
+  Type: AWS::ApiGatewayV2::DomainName
+  Properties:
+    DomainName: api.example.com
+    DomainNameConfigurations:
+      - EndpointType: REGIONAL
+        CertificateArn: !Ref MyCertificate
+
+MyMapping:
+  Type: AWS::ApiGatewayV2::ApiMapping
+  Properties:
+    DomainName: !Ref MyDomain
+    ApiId: !Ref MyApi
+    Stage: !Ref MyStage
+    ApiMappingKey: v1/orders
+```
+
+## Infrastructure Patterns
+
+### Private API with VPC Endpoint
+
+```yaml
+MyApi:
+  Type: AWS::Serverless::Api
+  Properties:
+    StageName: prod
+    EndpointConfiguration:
+      Type: PRIVATE
+      VPCEndpointIds:
+        - !Ref VpcEndpoint
+    Auth:
+      ResourcePolicy:
+        CustomStatements:
+          - Effect: Allow
+            Principal: "*"
+            Action: execute-api:Invoke
+            Resource: execute-api:/*
+            Condition:
+              StringEquals:
+                aws:SourceVpce: !Ref VpcEndpoint
+```
+
+### Gateway Responses with CORS Headers
+
+```yaml
+MyApi:
+  Type: AWS::Serverless::Api
+  Properties:
+    StageName: Prod
+    Cors:
+      AllowMethods: "'GET,POST,OPTIONS'"
+      AllowHeaders: "'Content-Type,Authorization'"
+      AllowOrigin: "'https://example.com'"
+    GatewayResponses:
+      DEFAULT_4XX:
+        ResponseParameters:
+          Headers:
+            Access-Control-Allow-Origin: "'https://example.com'"
+            Access-Control-Allow-Headers: "'Content-Type,Authorization'"
+      DEFAULT_5XX:
+        ResponseParameters:
+          Headers:
+            Access-Control-Allow-Origin: "'https://example.com'"
+            Access-Control-Allow-Headers: "'Content-Type,Authorization'"
+```
+
+### Response Streaming
+
+```yaml
+MyFunction:
+  Type: AWS::Serverless::Function
+  Properties:
+    Handler: app.handler
+    Runtime: nodejs20.x
+    Events:
+      Stream:
+        Type: Api
+        Properties:
+          Path: /stream
+          Method: get
+          RestApiId: !Ref MyApi
+
+MyApi:
+  Type: AWS::Serverless::Api
+  Properties:
+    StageName: Prod
+    DefinitionBody:
+      openapi: "3.0"
+      paths:
+        /stream:
+          get:
+            x-amazon-apigateway-integration:
+              type: aws_proxy
+              httpMethod: POST
+              uri: !Sub "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunction.Arn}/invocations"
+              responseTransferMode: STREAM
+```
+
+### Routing Rules
+
+```yaml
+# Based on https://github.com/aws-samples/serverless-samples/blob/main/apigw-header-routing/template-header-based-routing.yaml
+MyRoutingRule:
+  Type: AWS::ApiGatewayV2::RoutingRule
+  Properties:
+    DomainNameArn: !Sub "arn:aws:apigateway:${AWS::Region}::/domainnames/${MyDomain}"
+    Priority: 100
+    Conditions:
+      - MatchHeaders:
+          AnyOf:
+            - Header: X-API-Version
+              ValueGlob: "v2*"
+    Actions:
+      - InvokeApi:
+          ApiId: !Ref MyV2Api
+          Stage: prod
+          StripBasePath: false
+```
+
+## Key Pitfalls
+
+For general SAM/CloudFormation pitfalls (circular dependencies, `!Sub` defaults, YAML duplicate keys, build issues, layer nesting, `confirm_changeset`), see the [aws-serverless-deployment skill](../../aws-serverless-deployment/).
+
+API-Gateway-specific pitfalls:
+
+1. Root-level `security` in OpenAPI is ignored. Must set per-operation
+2. `$ref` cannot reference external files in OpenAPI; only internal references (`#/definitions/` for Swagger 2.0, `#/components/schemas/` for OpenAPI 3.0)
+3. JSON Schema draft 4 only: no `discriminator`, `nullable`, `exclusiveMinimum`, no `oneOf`/`anyOf`/`allOf` with `$ref` in same schema
+
+## VTL Mapping Templates (REST API)
+
+### Key Variables
+
+- `$input.body`: Raw request body
+- `$input.json('$.jsonpath')`: Extract JSON
+- `$input.path('$.jsonpath')`: Extract as object
+- `$input.params('name')`: Get parameter by name
+- `$input.params().header`, `.querystring`, `.path`: Parameter maps
+- `$context.*`: Request context
+- `$stageVariables.*`: Stage variables
+- `$util.escapeJavaScript()`, `$util.parseJson()`, `$util.urlEncode()`, `$util.base64Encode()`, `$util.base64Decode()`
+
+### Limits
+
+- Template size: 300 KB
+- `#foreach` iterations: 1,000
+
+### Passthrough Behavior
+
+- `WHEN_NO_MATCH`: Pass through when no template matches Content-Type
+- `WHEN_NO_TEMPLATES`: Pass through when no templates defined
+- `NEVER`: Reject with 415 Unsupported Media Type
+
+### Response Override
+
+```velocity
+#set($context.responseOverride.status = 400)
+#set($context.responseOverride.header.X-Custom = "value")
+```
+
+Gotcha: Applying override to same parameter twice causes 5XX
+
+## HTTP API Parameter Mapping
+
+No VTL. Simple expressions:
+
+- `$request.header.name`, `$request.querystring.name`, `$request.body.jsonpath`, `$request.path.name`
+- `$context.*`, `$stageVariables.*`
+- Actions: `overwrite`, `append`, `remove`
+
+## Binary Data Handling
+
+### REST API
+
+- Register binary media types (e.g., `image/png`, `*/*`)
+- `contentHandling` on Integration/IntegrationResponse: `CONVERT_TO_BINARY` or `CONVERT_TO_TEXT`
+- Lambda proxy: `isBase64Encoded: true` in response; request body arrives as base64 when binary
+- Only the first `Accept` media type is honored
+
+### HTTP API
+
+- Payload format 2.0: `isBase64Encoded` in request event automatically. Lambda returns `isBase64Encoded: true`
+- No need to register binary media types explicitly

--- a/plugins/aws-serverless/skills/aws-serverless-api-gateway/references/sam-service-integrations.md
+++ b/plugins/aws-serverless/skills/aws-serverless-api-gateway/references/sam-service-integrations.md
@@ -1,0 +1,730 @@
+# SAM Service Integration Templates
+
+Direct AWS service integrations without Lambda. These templates connect API Gateway directly to AWS services using VTL mapping templates (REST API) or WebSocket request templates.
+
+## Table of Contents
+
+- [EventBridge](#direct-aws-service-integration-eventbridge)
+- [SQS](#direct-aws-service-integration-sqs)
+- [DynamoDB Full CRUD](#direct-aws-service-integration-dynamodb-full-crud)
+  - [Option A: OpenAPI-based definition](#option-a-openapi-based-definition-recommended-for-complex-apis)
+  - [Option B: Inline CloudFormation methods](#option-b-inline-cloudformation-methods-simpler-for-small-apis)
+- [Kinesis Data Streams](#direct-aws-service-integration-kinesis-data-streams)
+- [Step Functions (REST API)](#direct-aws-service-integration-step-functions)
+- [Step Functions (WebSocket API)](#websocket-api-express-workflow-sync-and-standard-workflow-async-with-callback)
+
+---
+
+## Direct AWS Service Integration (EventBridge)
+
+Based on [aws-samples/serverless-patterns/apigw-rest-api-eventbridge-sam](https://github.com/aws-samples/serverless-patterns/tree/main/apigw-rest-api-eventbridge-sam). Supports batching multiple events via `#foreach`.
+
+```yaml
+MyCustomEventBus:
+  Type: AWS::Events::EventBus
+  Properties:
+    Name: !Sub "${AWS::StackName}-EventBus"
+
+ApiGatewayEventBridgeRole:
+  Type: AWS::IAM::Role
+  Properties:
+    AssumeRolePolicyDocument:
+      Version: "2012-10-17"
+      Statement:
+        - Effect: Allow
+          Principal:
+            Service: apigateway.amazonaws.com
+          Action: sts:AssumeRole
+    Policies:
+      - PolicyName: EBPutEvents
+        PolicyDocument:
+          Version: "2012-10-17"
+          Statement:
+            - Effect: Allow
+              Action: events:PutEvents
+              Resource: !GetAtt MyCustomEventBus.Arn
+
+EventBridgeIntegration:
+  Type: AWS::ApiGateway::Method
+  Properties:
+    HttpMethod: POST
+    ResourceId: !GetAtt Api.RootResourceId
+    RestApiId: !Ref Api
+    AuthorizationType: NONE
+    Integration:
+      Type: AWS
+      IntegrationHttpMethod: POST
+      Credentials: !GetAtt ApiGatewayEventBridgeRole.Arn
+      Uri: !Sub "arn:aws:apigateway:${AWS::Region}:events:action/PutEvents"
+      PassthroughBehavior: WHEN_NO_TEMPLATES
+      RequestTemplates:
+        application/json: !Sub
+          - |-
+            #set($context.requestOverride.header.X-Amz-Target = "AWSEvents.PutEvents")
+            #set($context.requestOverride.header.Content-Type = "application/x-amz-json-1.1")
+            #set($inputRoot = $input.path('$'))
+            {
+              "Entries": [
+                #foreach($elem in $inputRoot.items)
+                {
+                  "Detail": "$util.escapeJavaScript($elem.Detail).replaceAll("\\'","'")",
+                  "DetailType": "$elem.DetailType",
+                  "EventBusName": "${EventBusName}",
+                  "Source": "$elem.Source"
+                }#if($foreach.hasNext),#end
+                #end
+              ]
+            }
+          - EventBusName: !Ref MyCustomEventBus
+      IntegrationResponses:
+        - StatusCode: "200"
+          ResponseTemplates:
+            application/json: '{}'
+    MethodResponses:
+      - StatusCode: "200"
+        ResponseModels:
+          application/json: Empty
+```
+
+## Direct AWS Service Integration (SQS)
+
+Based on [aws-samples/serverless-patterns/apigw-sqs-lambda-iot](https://github.com/aws-samples/serverless-patterns/tree/main/apigw-sqs-lambda-iot). Uses query protocol with `PassthroughBehavior: NEVER` to reject unmatched content types.
+
+```yaml
+SqsIntegration:
+  Type: AWS::ApiGateway::Method
+  Properties:
+    HttpMethod: POST
+    ResourceId: !Ref MessagesResource
+    RestApiId: !Ref MyRestApi
+    AuthorizationType: CUSTOM
+    AuthorizerId: !Ref MyAuthorizer
+    RequestValidatorId: !Ref BodyValidator
+    RequestModels:
+      application/json: !Ref MessageModel
+    Integration:
+      Type: AWS
+      IntegrationHttpMethod: POST
+      Uri: !Sub "arn:aws:apigateway:${AWS::Region}:sqs:path/${AWS::AccountId}/${MyQueue.QueueName}"
+      Credentials: !GetAtt SqsRole.Arn
+      PassthroughBehavior: NEVER
+      RequestParameters:
+        integration.request.header.Content-Type: "'application/x-www-form-urlencoded'"
+      RequestTemplates:
+        application/json: "Action=SendMessage&MessageBody=$util.urlEncode($input.body)"
+      IntegrationResponses:
+        - StatusCode: "200"
+          ResponseTemplates:
+            application/json: '{"messageId": "$input.path(''$.SendMessageResponse.SendMessageResult.MessageId'')"}'
+    MethodResponses:
+      - StatusCode: "200"
+
+SqsRole:
+  Type: AWS::IAM::Role
+  Properties:
+    AssumeRolePolicyDocument:
+      Version: "2012-10-17"
+      Statement:
+        - Effect: Allow
+          Principal:
+            Service: apigateway.amazonaws.com
+          Action: sts:AssumeRole
+    Policies:
+      - PolicyName: SqsSendMessage
+        PolicyDocument:
+          Version: "2012-10-17"
+          Statement:
+            - Effect: Allow
+              Action: sqs:SendMessage
+              Resource: !GetAtt MyQueue.Arn
+```
+
+## Direct AWS Service Integration (DynamoDB Full CRUD)
+
+Full CRUD pattern based on [aws-samples/serverless-patterns](https://github.com/aws-samples/serverless-patterns/tree/main/apigw-dynamodb-lambda-scheduler-ses-auto-deletion-sam). Uses OpenAPI definition with `AWS::Include` for clean separation of API spec and infrastructure.
+
+### Option A: OpenAPI-based definition (recommended for complex APIs)
+
+SAM template references an external OpenAPI file:
+
+```yaml
+MyApi:
+  Type: AWS::Serverless::Api
+  Properties:
+    StageName: v1
+    EndpointConfiguration:
+      Type: REGIONAL
+    DefinitionBody:
+      'Fn::Transform':
+        Name: 'AWS::Include'
+        Parameters:
+          Location: './restapi/api.yaml'
+    MethodSettings:
+      - ResourcePath: "/*"
+        HttpMethod: "*"
+        LoggingLevel: ERROR
+
+MyTable:
+  Type: AWS::DynamoDB::Table
+  Properties:
+    AttributeDefinitions:
+      - AttributeName: id
+        AttributeType: S
+    KeySchema:
+      - AttributeName: id
+        KeyType: HASH
+    BillingMode: PAY_PER_REQUEST
+    StreamSpecification:
+      StreamViewType: NEW_IMAGE
+
+APIGatewayDynamoDBRole:
+  Type: AWS::IAM::Role
+  Properties:
+    AssumeRolePolicyDocument:
+      Version: "2012-10-17"
+      Statement:
+        - Effect: Allow
+          Principal:
+            Service: apigateway.amazonaws.com
+          Action: sts:AssumeRole
+    Policies:
+      - PolicyName: DynamoDbCrud
+        PolicyDocument:
+          Version: "2012-10-17"
+          Statement:
+            - Effect: Allow
+              Action:
+                - dynamodb:GetItem
+                - dynamodb:UpdateItem
+                - dynamodb:DeleteItem
+                - dynamodb:Scan
+                - dynamodb:Query
+              Resource: !GetAtt MyTable.Arn
+```
+
+OpenAPI file (`restapi/api.yaml`), key methods shown:
+
+```yaml
+openapi: "3.0.1"
+info:
+  title: "my-api"
+paths:
+  /items:
+    ## Create: uses UpdateItem with $context.requestId as auto-generated ID
+    post:
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/item"
+        required: true
+      x-amazon-apigateway-request-validator: "Validate body"
+      x-amazon-apigateway-integration:
+        credentials:
+          Fn::GetAtt: [APIGatewayDynamoDBRole, Arn]
+        httpMethod: "POST"
+        uri:
+          Fn::Sub: "arn:aws:apigateway:${AWS::Region}:dynamodb:action/UpdateItem"
+        requestTemplates:
+          application/json:
+            Fn::Sub: |
+              {
+                "TableName": "${MyTable}",
+                "Key": {
+                  "id": {"S": "$context.requestId"}
+                },
+                "UpdateExpression": "set description = :description, #dt = :dt, #email = :email",
+                "ExpressionAttributeValues": {
+                  ":description": {"S": "$input.path('$.description')"},
+                  ":dt": {"S": "$input.path('$.datetime')"},
+                  ":email": {"S": "$input.path('$.email')"}
+                },
+                "ExpressionAttributeNames": {
+                  "#dt": "datetime",
+                  "#email": "email"
+                },
+                "ReturnValues": "ALL_NEW"
+              }
+        responses:
+          default:
+            statusCode: "200"
+            responseTemplates:
+              application/json: |
+                #set($inputRoot = $input.path('$'))
+                {
+                  "message": "Item created successfully",
+                  "data": {
+                    "id": "$inputRoot.Attributes.id.S",
+                    "description": "$inputRoot.Attributes.description.S",
+                    "datetime": "$inputRoot.Attributes.datetime.S"
+                  }
+                }
+        type: "aws"
+    ## List: Scan with #foreach to build JSON array
+    get:
+      x-amazon-apigateway-integration:
+        credentials:
+          Fn::GetAtt: [APIGatewayDynamoDBRole, Arn]
+        httpMethod: "POST"
+        uri:
+          Fn::Sub: "arn:aws:apigateway:${AWS::Region}:dynamodb:action/Scan"
+        requestTemplates:
+          application/json:
+            Fn::Sub: |
+              #set($startKey = $input.params('startKey'))
+              {
+                "TableName": "${MyTable}",
+                "Limit": 25
+                #if($startKey != "")
+                ,"ExclusiveStartKey": {"id": {"S": "$startKey"}}
+                #end
+              }
+        responses:
+          default:
+            statusCode: "200"
+            responseTemplates:
+              application/json: |
+                #set($inputRoot = $input.path('$'))
+                {
+                  "items": [
+                  #foreach($elem in $inputRoot.Items)
+                    {
+                      "id": "$elem.id.S",
+                      "description": "$elem.description.S",
+                      "datetime": "$elem.datetime.S"
+                    }#if($foreach.hasNext),#end
+                  #end
+                  ]
+                  #if($inputRoot.LastEvaluatedKey.id.S != "")
+                  ,"nextKey": "$inputRoot.LastEvaluatedKey.id.S"
+                  #end
+                }
+        type: "aws"
+  /items/{id}:
+    ## Read
+    get:
+      parameters:
+        - name: "id"
+          in: "path"
+          required: true
+          schema:
+            type: "string"
+      x-amazon-apigateway-integration:
+        credentials:
+          Fn::GetAtt: [APIGatewayDynamoDBRole, Arn]
+        httpMethod: "POST"
+        uri:
+          Fn::Sub: "arn:aws:apigateway:${AWS::Region}:dynamodb:action/GetItem"
+        requestTemplates:
+          application/json:
+            Fn::Sub: |
+              {
+                "TableName": "${MyTable}",
+                "Key": {
+                  "id": {"S": "$input.params().path.id"}
+                }
+              }
+        responses:
+          default:
+            statusCode: "200"
+            responseTemplates:
+              application/json: |
+                #set($inputRoot = $input.path('$'))
+                {
+                  "id": "$inputRoot.Item.id.S",
+                  "description": "$inputRoot.Item.description.S",
+                  "datetime": "$inputRoot.Item.datetime.S"
+                }
+        type: "aws"
+    ## Delete: returns deleted item via ReturnValues: ALL_OLD
+    delete:
+      parameters:
+        - name: "id"
+          in: "path"
+          required: true
+          schema:
+            type: "string"
+      x-amazon-apigateway-integration:
+        credentials:
+          Fn::GetAtt: [APIGatewayDynamoDBRole, Arn]
+        httpMethod: "POST"
+        uri:
+          Fn::Sub: "arn:aws:apigateway:${AWS::Region}:dynamodb:action/DeleteItem"
+        requestTemplates:
+          application/json:
+            Fn::Sub: |
+              {
+                "TableName": "${MyTable}",
+                "Key": {
+                  "id": {"S": "$input.params().path.id"}
+                },
+                "ReturnValues": "ALL_OLD"
+              }
+        responses:
+          default:
+            statusCode: "200"
+            responseTemplates:
+              application/json: |
+                #set($inputRoot = $input.path('$'))
+                {
+                  "message": "Item deleted successfully",
+                  "data": {
+                    "id": "$inputRoot.Attributes.id.S",
+                    "description": "$inputRoot.Attributes.description.S"
+                  }
+                }
+        type: "aws"
+components:
+  schemas:
+    item:
+      required: [description, datetime, email]
+      type: object
+      properties:
+        description:
+          type: string
+        datetime:
+          type: string
+          format: date-time
+        email:
+          type: string
+          format: email
+x-amazon-apigateway-gateway-responses:
+  BAD_REQUEST_BODY:
+    statusCode: 400
+    responseTemplates:
+      application/json: '{"error": "$context.error.validationErrorString"}'
+x-amazon-apigateway-request-validators:
+  Validate body:
+    validateRequestParameters: false
+    validateRequestBody: true
+```
+
+### Option B: Inline CloudFormation methods (simpler for small APIs)
+
+```yaml
+## Single-method example: use Option A for full CRUD APIs
+DynamoDbGetIntegration:
+  Type: AWS::ApiGateway::Method
+  Properties:
+    HttpMethod: GET
+    ResourceId: !Ref ItemResource
+    RestApiId: !Ref MyRestApi
+    AuthorizationType: CUSTOM
+    AuthorizerId: !Ref MyAuthorizer
+    RequestParameters:
+      method.request.path.id: true
+    Integration:
+      Type: AWS
+      IntegrationHttpMethod: POST
+      Uri: !Sub "arn:aws:apigateway:${AWS::Region}:dynamodb:action/GetItem"
+      Credentials: !GetAtt DynamoDbRole.Arn
+      RequestTemplates:
+        application/json: !Sub |
+          {
+            "TableName": "${MyTable}",
+            "Key": {
+              "id": {"S": "$input.params('id')"}
+            }
+          }
+      IntegrationResponses:
+        - StatusCode: "200"
+          ResponseTemplates:
+            application/json: |
+              #set($item = $input.path('$.Item'))
+              {
+                "id": "$item.id.S",
+                "data": "$item.data.S",
+                "createdAt": "$item.createdAt.S"
+              }
+    MethodResponses:
+      - StatusCode: "200"
+```
+
+## Direct AWS Service Integration (Kinesis Data Streams)
+
+Based on [aws-samples/serverless-patterns/apigw-kinesis-lambda](https://github.com/aws-samples/serverless-patterns/tree/main/apigw-kinesis-lambda). Uses REST API resources with path parameter for stream name and Lambda as stream consumer.
+
+```yaml
+KinesisStream:
+  Type: AWS::Kinesis::Stream
+  Properties:
+    ShardCount: 1
+
+APIGatewayRole:
+  Type: AWS::IAM::Role
+  Properties:
+    AssumeRolePolicyDocument:
+      Version: "2012-10-17"
+      Statement:
+        - Effect: Allow
+          Principal:
+            Service: apigateway.amazonaws.com
+          Action: sts:AssumeRole
+    Policies:
+      - PolicyName: APIGWKinesisPolicy
+        PolicyDocument:
+          Version: "2012-10-17"
+          Statement:
+            - Effect: Allow
+              Action:
+                - kinesis:PutRecord
+                - kinesis:PutRecords
+              Resource: !Sub "${KinesisStream.Arn}*"
+
+Api:
+  Type: AWS::ApiGateway::RestApi
+  Properties:
+    Name: apigw-kinesis-api
+
+## Resources: /streams/{stream-name}/record and /streams/{stream-name}/records
+## (resource definitions omitted for brevity)
+
+## PutRecord: single record ingestion
+recordMethodPut:
+  Type: AWS::ApiGateway::Method
+  Properties:
+    RestApiId: !Ref Api
+    ResourceId: !Ref record
+    HttpMethod: PUT
+    AuthorizationType: NONE
+    Integration:
+      Type: AWS
+      Credentials: !GetAtt APIGatewayRole.Arn
+      IntegrationHttpMethod: POST
+      Uri: !Sub "arn:aws:apigateway:${AWS::Region}:kinesis:action/PutRecord"
+      PassthroughBehavior: WHEN_NO_TEMPLATES
+      RequestTemplates:
+        application/json: |
+          {
+            "StreamName": "$input.params('stream-name')",
+            "Data": "$util.base64Encode($input.json('$.Data'))",
+            "PartitionKey": "$input.path('$.PartitionKey')"
+          }
+      IntegrationResponses:
+        - StatusCode: "200"
+    MethodResponses:
+      - StatusCode: "200"
+
+## PutRecords: batch ingestion with #foreach
+recordsMethodPut:
+  Type: AWS::ApiGateway::Method
+  Properties:
+    RestApiId: !Ref Api
+    ResourceId: !Ref records
+    HttpMethod: PUT
+    AuthorizationType: NONE
+    Integration:
+      Type: AWS
+      Credentials: !GetAtt APIGatewayRole.Arn
+      IntegrationHttpMethod: POST
+      Uri: !Sub "arn:aws:apigateway:${AWS::Region}:kinesis:action/PutRecords"
+      PassthroughBehavior: WHEN_NO_TEMPLATES
+      RequestTemplates:
+        application/json: |
+          {
+            "StreamName": "$input.params('stream-name')",
+            "Records": [
+              #foreach($elem in $input.path('$.records'))
+              {
+                "Data": "$util.base64Encode($elem.data)",
+                "PartitionKey": "$elem.partition-key"
+              }#if($foreach.hasNext),#end
+              #end
+            ]
+          }
+      IntegrationResponses:
+        - StatusCode: "200"
+    MethodResponses:
+      - StatusCode: "200"
+
+## Lambda consumer triggered by Kinesis stream
+LambdaConsumer:
+  Type: AWS::Serverless::Function
+  Properties:
+    Handler: lambda_function.lambda_handler
+    Runtime: python3.13
+    CodeUri: src/
+    Policies:
+      - KinesisStreamReadPolicy:
+          StreamName: !Ref KinesisStream
+    Events:
+      Stream:
+        Type: Kinesis
+        Properties:
+          Stream: !GetAtt KinesisStream.Arn
+          StartingPosition: LATEST
+          BatchSize: 100
+```
+
+## Direct AWS Service Integration (Step Functions)
+
+REST API pattern based on [aws-samples/serverless-patterns/apigw-rest-stepfunction](https://github.com/aws-samples/serverless-patterns/tree/main/apigw-rest-stepfunction). WebSocket pattern based on [aws-samples/serverless-samples/apigw-ws-integrations](https://github.com/aws-samples/serverless-samples/tree/main/apigw-ws-integrations).
+
+### REST API: Standard workflow (async, fire-and-forget with polling)
+
+```yaml
+WaitableStateMachine:
+  Type: AWS::Serverless::StateMachine
+  Properties:
+    DefinitionUri: statemachine/workflow.asl.json
+    DefinitionSubstitutions:
+      DDBTable: !Ref StatusTable
+    Policies:
+      - DynamoDBWritePolicy:
+          TableName: !Ref StatusTable
+
+StatusTable:
+  Type: AWS::Serverless::SimpleTable
+  Properties:
+    PrimaryKey:
+      Name: Id
+      Type: String
+
+ApiGatewayStepFunctionsRole:
+  Type: AWS::IAM::Role
+  Properties:
+    AssumeRolePolicyDocument:
+      Version: "2012-10-17"
+      Statement:
+        - Effect: Allow
+          Principal:
+            Service: apigateway.amazonaws.com
+          Action: sts:AssumeRole
+    Policies:
+      - PolicyName: CallStepFunctions
+        PolicyDocument:
+          Version: "2012-10-17"
+          Statement:
+            - Effect: Allow
+              Action: states:StartExecution
+              Resource: !Ref WaitableStateMachine
+
+StartExecutionMethod:
+  Type: AWS::ApiGateway::Method
+  Properties:
+    RestApiId: !Ref Api
+    ResourceId: !GetAtt Api.RootResourceId
+    HttpMethod: POST
+    AuthorizationType: NONE
+    Integration:
+      Type: AWS
+      IntegrationHttpMethod: POST
+      Credentials: !GetAtt ApiGatewayStepFunctionsRole.Arn
+      Uri: !Sub "arn:aws:apigateway:${AWS::Region}:states:action/StartExecution"
+      PassthroughBehavior: WHEN_NO_TEMPLATES
+      RequestTemplates:
+        application/json: !Sub
+          - |-
+            #set($data = $util.escapeJavaScript($input.json('$')))
+            {
+              "input": "$data",
+              "stateMachineArn": "${StateMachineArn}"
+            }
+          - StateMachineArn: !Ref WaitableStateMachine
+      IntegrationResponses:
+        - StatusCode: "200"
+          ResponseTemplates:
+            application/json: ''
+    MethodResponses:
+      - StatusCode: "200"
+        ResponseModels:
+          application/json: Empty
+```
+
+### WebSocket API: Express workflow (sync) and Standard workflow (async with callback)
+
+```yaml
+## Express workflow: synchronous, returns result to WebSocket client
+SyncSFn:
+  Type: AWS::Serverless::StateMachine
+  Properties:
+    Type: EXPRESS
+    Definition:
+      StartAt: ProcessRequest
+      States:
+        ProcessRequest:
+          Type: Wait
+          Seconds: 5
+          End: true
+
+SFnSyncRouteIntegration:
+  Type: AWS::ApiGatewayV2::Integration
+  Properties:
+    ApiId: !Ref WebSocketApi
+    IntegrationType: AWS
+    IntegrationMethod: POST
+    IntegrationUri: !Sub "arn:aws:apigateway:${AWS::Region}:states:action/StartSyncExecution"
+    CredentialsArn: !GetAtt StepFunctionsSyncExecutionRole.Arn
+    TemplateSelectionExpression: \$default
+    RequestTemplates:
+      "$default":
+        Fn::Sub: >
+          #set($sfn_input=$util.escapeJavaScript($input.json("$.data")).replaceAll("\\'","'"))
+          {
+            "input": "$sfn_input",
+            "stateMachineArn": "${SyncSFn}"
+          }
+
+## Standard workflow: async, pushes result back via @connections API
+AsyncSFn:
+  Type: AWS::Serverless::StateMachine
+  Properties:
+    Type: STANDARD
+    Definition:
+      StartAt: ProcessRequest
+      States:
+        ProcessRequest:
+          Type: Wait
+          Seconds: 5
+          Next: NotifyClient
+        NotifyClient:
+          Type: Task
+          Resource: arn:aws:states:::apigateway:invoke
+          Parameters:
+            ApiEndpoint: !Sub "${WebSocketApi}.execute-api.${AWS::Region}.amazonaws.com"
+            Method: POST
+            Stage: !Ref ApiStageName
+            Path.$: "States.Format('/@connections/{}', $.ConnectionID)"
+            RequestBody:
+              Message: Processing complete!
+            AuthType: IAM_ROLE
+          End: true
+
+SFnAsyncRouteIntegration:
+  Type: AWS::ApiGatewayV2::Integration
+  Properties:
+    ApiId: !Ref WebSocketApi
+    IntegrationType: AWS
+    IntegrationMethod: POST
+    IntegrationUri: !Sub "arn:aws:apigateway:${AWS::Region}:states:action/StartExecution"
+    CredentialsArn: !GetAtt StepFunctionsAsyncExecutionRole.Arn
+    TemplateSelectionExpression: \$default
+    RequestTemplates:
+      "$default":
+        Fn::Sub: >
+          #set($sfn_input=$util.escapeJavaScript($input.json("$.data")).replaceAll("\\'","'"))
+          {
+            "input": "{\"data\":$sfn_input, \"ConnectionID\":\"$context.connectionId\"}",
+            "stateMachineArn": "${AsyncSFn}"
+          }
+
+## Async workflow role needs @connections permission to push results back
+AsyncSFnRole:
+  Type: AWS::IAM::Role
+  Properties:
+    AssumeRolePolicyDocument:
+      Version: "2012-10-17"
+      Statement:
+        - Effect: Allow
+          Principal:
+            Service: states.amazonaws.com
+          Action: sts:AssumeRole
+    Policies:
+      - PolicyName: APIGWConnectionsAccess
+        PolicyDocument:
+          Version: "2012-10-17"
+          Statement:
+            - Effect: Allow
+              Action: execute-api:ManageConnections
+              Resource: !Sub "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${WebSocketApi}/${ApiStageName}/POST/@connections/*"
+```

--- a/plugins/aws-serverless/skills/aws-serverless-api-gateway/references/security.md
+++ b/plugins/aws-serverless/skills/aws-serverless-api-gateway/references/security.md
@@ -1,0 +1,260 @@
+# Security Best Practices
+
+## TLS Configuration
+
+### TLS Security Policies
+
+- TLS 1.2 is the recommended minimum
+- Two naming conventions: legacy policies use `TLS_` prefix (e.g., `TLS_1_0`, `TLS_1_2`), enhanced policies use `SecurityPolicy_` prefix (e.g., `SecurityPolicy_TLS13_1_3_2025_09`) and support TLS 1.3 and post-quantum cryptography
+- Edge-optimized endpoints: use CloudFront TLS stack with `_EDGE` suffix policies (e.g., `SecurityPolicy_TLS13_2025_EDGE`). Supports TLS 1.3
+- Regional/Private endpoints: use API Gateway TLS stack with date-based suffix policies (e.g., `SecurityPolicy_TLS13_1_2_PQ_2025_09`). Supports TLS 1.3 and post-quantum
+- Endpoint access mode: `BASIC` (standard) vs `STRICT` (validates SNI matches Host header)
+- Migration: Apply enhanced policy with BASIC first, validate with access logs (`$context.tlsVersion`, `$context.cipherSuite`), then switch to STRICT
+- STRICT mode takes up to 15 minutes to propagate
+
+### Disable Default Endpoint
+
+- Set `disableExecuteApiEndpoint: true` to force all traffic through custom domain
+- REST APIs return 403 when disabled; HTTP APIs return 404 (observed behavior; not explicitly documented in the developer guide)
+- Must redeploy after changing this setting
+
+## Mutual TLS (mTLS)
+
+### Setup
+
+1. Create CA hierarchy (ACM Private CA or self-managed)
+2. Export root CA public key to PEM truststore file
+3. Upload to versioned S3 bucket (same region as API Gateway)
+4. Configure custom domain with truststore URI (`s3://bucket/truststore.pem`)
+5. Use public ACM certificate for the API Gateway domain itself
+6. Disable default endpoint
+
+### Automation with ACM Private CA
+
+- Lambda-backed CloudFormation custom resource concatenates certificate chain and uploads to S3
+- Certificates issued by root CA or any subordinate CA are automatically trusted
+- SAM resources: `AWS::ACMPCA::CertificateAuthority`, `AWS::ACMPCA::Certificate`, `AWS::CertificateManager::Certificate`
+
+### Certificate Revocation Lists (CRL)
+
+- API Gateway does NOT check CRLs natively
+- Implement via Lambda authorizer:
+  1. Extract client cert serial number
+  2. Check against CRL stored in DynamoDB (fast lookups at scale)
+  3. Deny access if revoked
+- S3 PutObject event triggers preprocessing Lambda: validates CRL signature, decodes ASN.1, stores simplified JSON
+- Use function-level caching with S3 ETag for cache invalidation
+- Lambda authorizer caching and CRL checks: Disable authorizer caching if near-real-time revocation is required. If some latency is acceptable, use a short TTL (e.g., 60s) matching your revocation freshness requirements
+
+### Propagating Client Identity
+
+- Lambda authorizer extracts client cert subject: `from cryptography import x509; cert = x509.load_pem_x509_certificate(event['requestContext']['identity']['clientCert']['clientCertPem'].encode())`
+- Returns `clientCertSub` (from `cert.subject.rfc4514_string()`) in authorizer `context`
+- API Gateway injects via `RequestParameters: 'integration.request.header.X-Client-Cert-Sub': 'context.authorizer.clientCertSub'`
+- Backend receives client identity without performing mTLS validation itself
+
+### CloudFront Viewer mTLS
+
+CloudFront now supports mTLS authentication between viewers (clients) and CloudFront edge locations. This enables mTLS for any origin, including API Gateway HTTP APIs and WebSocket APIs that don't natively support mTLS.
+
+Architecture: Client <-> mTLS <-> CloudFront <-> API Gateway (any type)
+
+Setup:
+
+1. Upload root CA and intermediate CA certificates (PEM bundle) to S3
+2. Create CloudFront Trust Store referencing the S3 path
+3. Enable "Viewer mutual authentication (mTLS)" on distribution settings
+4. Associate the trust store with the distribution
+
+Modes:
+
+- Required: All clients must present valid certificates
+- Optional: Accepts both mTLS and non-mTLS clients on the same distribution; still rejects invalid certificates
+
+Certificate headers forwarded to origin (enable in origin request policy):
+
+- `CloudFront-Viewer-Cert-Serial-Number`, `CloudFront-Viewer-Cert-Issuer`, `CloudFront-Viewer-Cert-Subject`
+- `CloudFront-Viewer-Cert-Validity`, `CloudFront-Viewer-Cert-PEM`, `CloudFront-Viewer-Cert-Present`, `CloudFront-Viewer-Cert-SHA256`
+- Use these headers in Lambda authorizers or backend logic for identity-based access control
+
+Certificate revocation: Use CloudFront Connection Functions + KeyValueStore for real-time CRL checks during TLS handshake:
+
+- Store revoked serial numbers in KeyValueStore
+- Connection function checks `connection.clientCertificate.certificates.leaf.serialNumber` against KVS
+- Call `connection.deny()` for revoked certificates; rejection happens at the edge before any request reaches the origin
+
+Connection functions: Execute custom logic during TLS handshake (before viewer request). Can allow, deny, or log connection details. Use `connection.logCustomData()` for custom connection log entries.
+
+Monitoring: CloudFront connection logs capture TLS handshake details. Each connection gets a unique `connectionId` that correlates across connection logs, standard logs, and real-time logs.
+
+Options:
+
+- `Ignore certificate expiration date`: Accept expired certificates (useful for gradual migration)
+- `Advertise trust store CA names`: Send list of accepted CA distinguished names to clients
+- Certificate chain depth supported: up to 4 (root + intermediates)
+
+When to use CloudFront viewer mTLS instead of API Gateway mTLS:
+
+- HTTP APIs or WebSocket APIs that don't support native mTLS
+- Need edge-based certificate validation (lower latency for global clients)
+- Need optional mode (mixed mTLS and non-mTLS on same endpoint)
+- Need Connection Functions for custom TLS handshake logic
+- Need real-time CRL checks via KeyValueStore (faster than Lambda authorizer approach)
+
+### Private APIs + mTLS
+
+- Private APIs do not natively support mTLS
+- Pattern: ALB with mTLS "Verify with trust store" mode -> VPC endpoint -> private API
+- ALB supports CRL checks on trust store
+- Cross-account: client -> PrivateLink -> NLB -> ALB (mTLS) -> VPC endpoint -> private API
+
+## Resource Policies (REST API)
+
+### IP-Based Access Control
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": "*",
+      "Action": "execute-api:Invoke",
+      "Resource": "execute-api:/*"
+    },
+    {
+      "Effect": "Deny",
+      "Principal": "*",
+      "Action": "execute-api:Invoke",
+      "Resource": "execute-api:/*",
+      "Condition": { "NotIpAddress": { "aws:SourceIp": ["203.0.113.0/24", "198.51.100.0/24"] } }
+    }
+  ]
+}
+```
+
+- `execute-api:/*` is a shorthand accepted only in API Gateway resource policies (API Gateway auto-expands it to the full ARN (`arn:aws:execute-api:region:account-id:api-id/*`)). Do not use this shorthand in IAM identity-based policies
+- For traffic through VPC endpoint: use `aws:VpcSourceIp` instead of `aws:SourceIp`
+
+### HTTP API IP Control
+
+- No resource policies for HTTP APIs
+- Use Lambda authorizer checking `event.requestContext.http.sourceIp` against allowlist
+- Support both exact IPs and CIDR ranges
+
+### VPC Endpoint Restriction
+
+```json
+{ "Condition": { "StringEquals": { "aws:SourceVpce": "vpce-0123456789abcdef0" } } }
+```
+
+## AWS WAF (REST API Direct; HTTP API via CloudFront)
+
+- REST API: Associate Web ACL directly with API stage (no CloudFront required)
+- HTTP API: No direct WAF association. Workaround: Place CloudFront distribution in front of HTTP API and attach WAF to CloudFront. This is a common production pattern
+- Gateway response type `WAF_FILTERED` (403) when WAF blocks request
+- Access log variables: `$context.waf.error`, `$context.waf.latency`, `$context.waf.status`
+- Body inspection limit: Default 16 KB for regional API Gateway (configurable up to 64 KB in web ACL for additional cost)
+- Header inspection limit: First 8 KB or 200 headers (whichever comes first)
+- "Distributed Denial of Wallet" protection: Without WAF, DDoS traffic invokes Lambda authorizers for every request. WAF blocks malicious traffic before it reaches the authorizer
+
+### Recommended Managed Rule Groups for APIs
+
+Tier 1: Always enable for API protection.
+
+| Rule Group       | Name                                    | WCU | Purpose                                                                                                                                                                   |
+| ---------------- | --------------------------------------- | --- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Core Rule Set    | `AWSManagedRulesCommonRuleSet`          | 700 | XSS, LFI, RFI, SSRF, path traversal, size restrictions. Note: `SizeRestrictions_BODY` rule blocks bodies >8 KB; override to Count if your API accepts larger payloads |
+| Known Bad Inputs | `AWSManagedRulesKnownBadInputsRuleSet`  | 200 | Log4j RCE, Java deserialization, PROPFIND, exploitable paths, localhost Host header                                                                                       |
+| SQL Database     | `AWSManagedRulesSQLiRuleSet`            | 200 | SQL injection in query params, body, cookies, URI path                                                                                                                    |
+| IP Reputation    | `AWSManagedRulesAmazonIpReputationList` | 25  | Blocks IPs from AWS threat intelligence (MadPot): malicious actors, reconnaissance, DDoS sources                                                                          |
+
+Tier 2: Enable based on use case.
+
+| Rule Group                  | Name                                    | WCU | When to use                                                                                                                                                                                                                                                                                                                                                                                                      |
+| --------------------------- | --------------------------------------- | --- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Anonymous IP List           | `AWSManagedRulesAnonymousIpList`        | 50  | Block TOR nodes, anonymous proxies, VPN services, hosting provider IPs. Use when API should not be accessed anonymously                                                                                                                                                                                                                                                                                          |
+| Bot Control                 | `AWSManagedRulesBotControlRuleSet`      | 50  | Detect/block scrapers, automated browsers, bad bots. Common ($1/M requests) for basic detection; Targeted ($10/M requests) adds ML-based detection (same WCU, higher per-request cost). Note: `CategoryAI` rule blocks all AI bot traffic (both verified and unverified) unlike other category rules; override to Count and use labels (`bot:category:ai:verified` vs `unverified`) for fine-grained control |
+| Admin Protection            | `AWSManagedRulesAdminProtectionRuleSet` | 100 | Block access to admin URI paths. Use if API has admin endpoints                                                                                                                                                                                                                                                                                                                                                  |
+| Account Takeover Prevention | `AWSManagedRulesATPRuleSet`             | 50  | Credential stuffing protection on login endpoints. Checks against stolen credential databases. Additional fees apply                                                                                                                                                                                                                                                                                             |
+
+Tier 3: Custom rules for API-specific protection.
+
+| Rule Type             | Purpose                                                           |
+| --------------------- | ----------------------------------------------------------------- |
+| Rate-based rules      | Per-IP request rate limiting (complements API Gateway throttling) |
+| Geo-match rules       | Block traffic from regions where you have no customers            |
+| IP set rules          | Allow/deny specific IP ranges                                     |
+| Size constraint rules | Custom payload size limits per endpoint                           |
+| Regex pattern rules   | Block specific patterns in headers/body (e.g., malformed JWTs)    |
+
+### WAF Best Practices for APIs
+
+- Start in Count mode: Deploy managed rules in Count mode first, analyze CloudWatch metrics and WAF logs, then switch to Block
+- Use labels for custom logic: Managed rules add labels to requests. Write custom rules that match on labels for fine-grained control (e.g., allow verified bots but block unverified ones)
+- Override specific rules: If a managed rule causes false positives, override that single rule to Count rather than disabling the entire rule group
+- Web ACL capacity: Default allocation is 1,500 WCU per web ACL (hard limit 5,000 via support request). WCU above 1,500 incurs additional cost ($0.20 per million requests per 500 WCU block). Plan rule group selection within this budget. Tier 1 rules alone total 1,125 WCU
+- Scope down statements: Apply expensive rule groups (Bot Control, ATP) only to specific URI paths to reduce cost and false positives
+- WAF + API Gateway throttling: WAF rate-based rules operate at the edge; API Gateway throttling operates at the service level. Use both for defense in depth
+- WAF token domain: When CloudFront fronts a WAF-protected API Gateway, CloudFront rewrites the `Host` header to the origin domain. WAF challenge/CAPTCHA tokens are tied to the client-facing domain, causing a domain mismatch at the origin. Fix: add the CloudFront distribution domain to the token domain list in the origin's web ACL, and forward the `aws-waf-token` cookie to the origin
+
+## CORS Configuration
+
+### REST API
+
+- Configure `OPTIONS` method with Mock integration returning CORS headers
+- Lambda must ALSO return CORS headers in actual response (proxy integration)
+- Critical: Add CORS headers to `DEFAULT_4XX` and `DEFAULT_5XX` gateway responses; otherwise errors are blocked by browser
+- SAM `Cors` property helps but does NOT cover gateway responses
+- Only one origin allowed in MOCK response; use `*` or Lambda integration for dynamic origin. Security warning: dynamically reflecting the `Origin` header without validating against an allowlist is functionally equivalent to `*` but also works with credentials. Always validate against an explicit allowlist
+- Add `AddDefaultAuthorizerToCorsPreflight: false` to exclude authorizer from OPTIONS
+
+### HTTP API
+
+- First-class `CorsConfiguration` property: `allowOrigins`, `allowMethods`, `allowHeaders`, `exposeHeaders`, `maxAge`, `allowCredentials`
+- API Gateway automatically handles OPTIONS preflight; no MOCK integration needed
+- `*` for AllowOrigins does not work when `AllowCredentials` is true
+
+### Common Gotchas
+
+- Forgetting CORS headers on gateway responses means 403/500 errors are blocked by browser
+- For private APIs: avoid `x-apigw-api-id` header (triggers preflight that fails); use Host header instead
+- `Access-Control-Allow-Origin` must match requesting origin exactly when using credentials
+
+## HttpOnly Cookie Authentication
+
+Pattern for preventing XSS token theft:
+
+1. OAuth2 callback Lambda: Exchanges auth code for access token, returns via `Set-Cookie` header with `HttpOnly`, `Secure`, `SameSite=Lax`
+2. Lambda authorizer: Extracts cookie from request, validates JWT, allows/denies
+3. Identity source: `$request.header.cookie` for caching
+4. Use `aws-jwt-verify` library; create verifier outside handler for JWKS caching across warm starts
+
+## API Gateway Architecture
+
+- API Gateway is a multi-tenant managed service running in an AWS-managed VPC; nothing is deployed into customer VPCs
+- This is why VPC Links exist: they bridge the gap between the AWS-managed VPC (where API Gateway runs) and your VPC (where private resources live)
+- API Gateway has internet connectivity by default, which is why it can reach external endpoints even when your VPC cannot
+
+## Security at All Layers
+
+Apply security at every component, not just the data plane (who can call APIs). Also secure the control plane (who can modify/deploy APIs).
+
+## Cache Encryption (REST API)
+
+- API Gateway cache is not encrypted at rest by default; encryption must be explicitly enabled when provisioning the cache
+- Cache is not isolated per API key by default: one client can receive cached responses generated for another client if the cache key parameters (path, query strings, configured headers) match. To prevent this, add a client-identifying parameter (e.g., API key header) as a cache key
+- For APIs handling sensitive data, always enable cache encryption
+- Cache encryption can only be set at cache creation time; changing it requires re-provisioning
+
+## Logging Data Sensitivity
+
+- Standard execution logging auto-redacts authorization headers, API key values, and similar sensitive parameters
+- Data tracing (separate option from execution logging) logs full request/response bodies including PII and credentials. AWS recommends against enabling data tracing in production
+- Treat CloudWatch log groups containing execution logs as sensitive data: apply appropriate IAM access controls, retention policies, and CloudWatch Logs data protection policies
+
+## Binary Data Security
+
+- Register binary media types explicitly (e.g., `image/png`, `application/octet-stream`)
+- Avoid `*/*` in binary media types unless intentional, as it treats ALL content as binary
+- For file uploads via S3: use presigned URLs for large files instead of proxying through API Gateway (10 MB payload limit)

--- a/plugins/aws-serverless/skills/aws-serverless-api-gateway/references/service-integrations.md
+++ b/plugins/aws-serverless/skills/aws-serverless-api-gateway/references/service-integrations.md
@@ -1,0 +1,191 @@
+# AWS Service Integrations
+
+API Gateway integrates directly with AWS services without Lambda. Two implementation approaches:
+
+- REST API and WebSocket API: Use `Type: AWS` with VTL mapping templates for full request/response transformation. Supports any AWS service action. Both synchronous (wait for response) and asynchronous (fire-and-forget) patterns
+- HTTP API: Uses first-class integrations (`Type: AWS_PROXY` with `IntegrationSubtype`) and parameter mapping instead of VTL. Supported subtypes: `EventBridge-PutEvents`, `SQS-SendMessage`, `SQS-ReceiveMessage`, `SQS-DeleteMessage`, `SQS-PurgeQueue`, `Kinesis-PutRecord`, `StepFunctions-StartExecution`, `StepFunctions-StartSyncExecution`, `StepFunctions-StopExecution`, `AppConfig-GetConfiguration`. For services not in this list (DynamoDB, SNS, S3), use Lambda proxy instead. See [Integration subtype reference](https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-aws-services-reference.html)
+
+The patterns below cover the most commonly used service integrations. REST API `Type: AWS` can integrate with any AWS service that exposes an HTTP API; the same approach (URI, IAM role, VTL mapping) applies to services not listed here. For HTTP API first-class integrations, the same services apply but use parameter mapping (`$request.body`, `$request.header`, `$request.path`, `$context`) instead of VTL.
+
+## EventBridge Integration
+
+Integrates directly with EventBridge PutEvents API (see [aws-samples/serverless-patterns/apigw-rest-api-eventbridge-sam](https://github.com/aws-samples/serverless-patterns/tree/main/apigw-rest-api-eventbridge-sam)). For a complete SAM template, see [SAM Service Integration Templates -- EventBridge](sam-service-integrations.md#direct-aws-service-integration-eventbridge).
+
+- Use `Type: AWS` integration with URI `arn:aws:apigateway:{region}:events:action/PutEvents`
+- Set required headers via `RequestParameters` (e.g., `integration.request.header.X-Amz-Target: "'AWSEvents.PutEvents'"`, `integration.request.header.Content-Type: "'application/x-amz-json-1.1'"`). Alternative: set via VTL `$context.requestOverride.header` in the mapping template, but avoid applying the same header in both places ([double-application causes 5XX](https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-override-request-response-parameters.html))
+- VTL mapping template transforms HTTP requests into EventBridge events. Use `#foreach` to batch multiple events from a single API call
+- Input escaping: Use `$util.escapeJavaScript($elem.Detail).replaceAll("\\'","'")`, since `escapeJavaScript` over-escapes single quotes which breaks JSON; the `replaceAll` corrects this
+- Supports custom event buses (not just default); pass bus name via `!Sub` in the mapping template
+- Lambda authorizer can return `custom:clientId` to enrich events with caller identity
+- Request validation via API Gateway models
+- Use `PassthroughBehavior: NEVER` or `WHEN_NO_TEMPLATES` to reject unmatched content types. Avoid the default `WHEN_NO_MATCH` which passes malformed payloads through to the backend service
+- EventBridge rules route events to Kinesis Data Firehose, Lambda, or API destinations
+- Gotcha: EventBridge does not add newlines between records when forwarding to Firehose; use `\n` in InputTemplate
+- Gotcha: `PutEvents` can succeed (200) with `FailedEntryCount > 0` (partial failures are silent). Check `$input.path('$.FailedEntryCount')` in the response template and return an error status if non-zero
+
+## SQS Integration (Async Buffer)
+
+Integrates directly with SQS SendMessage API to decouple producers from consumers (see [aws-samples/serverless-patterns/apigw-sqs-lambda-iot](https://github.com/aws-samples/serverless-patterns/tree/main/apigw-sqs-lambda-iot)). For a complete SAM template, see [SAM Service Integration Templates -- SQS](sam-service-integrations.md#direct-aws-service-integration-sqs).
+
+- Use `Type: AWS` integration with URI `arn:aws:apigateway:{region}:sqs:path/{account-id}/{queue-name}`
+- Two protocol options:
+  - AWS query protocol: Set `Content-Type: 'application/x-www-form-urlencoded'` header in integration request. Mapping template: `Action=SendMessage&MessageBody=$util.urlEncode($input.body)`
+  - AWS JSON protocol: Set `Content-Type: 'application/x-amz-json-1.0'` and `X-Amz-Target: 'AmazonSQS.SendMessage'` headers. Pass JSON body with `QueueUrl` and `MessageBody`
+- Set `PassthroughBehavior: NEVER` to reject requests that don't match any mapping template (returns 415 Unsupported Media Type)
+- Always use `$util.urlEncode()` with the query protocol; special characters in the message body cause `AccessDenied` errors without encoding
+- FIFO queues: Append `MessageGroupId` to the mapping template: `Action=SendMessage&MessageGroupId=$context.extendedRequestId&MessageBody=$util.urlEncode($input.body)`. Enable content-based deduplication on the queue, or add `MessageDeduplicationId` explicitly
+- KMS-encrypted queues: IAM execution role needs `kms:GenerateDataKey` and `kms:Decrypt` on the queue's KMS key, otherwise `KMS.AccessDeniedException`
+- Lambda consumer processes messages from SQS at its own pace, with built-in retry and DLQ support
+
+## SNS Integration (Fan-Out / Pub-Sub)
+
+Integrates directly with SNS Publish API for fan-out to multiple subscribers (see [aws-samples/serverless-patterns/apigw-websocket-api-sns](https://github.com/aws-samples/serverless-patterns/tree/main/apigw-websocket-api-sns)):
+
+- Use `Type: AWS` integration with URI `arn:aws:apigateway:{region}:sns:action/Publish`
+- Uses AWS query protocol: Set `Content-Type: 'application/x-www-form-urlencoded'` header in integration request
+- VTL mapping template: `Action=Publish&TopicArn=$util.urlEncode("${TopicArn}")&Message=$util.urlEncode(...)`; always URL-encode both the TopicArn and Message
+- Enrich messages with API Gateway context: `$context.connectionId` (WebSocket), `$context.requestTimeEpoch`, `$context.identity.sourceIp`
+- Request validation: Use API Gateway models to validate the message body before publishing, ensuring only well-formed messages reach SNS
+- Subscribers receive messages independently: Lambda, SQS, HTTP/S endpoints, email, SMS. One API call fans out to all
+- KMS-encrypted topics: IAM execution role needs `kms:GenerateDataKey` and `kms:Decrypt` on the topic's KMS key
+- Message attributes: Use indexed query parameters for subscription filter policies: `MessageAttributes.entry.1.Name=eventType&MessageAttributes.entry.1.Value.DataType=String&MessageAttributes.entry.1.Value.StringValue=...`. Required for SNS subscription filtering in fan-out architectures
+- FIFO topics: Append `MessageGroupId` (required) and optionally `MessageDeduplicationId` to the mapping template, same pattern as SQS FIFO queues
+- IAM execution role needs `sns:Publish` scoped to the specific topic ARN
+
+## DynamoDB Integration (Write-Through with Streams)
+
+Integrates directly with DynamoDB APIs for full CRUD without Lambda. For complete SAM templates (OpenAPI-based and inline), see [SAM Service Integration Templates -- DynamoDB Full CRUD](sam-service-integrations.md#direct-aws-service-integration-dynamodb-full-crud).
+
+- Use `Type: AWS` integration with URI `arn:aws:apigateway:{region}:dynamodb:action/{action}` (supports `GetItem`, `PutItem`, `UpdateItem`, `DeleteItem`, `Query`, and `Scan`)
+- VTL mapping template transforms HTTP request into DynamoDB JSON format:
+  - Request template: Maps request body/parameters to DynamoDB item attributes with type descriptors (`S`, `N`, `M`, `L`, etc.)
+  - Response template: Extracts DynamoDB response attributes into clean JSON for the client using `$input.path('$.Item.attribute.S')`
+- Full CRUD pattern (see [aws-samples/serverless-patterns/apigw-dynamodb-lambda-scheduler-ses-auto-deletion-sam](https://github.com/aws-samples/serverless-patterns/tree/main/apigw-dynamodb-lambda-scheduler-ses-auto-deletion-sam)):
+  - Create: Use `UpdateItem` (not `PutItem`) with `$context.requestId` as auto-generated ID, eliminating client-side ID generation. Set `ReturnValues: ALL_NEW` to return the created item in the response
+  - Read: `GetItem` with key from path parameter `$input.params().path.id`
+  - Update: `UpdateItem` with `UpdateExpression` and `ExpressionAttributeValues` mapped from request body. Use `ReturnValues: ALL_NEW` to return the updated item
+  - Delete: `DeleteItem` with `ReturnValues: ALL_OLD` to return the deleted item for confirmation
+  - List: `Scan` with `#foreach` loop in response template to build JSON array from `$inputRoot.Items`. Always include a `Limit` parameter in the Scan template (e.g., `"Limit": 25`) to cap items per request; without it, a single API call can scan the entire table, consuming all provisioned capacity. Support pagination via `ExclusiveStartKey` mapped from a query parameter
+- Request validation: Use `x-amazon-apigateway-request-validator` with OpenAPI schemas to validate request bodies at the gateway before reaching DynamoDB
+- OpenAPI-based definition: Define the full API in a separate OpenAPI file and include via `AWS::Include` transform in the SAM template, keeping the API definition clean and separates API spec from infrastructure
+- For async event processing, enable DynamoDB Streams on the table:
+  - Stream triggers Lambda function on every insert/update/delete
+  - Lambda processes changes asynchronously (enrichment, notifications, scheduling, cross-service sync)
+  - Example chain: API Gateway -> DynamoDB (Streams) -> Lambda -> EventBridge Scheduler -> SES for scheduled email reminders
+  - Stream view type options: `KEYS_ONLY`, `NEW_IMAGE`, `OLD_IMAGE`, `NEW_AND_OLD_IMAGES`; choose based on what the processor needs
+- Gotcha: DynamoDB reserved keywords (`datetime`, `email`, `status`, `name`, `type`, `data`, etc.) require `ExpressionAttributeNames` with `#placeholder` syntax. This applies in VTL templates too, not just SDK calls
+- Security: Never interpolate request input into DynamoDB expression strings (`UpdateExpression`, `FilterExpression`, `ProjectionExpression`). Hardcode expression structures in VTL and only map user input into `ExpressionAttributeValues` (`:placeholder` values). Interpolating into expressions allows callers to inject additional clauses that expose unintended attributes or modify other items
+- Canary deployments for DynamoDB service integrations are managed at the API Gateway stage level (no Lambda alias to canary)
+
+## Kinesis Data Streams Integration (High-Throughput Ingestion)
+
+Integrates directly with Kinesis Data Streams PutRecord/PutRecords APIs for high-volume data ingestion (see [aws-samples/serverless-patterns/apigw-kinesis-lambda](https://github.com/aws-samples/serverless-patterns/tree/main/apigw-kinesis-lambda)). For a complete SAM template, see [SAM Service Integration Templates -- Kinesis Data Streams](sam-service-integrations.md#direct-aws-service-integration-kinesis-data-streams).
+
+- Use `Type: AWS` integration with URI `arn:aws:apigateway:{region}:kinesis:action/{action}` (e.g., `action/PutRecord`, `action/PutRecords`)
+- Use `PassthroughBehavior: WHEN_NO_TEMPLATES` to ensure requests are only accepted when a matching mapping template exists
+- VTL mapping template constructs the Kinesis payload:
+  - `StreamName`: Target stream; can be hardcoded via `!Sub` or dynamic via path parameter (`$input.params('stream-name')`)
+  - `Data`: Base64-encoded record data. Use `$util.base64Encode()` in VTL. Encode the full body (`$input.body`) or a specific JSON field (`$input.json('$.Data')`)
+  - `PartitionKey`: Determines shard placement. Use a high-cardinality value from the request body (e.g., client ID) for even distribution across shards, or `$context.requestId` as a simple default for uniform distribution
+- PutRecords for batching: VTL `#foreach` loop transforms an array of items in the request body into multiple Kinesis records in a single API call, reducing round-trips
+- KMS-encrypted streams: IAM execution role needs `kms:GenerateDataKey` and `kms:Decrypt` on the stream's KMS key
+- Downstream consumers: Lambda (event source mapping), Kinesis Data Firehose (delivery to S3/Redshift/OpenSearch), Kinesis Data Analytics, or custom KCL applications
+- Shard limits: Each shard supports 1,000 records/s or 1 MB/s for writes and 2 MB/s for reads. Plan shard count based on expected ingestion rate. Use on-demand capacity mode to auto-scale shards
+- Gotcha: `PutRecord` response includes `ShardId` and `SequenceNumber`; map these in the response template for client-side tracking if needed
+- Gotcha: `PutRecords` can succeed (200) with `FailedRecordCount > 0`. Map `$input.path('$.FailedRecordCount')` in the response template so clients know to retry failed records
+
+## Step Functions Integration (Workflow Orchestration)
+
+Integrates directly with Step Functions to orchestrate multi-step workflows without Lambda glue code. For complete SAM templates (REST and WebSocket), see [SAM Service Integration Templates -- Step Functions](sam-service-integrations.md#direct-aws-service-integration-step-functions).
+
+REST API -> Step Functions (see [aws-samples/serverless-patterns/apigw-rest-stepfunction](https://github.com/aws-samples/serverless-patterns/tree/main/apigw-rest-stepfunction)):
+
+- Two execution modes available:
+  - Asynchronous (Standard workflow): `action/StartExecution`, which returns execution ARN immediately. Client does not wait for workflow completion. IAM role needs `states:StartExecution`
+  - Synchronous (Express workflow): `action/StartSyncExecution`, which waits for workflow to complete and returns the result in the response. IAM role needs `states:StartSyncExecution`. Must complete within the API Gateway integration timeout (29s default, up to 300s for Regional/Private)
+- VTL mapping template passes the request body as workflow input and the state machine ARN:
+
+  ```velocity
+  #set($data = $util.escapeJavaScript($input.json('$')).replaceAll("\\'","'"))
+  {
+    "input": "$data",
+    "stateMachineArn": "${StateMachineArn}"
+  }
+  ```
+
+WebSocket API -> Step Functions (see [aws-samples/serverless-samples/apigw-ws-integrations](https://github.com/aws-samples/serverless-samples/tree/main/apigw-ws-integrations)):
+
+- Two execution modes via custom routes matched by `routeSelectionExpression`:
+  - Synchronous (Express workflow): `action/StartSyncExecution`, which waits for workflow to complete and returns the result directly to the WebSocket client. Constrained by the 29-second WebSocket API integration timeout, not the 5-minute Express workflow maximum. Workflows exceeding 29 seconds will time out at the API Gateway level. Use for short-lived workflows where the client needs the result immediately
+  - Asynchronous (Standard workflow): `action/StartExecution`, which returns the execution ARN immediately. Workflow pushes results back to the WebSocket client via the `@connections` Management API (`POST https://{api-id}.execute-api.{region}.amazonaws.com/{stage}/@connections/{connectionId}`) using an HTTP task state or Lambda task. Pass `$context.connectionId` in the input so the workflow knows which client to notify
+- VTL escaping for WebSocket: `$util.escapeJavaScript($input.json("$.data")).replaceAll("\\'","'")` (the `replaceAll` handles single quotes that `escapeJavaScript` over-escapes)
+- WebSocket `$connect`/`$disconnect` routes can use direct DynamoDB integration (PutItem/DeleteItem) for connection tracking without Lambda
+- IAM roles: `states:StartSyncExecution` for Express, `states:StartExecution` for Standard. Async workflow role also needs `execute-api:ManageConnections` to call back the WebSocket client
+
+Express vs Standard workflows:
+
+- Express (sync): Max 5 minutes, at-least-once execution, lower cost for high-volume short tasks. Good for synchronous REST/WebSocket responses within the API Gateway timeout
+- Standard (async): Max 1 year, exactly-once execution, full execution history. Good for long-running orchestrations that push results via callback, webhook, or polling
+
+Lambda durable functions as alternative: Durable functions are invoked as regular Lambda integrations (proxy or custom) -- no `Type: AWS` service integration or VTL needed. See the [aws-serverless-durable-functions skill](../../aws-serverless-durable-functions/) for details.
+
+## S3 Integration (File Storage Proxy)
+
+Acts as an S3 proxy for file upload, download, and listing without Lambda (see [Developer Guide tutorial](https://docs.aws.amazon.com/apigateway/latest/developerguide/integrating-api-with-aws-services-s3.html)):
+
+- Use `Type: AWS` integration with `Action type: Use path override`. API Gateway forwards requests to S3 REST API path-style (`s3-host-name/{bucket}/{key}`)
+- Resource structure: `/{folder}` maps to S3 bucket, `/{folder}/{item}` maps to S3 object. Map path parameters in integration request: `method.request.path.folder` -> `{bucket}`, `method.request.path.item` -> `{object}`
+- Operations: GET on `/` lists buckets, GET on `/{folder}` lists objects in a bucket, GET on `/{folder}/{item}` downloads an object, PUT on `/{folder}/{item}` uploads an object
+- Binary files (images, PDFs, etc.): Register media types in `binaryMediaTypes` (e.g., `image/png`), add `Accept` (download) and `Content-Type` (upload) headers to the method request, leave `contentHandling` unset (passthrough behavior); no mapping template for binary content types
+- Payload limit: 10 MB max through API Gateway. For larger files, generate S3 presigned URLs via Lambda and have the client upload/download directly to S3 (presigned URLs cannot be generated from a direct service integration; Lambda is required)
+- Response header mapping: Map `integration.response.header.Content-Type`, `integration.response.header.Content-Length`, and `integration.response.header.Date` to method response headers for proper content delivery
+- S3 objects with `/` or special characters in the key must be URL-encoded in the request path (e.g., `test/test.txt` -> `test%2Ftest.txt`)
+- IAM execution role needs S3 permissions (`s3:GetObject`, `s3:PutObject`, `s3:ListBucket`) scoped to the specific bucket(s)
+
+## HTTP Integration (Proxy to HTTP Endpoints)
+
+Forwards requests to any HTTP-accessible endpoint: ALB, NLB, ECS, EC2, on-premises servers, or external third-party APIs:
+
+- Two modes:
+  - `HTTP_PROXY`: Passes request through to the backend as-is and returns the backend response directly to the client. Minimal configuration, no VTL templates. Available on both REST and HTTP APIs
+  - `HTTP` (non-proxy): Allows VTL mapping templates to transform request and response. REST API only
+- VPC Link for private backends: Use `connectionType: VPC_LINK` to reach ALB, NLB, or Cloud Map services inside a VPC without exposing them to the internet. VPC Link v2 supports REST and HTTP APIs (targets ALB and NLB); WebSocket API uses VPC Link v1 (NLB only)
+- Path and parameter passthrough: Map URL path parameters, query strings, and headers from the method request to the integration request. Use `{proxy+}` greedy path parameter for catch-all routing
+- TLS to backend: API Gateway validates the backend's TLS certificate by default. If the backend uses a self-signed or private CA certificate, set `insecureSkipVerification: true` on the integration (testing/development only; not recommended for production). Provide the full certificate chain on the backend for proper validation
+- Timeouts: Configure `timeoutInMillis` on the integration (50ms-29s for REST, 30s hard limit for HTTP API). For backends that may exceed this, consider async patterns
+- Connection reuse: API Gateway reuses connections to HTTP backends by default for lower latency on subsequent requests
+- No automatic retries: API Gateway does not retry failed HTTP integration requests. If the backend returns 5xx or the connection times out, the error is returned directly to the client. Implement retry logic on the client side or use SQS as a buffer
+
+## Mock Integration (No Backend)
+
+Returns responses directly from API Gateway without calling any backend:
+
+- Use `Type: MOCK` (no integration URI, no IAM role, no backend needed)
+- Health check endpoints: Return 200 on `/health` for load balancer or monitoring checks
+- CORS preflight: Handle `OPTIONS` requests with appropriate CORS headers without invoking Lambda
+- API prototyping: Define request/response contracts before backends are built. Consumers can develop against the mock
+- Static responses: Return fixed JSON/XML based on request parameters using VTL mapping templates
+- VTL request template must return `{"statusCode": 200}` (or appropriate code) to set the integration response status
+- Map different status codes using `IntegrationResponses` with selection patterns
+
+## Common Patterns
+
+- IAM execution role: Every direct service integration requires an IAM role with the specific action permission (e.g., `sqs:SendMessage`, `dynamodb:PutItem`, `events:PutEvents`, `kinesis:PutRecord`, `states:StartExecution`). Pass the role ARN in the integration `Credentials` field
+- Request validation at the gateway: Use API Gateway request validators (models) to reject invalid requests before they reach the backend service, reducing cost and protects downstream services
+- Response mapping: Transform raw AWS service responses into clean API responses using VTL response templates. Map HTTP status codes for error cases in `IntegrationResponses`
+- Lambda invocations support sync and async: API Gateway Lambda integrations default to synchronous invocation (wait for response). For asynchronous invocation (fire-and-forget, returns 200 immediately while Lambda processes in background), set `X-Amz-Invocation-Type: 'Event'` in the integration request HTTP headers (see [re:Post guide](https://repost.aws/knowledge-center/api-gateway-invoke-lambda)). Async invocation supports Lambda's built-in retry (up to 2 retries) and dead-letter queues. REST API supports this natively via non-proxy integration; HTTP API only supports proxy integrations for Lambda so `X-Amz-Invocation-Type` cannot be set -- use a proxy Lambda that invokes the target Lambda asynchronously via the SDK
+- Prevent backend bypass (zero trust): Ensure backends can only be reached through API Gateway, not invoked or accessed directly. Apply defense in depth per integration type:
+  - Lambda: Restrict Lambda resource policies to allow invocations only from the API Gateway source ARN
+  - VPC Link targets (ALB/NLB): Use security groups on the load balancer to accept traffic only from the VPC Link's ENIs, not from arbitrary sources
+  - HTTP integrations: Use mutual TLS, API keys, or signed requests between API Gateway and the backend to authenticate the caller
+  - Direct service integrations (SQS, DynamoDB, etc.): The IAM execution role scopes access -- ensure the role is only assumable by API Gateway (`apigateway.amazonaws.com` principal) and follows least-privilege for the specific resources
+- Parameter overriding (REST API): Override request/response parameters and status codes at method level:
+  - `RequestParameters` in Integration: Map method request values to integration request values
+  - `ResponseParameters` in IntegrationResponses: Map integration response values to method response values
+  - Override response status: `#set($context.responseOverride.status = 400)` in VTL
+  - Override request headers: `$context.requestOverride.header.<name>`
+  - Gotcha: Applying override to same parameter twice causes 5XX. Build in a variable first, apply at end
+- Binary media types: API Gateway request and response payloads can be text or binary (JPEG, GZip, XML, PDF, etc.). Configure `binaryMediaTypes` on the API, specifying content types treated as binary (e.g., `image/png`, `application/octet-stream`). Avoid `*/*` wildcard: it treats ALL responses as binary, breaking Lambda proxy integrations that return JSON:
+  - Lambda proxy integrations: Lambda must return the response body as base64-encoded and set `isBase64Encoded: true`. The API must have matching `binaryMediaTypes` configured. Client sends `Accept` header matching a binary media type
+  - Non-proxy integrations: Set `binaryMediaTypes` on the API, or use `contentHandling` on the `Integration` and `IntegrationResponse` resources: `CONVERT_TO_BINARY` (base64-decode text to binary), `CONVERT_TO_TEXT` (base64-encode binary to text), or undefined (passthrough)
+- Local testing limitation: `sam local start-api` does not support `Type: AWS` service integrations; it only supports Lambda proxy/non-proxy integrations. Test direct service integrations by deploying to a dev stage and using the API Gateway test console (AWS Console -> method -> Test) to validate VTL mapping templates against sample requests without a full deployment cycle

--- a/plugins/aws-serverless/skills/aws-serverless-api-gateway/references/service-limits.md
+++ b/plugins/aws-serverless/skills/aws-serverless-api-gateway/references/service-limits.md
@@ -1,0 +1,156 @@
+# Service Limits and Quotas
+
+Important: Values listed here are default quotas; many are adjustable via AWS Support or Service Quotas console. Do not use default values for architectural decisions without first checking with your AWS account team for current limits and increase possibilities. Consult the [latest API Gateway quotas page](https://docs.aws.amazon.com/apigateway/latest/developerguide/limits.html) for up-to-date values as they change over time.
+
+## REST API Limits
+
+| Resource                                 | Default Limit                                    | Adjustable                 |
+| ---------------------------------------- | ------------------------------------------------ | -------------------------- |
+| Regional APIs per region                 | 600                                              | Yes                        |
+| Edge-optimized APIs per region           | 120                                              | Yes                        |
+| Private APIs per region                  | 600                                              | Yes                        |
+| Resources per API                        | 300                                              | Yes                        |
+| Stages per API                           | 10                                               | No                         |
+| Stage variables per stage                | 100                                              | No                         |
+| Authorizers per API                      | 10                                               | Yes                        |
+| API keys per region                      | 10,000                                           | Yes                        |
+| Usage plans per region                   | 300                                              | Yes                        |
+| VPC links per region                     | 20                                               | Yes                        |
+| Custom domains (public) per region       | 120                                              | Yes                        |
+| Custom domains (private) per region      | 50                                               | Yes                        |
+| API mappings per domain                  | 200                                              | No                         |
+| Base path max length                     | 300 chars                                        | No                         |
+| Payload size                         | 10 MB                                        | No                     |
+| Integration timeout                  | 50ms - 29s (up to 300s for Regional/Private) | Yes (Regional/Private) |
+| Mapping template size                    | 300 KB                                           | No                         |
+| `#foreach` iterations                    | 1,000                                            | No                         |
+| Access log template                      | 3 KB                                             | No                         |
+| Header values total                      | 10,240 bytes                                     | No                         |
+| Header values total (private)            | 8,000 bytes                                      | No                         |
+| Cache TTL                                | 0 - 3,600s                                       | No                         |
+| Cached response max                      | 1,048,576 bytes (1 MB)                           | No                         |
+| Method ARN length                        | 1,600 bytes                                      | No                         |
+| Method-level throttle settings per stage | 20                                               | No                         |
+| Model size                               | 400 KB                                           | No                         |
+| mTLS truststore                          | 1,000 certs / 1 MB                               | No                         |
+| Idle connection timeout                  | 310s                                             | No                         |
+| API definition import size               | 6 MB                                             | No                         |
+| Lambda authorizer result TTL             | 0 - 3,600s (default 300s)                        | No                         |
+
+## HTTP API Limits
+
+| Resource                     | Default Limit        | Adjustable |
+| ---------------------------- | -------------------- | ---------- |
+| APIs per region              | 600                  | Yes        |
+| Routes per API               | 300                  | No         |
+| Integrations per API         | 300                  | No         |
+| Integration timeout      | 30s (hard limit) | No     |
+| Payload size             | 10 MB            | No     |
+| Stages per API               | 10                   | Yes        |
+| Custom domains per region    | 120                  | Yes        |
+| Access log entry max         | 1 MB                 | No         |
+| Authorizers per API          | 10                   | Yes        |
+| Audiences per JWT authorizer | 50                   | No         |
+| Scopes per route             | 10                   | No         |
+| JWKS endpoint timeout        | 1,500ms              | No         |
+| Lambda authorizer timeout    | 10,000ms             | No         |
+| VPC links per region         | 10                   | Yes        |
+
+## WebSocket API Limits
+
+| Resource              | Default Limit | Adjustable |
+| --------------------- | ------------- | ---------- |
+| Frame size            | 32 KB         | No         |
+| Message payload       | 128 KB        | No         |
+| Connection duration   | 2 hours       | No         |
+| Idle timeout          | 10 minutes    | No         |
+| New connections rate  | 500/s         | Yes        |
+| Routes per API        | 300           | No         |
+| Authorizer result max | 8 KB          | No         |
+| Integration timeout   | 29s           | No         |
+
+## Account-Level Throttling
+
+| Resource          | Default Limit | Adjustable |
+| ----------------- | ------------- | ---------- |
+| Steady-state rate | 10,000 rps    | Yes        |
+| Burst capacity    | 5,000         | Yes        |
+
+These apply across all REST APIs, HTTP APIs, WebSocket APIs, and WebSocket callback APIs in a region ([shared quota](https://docs.aws.amazon.com/apigateway/latest/developerguide/limits.html)). Lower defaults apply in opt-in and newer regions (2,500 rps / 1,250 burst): af-south-1, eu-south-1, ap-southeast-3, me-south-1, ap-south-2, ap-southeast-4, eu-south-2, eu-central-2, il-central-1, ca-west-1, ap-southeast-5, ap-southeast-7, mx-central-1.
+
+## Management API Rate Limits
+
+| Resource                   | Limit             |
+| -------------------------- | ----------------- |
+| Total management API calls | 10 rps / 40 burst |
+| Custom domain deletion     | 1 per 30 seconds  |
+
+## Cache Sizes (REST API)
+
+| Size    | Monthly Cost (approximate) |
+| ------- | -------------------------- |
+| 0.5 GB  | Low                        |
+| 1.6 GB  |                            |
+| 6.1 GB  |                            |
+| 13.5 GB |                            |
+| 28.4 GB |                            |
+| 58.2 GB |                            |
+| 118 GB  |                            |
+| 237 GB  | High                       |
+
+## Reserved Paths
+
+- `/ping` and `/sping` are reserved by API Gateway. Do not use for API resources
+
+## Gateway Response Types
+
+| Response Type                  | Default Status | Customizable |
+| ------------------------------ | -------------- | ------------ |
+| ACCESS_DENIED                  | 403            | Yes          |
+| API_CONFIGURATION_ERROR        | 500            | Yes          |
+| AUTHORIZER_CONFIGURATION_ERROR | 500            | Yes          |
+| AUTHORIZER_FAILURE             | 500            | Yes          |
+| BAD_REQUEST_PARAMETERS         | 400            | Yes          |
+| BAD_REQUEST_BODY               | 400            | Yes          |
+| DEFAULT_4XX                    | Varies         | Yes          |
+| DEFAULT_5XX                    | Varies         | Yes          |
+| EXPIRED_TOKEN                  | 403            | Yes          |
+| INTEGRATION_FAILURE            | 504            | Yes          |
+| INTEGRATION_TIMEOUT            | 504            | Yes          |
+| INVALID_API_KEY                | 403            | Yes          |
+| INVALID_SIGNATURE              | 403            | Yes          |
+| MISSING_AUTHENTICATION_TOKEN   | 403            | Yes          |
+| QUOTA_EXCEEDED                 | 429            | Yes          |
+| REQUEST_TOO_LARGE          | 413        | No       |
+| RESOURCE_NOT_FOUND             | 404            | Yes          |
+| THROTTLED                      | 429            | Yes          |
+| UNAUTHORIZED                   | 401            | Yes          |
+| WAF_FILTERED                   | 403            | Yes          |
+
+Note: REQUEST_TOO_LARGE (413) is the only gateway response that CANNOT be customized. Use DEFAULT_4XX for CORS headers on this response.
+
+## Feature Availability Matrix
+
+| Feature                  | REST API              | HTTP API              | WebSocket                  |
+| ------------------------ | --------------------- | --------------------- | -------------------------- |
+| Caching                  | Yes                   | No                    | No                         |
+| Usage plans / API keys   | Yes                   | No                    | No                         |
+| AWS WAF                  | Yes                   | No                    | No                         |
+| Request validation       | Yes                   | No                    | No                         |
+| VTL mapping templates    | Yes                   | No                    | Yes                        |
+| Resource policies        | Yes                   | No                    | No                         |
+| Private endpoints        | Yes                   | No                    | No                         |
+| mTLS                     | Yes (custom domain)   | Yes (custom domain)   | Via CloudFront viewer mTLS |
+| JWT authorizer           | No                    | Yes                   | No                         |
+| Cognito authorizer       | Yes                   | Use JWT               | No                         |
+| Lambda authorizer        | Yes (TOKEN + REQUEST) | Yes (REQUEST, simple) | Yes ($connect)             |
+| Canary deployments       | Yes                   | No                    | No                         |
+| Response streaming       | Yes                   | No                    | No                         |
+| Automatic deployments    | No                    | Yes                   | No                         |
+| X-Ray tracing            | Yes                   | No                    | No                         |
+| Execution logging        | Yes                   | No                    | Yes                        |
+| Access logging           | Yes                   | Yes                   | Yes                        |
+| Custom gateway responses | Yes                   | No                    | No                         |
+| SDK generation           | Yes                   | No                    | No                         |
+| API documentation        | Yes                   | No                    | No                         |
+| Client certificates      | Yes                   | No                    | No                         |

--- a/plugins/aws-serverless/skills/aws-serverless-api-gateway/references/troubleshooting.md
+++ b/plugins/aws-serverless/skills/aws-serverless-api-gateway/references/troubleshooting.md
@@ -1,0 +1,375 @@
+# Troubleshooting Guide
+
+## Table of Contents
+
+- [General Approach](#general-approach)
+- [HTTP 400 Bad Request](#http-400-bad-request)
+- [HTTP 401 Unauthorized](#http-401-unauthorized)
+- [HTTP 403 Forbidden](#http-403-forbidden)
+- [HTTP 413 Request Too Large](#http-413-request-too-large)
+- [HTTP 429 Too Many Requests](#http-429-too-many-requests)
+- [HTTP 500 Internal Server Error](#http-500-internal-server-error)
+- [HTTP 502 Bad Gateway](#http-502-bad-gateway)
+- [HTTP 504 Gateway Timeout](#http-504-gateway-timeout)
+- [SSL/TLS and Certificate Issues](#ssltls-and-certificate-issues)
+- [CORS Errors](#cors-errors)
+- [Lambda Integration Errors](#lambda-integration-errors)
+- [VPC and Private API Issues](#vpc-and-private-api-issues)
+- [Mapping Template Errors](#mapping-template-errors)
+- [WebSocket Issues](#websocket-issues)
+- [SQS Integration Errors](#sqs-integration-errors)
+- [Useful Debugging Commands](#useful-debugging-commands)
+
+---
+
+## General Approach
+
+1. Enable execution logging (REST/WebSocket only -- [HTTP API supports access logging only](https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-logging.html)) AND access logging before troubleshooting
+2. Use `x-amzn-requestid` response header to trace specific requests in execution logs
+3. Check enhanced observability variables in access logs to identify which phase failed (see `references/observability-logging.md`)
+4. Use CloudWatch Logs Insights for pattern analysis across many requests
+
+### Request Phase Order
+
+WAF -> Authenticate -> Authorizer -> Authorize -> Integration
+
+Each phase exposes `$context.{phase}.status`, `$context.{phase}.latency`, `$context.{phase}.error` in access logs.
+
+---
+
+## HTTP 400 Bad Request
+
+### Protocol Mismatch with ALB
+
+- Cause: Sending HTTP to TLS listener or HTTPS to non-TLS listener
+- Fix: Match protocol (HTTP/HTTPS) to ALB listener type
+
+### ALB Desync Mode
+
+- Cause: ALB desync mitigation set to "strictest" rejects non-RFC-compliant requests
+- Fix: Switch to "defensive" mode or ensure requests are RFC-compliant
+
+### Invalid Request Body
+
+- Cause: Request body fails JSON Schema validation (REST API request validator)
+- Fix: Check model definition; note `maxItems`/`minItems` are NOT validated
+
+---
+
+## HTTP 401 Unauthorized
+
+### Lambda Authorizer
+
+- Missing token: Token source header not sent or wrong header name
+- Regex mismatch: Token fails the Token Validation regex pattern
+- Missing identity sources: Required headers/query strings not sent (REQUEST type)
+- Fix: Verify header name, regex pattern, and all identity sources
+
+### Cognito
+
+- Wrong token type: Use ID token when no scopes configured; access token when scopes configured
+- Expired token: Check token expiration
+- User pool mismatch: Verify user pool ID in authorizer config
+
+---
+
+## HTTP 403 Forbidden
+
+### "Missing Authentication Token"
+
+- Cause: Stage name in URL when using custom domain (stage already mapped)
+- Fix: Remove stage name from URL path
+- Also occurs when: hitting nonexistent resource path, default endpoint disabled
+- Note: This 403 behavior is REST API specific. HTTP API returns 404 Not Found for nonexistent paths ([Gateway response types](https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-gatewayResponse-definition.html))
+
+### From VPC (All APIs Fail)
+
+- Cause: Private DNS on `execute-api` VPC endpoint routes ALL API calls through the endpoint
+- Fix: Use custom domain names for public APIs, or disable private DNS
+
+### Lambda Authorizer with {proxy+}
+
+- Cause: Authorizer returns IAM policy with path-specific resource ARN. When caching is enabled, that policy is reused for requests to different proxy paths, which are denied by the cached partial policy ([Configure Lambda authorizer caching](https://docs.aws.amazon.com/apigateway/latest/developerguide/configure-api-gateway-lambda-authorization-with-console.html))
+- Fix: Return wildcard resource ARN (`*/*`) in policy, or disable authorizer caching
+
+### Cross-Account IAM
+
+- Cause: Missing either IAM policy (caller account) OR resource policy (API account)
+- Fix: REST API: configure both. HTTP API: use `sts:AssumeRole` (no resource policies)
+
+### Resource Policy
+
+Common causes:
+
+1. IP not in allow list or is in deny list
+2. HTTP method/resource not covered by policy
+3. Auth type mismatch (e.g., IAM auth expected but not provided)
+4. API not redeployed after policy change
+5. Wrong condition key (`aws:SourceVpce` vs `aws:SourceVpc`)
+
+### mTLS 403
+
+- Certificate issuer not in truststore
+- Insecure signature algorithm (must be SHA-256+)
+- Self-signed certificates with insufficient key size (RSA-2048+ or ECDSA-256+ required)
+
+### WAF Filtered
+
+- `waf-status: 403` in access logs
+- Check WAF rules and web ACL configuration
+
+---
+
+## HTTP 413 Request Too Large
+
+- Cause: Payload exceeds 10 MB limit (REST and HTTP API) ([API Gateway quotas](https://docs.aws.amazon.com/apigateway/latest/developerguide/limits.html))
+- REQUEST_TOO_LARGE is the only gateway response that [cannot be customized](https://docs.aws.amazon.com/apigateway/latest/developerguide/supported-gateway-response-types.html). Use `DEFAULT_4XX` as a catch-all to add CORS headers for all 4xx errors including 413
+- For larger payloads: Use S3 presigned URLs for direct client upload/download
+
+---
+
+## HTTP 429 Too Many Requests
+
+### "429 Too Many Requests"
+
+- Cause: API rate or burst limits exceeded at account, stage, or method level
+- Fix: Implement retries with jittered exponential backoff; request limit increase
+
+### "Limit Exceeded"
+
+- Cause: API quota limits exceeded (daily/weekly/monthly)
+- Fix: Request quota extension via usage plan or AWS Support
+
+---
+
+## HTTP 500 Internal Server Error
+
+### Lambda Stage Variable Permission
+
+- Cause: Missing Lambda invoke permission when function referenced via stage variable
+- Fix: Add resource-based policy: `aws lambda add-permission --function-name <fn> --statement-id apigateway --action lambda:InvokeFunction --principal apigateway.amazonaws.com --source-arn <api-arn>` ([Lambda permissions for API Gateway](https://docs.aws.amazon.com/apigateway/latest/developerguide/getting-started-with-lambda-integration.html#getting-started-with-lambda-integration-add-permission))
+
+### VPC Link Issues
+
+- VPC link in "Failed" state
+- Unhealthy NLB targets
+- Security group blocks (port 443 TCP)
+- NACLs blocking traffic
+- TLS certificate mismatch on backend
+- Fix: Check VPC link status, NLB target health, security groups, backend TLS chain
+
+### Lambda Authorizer Malformed Response
+
+- Cause: Lambda authorizer returns invalid JSON, missing `principalId`, or policy exceeding ~8 KB. API Gateway returns 500 (not 401/403) -- commonly mistaken for a backend issue ([Authorizer output format](https://docs.aws.amazon.com/apigateway/latest/developerguide/api-gateway-lambda-authorizer-output.html))
+- Fix: Check execution logs for authorizer errors; verify response includes `principalId` and valid `policyDocument`
+
+### General Lambda Integration
+
+- Missing Lambda invoke permissions
+- Lambda throttled (concurrency limit)
+- Incorrect status code mapping (non-proxy integration)
+- Fix: Add permissions, implement backoff, configure correct mappings
+
+---
+
+## HTTP 502 Bad Gateway
+
+### Lambda Proxy Integration
+
+- Cause: Lambda response not in required format
+- REST API / payload format 1.0 ([response format](https://docs.aws.amazon.com/apigateway/latest/developerguide/set-up-lambda-proxy-integrations.html#api-gateway-simple-proxy-for-lambda-output-format)):
+
+```json
+{
+  "statusCode": 200,
+  "headers": { "Content-Type": "application/json" },
+  "body": "{\"key\": \"value\"}",
+  "isBase64Encoded": false
+}
+```
+
+- `statusCode` must be integer, `body` must be string, `headers` must be object
+- HTTP API payload format 2.0 is more flexible ([response format](https://docs.aws.amazon.com/apigateway/latest/developerguide/http-api-develop-integrations-lambda.html#http-api-develop-integrations-lambda.response)): `body` can be string or object (auto-serialized to JSON), a bare string return is treated as 200 body, and `cookies` array is supported for Set-Cookie headers
+- Also check Lambda permissions and package file permissions
+
+---
+
+## HTTP 504 Gateway Timeout
+
+### REST API
+
+- Default: 29 seconds integration timeout (increasable up to 300s for Regional/Private via quota request)
+- Lambda continues running but client receives 504
+
+### HTTP API
+
+- 30 seconds hard limit (not increasable)
+- Returns HTTP 504 while Lambda continues ([Troubleshoot 504 errors](https://repost.aws/knowledge-center/api-gateway-504-errors))
+
+### Diagnosis
+
+1. Check `IntegrationLatency` metric for spikes
+2. Use CloudWatch Logs Insights to identify slow requests
+3. Enable [X-Ray tracing](https://docs.aws.amazon.com/apigateway/latest/developerguide/apigateway-xray.html) for detailed latency breakdown (REST API only). For HTTP API, enable X-Ray in Lambda functions and correlate via `$context.integration.requestId`
+
+### Fixes
+
+- Optimize Lambda: increase memory, reduce cold starts, use provisioned concurrency
+- Check backend health and response times
+- For REST API Regional/Private: request timeout increase up to 300s via AWS Support
+- For better UX or operations exceeding max timeout: consider async patterns (SQS, EventBridge, Step Functions): acknowledge immediately, process in background
+
+---
+
+## SSL/TLS and Certificate Issues
+
+### PKIX Path Building Failed
+
+- Cause: Incomplete certificate chain, unsupported CA, or self-signed cert on backend
+- Fix: Provide complete certificate chain on backend; use `insecureSkipVerification=true` for testing only
+
+### General SSLEngine Problem
+
+- Unsupported CA, expired certificate, invalid chain, unsupported cipher suite
+- Fix: Verify CA support, check expiry, ensure valid chain. RSA keys 2048-4096 bits and ECDSA keys are supported
+
+### VPC Link TLS
+
+- NLB TLS listener terminates TLS at NLB; TCP listener passes through
+- Fix: Use TCP listener for end-to-end TLS; TLS listener for NLB-terminated TLS
+
+### Wrong Certificate Returned
+
+- Cause: DNS record points to stage URL instead of API Gateway domain name target
+- Fix: Point DNS to correct API Gateway domain name
+
+### mTLS Certificate Conflicts
+
+- Multiple CAs with same subject in truststore
+- Fix: Clean up truststore, remove duplicate/conflicting CA certificates
+
+---
+
+## CORS Errors
+
+### Missing CORS Headers on Error Responses
+
+- Cause: Gateway responses (4XX/5XX) bypass integration and don't include CORS headers
+- Fix: Add CORS headers to `DEFAULT_4XX` and `DEFAULT_5XX` gateway responses
+
+### Proxy Integration Missing CORS
+
+- Cause: API Gateway doesn't add CORS headers in proxy integration
+- Fix: Lambda/backend must return `Access-Control-Allow-Origin` and other CORS headers
+
+### Private API Preflight Failure
+
+- Cause: `x-apigw-api-id` header triggers preflight requests that fail
+- Fix: Use `Host` header instead of `x-apigw-api-id`
+
+---
+
+## Lambda Integration Errors
+
+### "Invalid permissions on Lambda function"
+
+- Fix (console): Re-save Lambda integration to auto-add permissions
+- Fix (CLI): `aws lambda add-permission --function-name <fn> --statement-id apigateway --action lambda:InvokeFunction --principal apigateway.amazonaws.com --source-arn <method-arn>`
+- Fix (CloudFormation): Add `AWS::Lambda::Permission` resource
+
+### Lambda Authorizer Permission Error
+
+- Create IAM role with `lambda:InvokeFunction` and set as Lambda Invoke Role on the authorizer
+
+### Async Invocation
+
+- REST API: Set `X-Amz-Invocation-Type: 'Event'` in Integration Request HTTP Headers
+- HTTP API: Not directly supported. Use proxy Lambda that invokes target Lambda asynchronously
+
+---
+
+## VPC and Private API Issues
+
+### Connection Checklist
+
+1. Resource policy allows VPC endpoint or VPC
+2. VPC endpoint policy allows the API
+3. Security groups allow TCP 443 inbound
+4. DNS resolution works (check private DNS setting)
+
+### Invoke URL Formats (Without Private DNS)
+
+- Route 53 alias to VPC endpoint
+- VPC endpoint public DNS + `Host` header
+- VPC endpoint public DNS + `x-apigw-api-id` header
+
+### On-Premises DNS Resolution
+
+- Create Route 53 Resolver inbound endpoint in VPC
+- Configure on-prem DNS forwarder to forward `amazonaws.com` queries to Resolver
+
+---
+
+## Mapping Template Errors
+
+### "Invalid mapping expression specified"
+
+- Cause: `{proxy+}` path variable needs URL path parameter mapping
+- Fix: Define URL path parameter `proxy` mapped from `method.request.path.proxy`
+
+### "Illegal character in path"
+
+- Cause: Without mapping, API Gateway sends literal `{proxy+}` (containing `{`)
+- Fix: Same as above. Ensure Endpoint URL uses `{proxy}` (without `+`)
+
+---
+
+## WebSocket Issues
+
+### 410 GoneException
+
+- Message sent before connection fully established
+- Connection terminated by client
+- Invalid connectionId format
+- Fix: Use `getConnection` before `postToConnection`; do NOT post from $connect route Lambda
+
+### Connection Errors
+
+- Missing Lambda permissions, incorrect API URL, backend errors
+- WebSocket URL format: `wss://api-id.execute-api.region.amazonaws.com/stage`
+
+---
+
+## SQS Integration Errors
+
+| Error                     | Cause                                       | Fix                                               |
+| ------------------------- | ------------------------------------------- | ------------------------------------------------- |
+| UnknownOperationException | Wrong Content-Type or Action name           | Verify Content-Type and action                    |
+| AccessDenied              | IAM role missing SQS permissions            | Add SQS permissions to role                       |
+| KMS.AccessDeniedException | Missing KMS permissions for encrypted queue | Add KMS permissions                               |
+| SignatureDoesNotMatch     | Content-Type header mismatch                | Align Content-Type between method and integration |
+| InvalidAddress            | Queue URL doesn't match region              | Use correct regional queue URL                    |
+
+---
+
+## Useful Debugging Commands
+
+### Systems Manager Automation
+
+Use `AWSSupport-TroubleshootAPIGatewayHttpErrors` runbook to automatically analyze CloudWatch logs for 4xx/5xx errors.
+
+### CloudWatch Logs Insights for Specific Request
+
+```
+fields @timestamp, @message
+| filter @message like "REQUEST_ID_HERE"
+| sort @timestamp asc
+```
+
+### Execution Log Sequence (REST API Only)
+
+Authorizer -> Usage Plan -> Method Request -> Endpoint Request -> Endpoint Response -> Method Response
+
+### Tracing with x-amzn-requestid
+
+Every API Gateway response includes `x-amzn-requestid` header. Use this to search execution logs for the full request trace.

--- a/plugins/aws-serverless/skills/aws-serverless-api-gateway/references/websocket.md
+++ b/plugins/aws-serverless/skills/aws-serverless-api-gateway/references/websocket.md
@@ -1,0 +1,174 @@
+# WebSocket API
+
+## Route Selection
+
+- `$connect`: Called when client connects; authorization is enforced only at connection time. Once connected, all subsequent messages bypass authorization checks. Lambda authorizer's cached policy must cover all routes the client will access during the connection lifetime
+- `$disconnect`: Best-effort delivery when client disconnects
+- `$default`: Fallback for unmatched messages
+- Custom routes: Matched by `routeSelectionExpression` (e.g., `$request.body.action`)
+
+## @connections Management API
+
+- `POST @connections/{connectionId}`: Send message to client
+- `GET @connections/{connectionId}`: Get connection info
+- `DELETE @connections/{connectionId}`: Disconnect client
+- IAM action: `execute-api:ManageConnections`
+
+## Session Management
+
+- Store connectionId together with user ID in DynamoDB on `$connect`. When a user reconnects (new connectionId), update the mapping (the user ID stays the same; only the connectionId changes). This allows the session to continue seamlessly across reconnects, network drops, and the 2-hour connection limit
+- Use a GSI on user ID to look up the current connectionId for a given user (e.g., to send a targeted message to a specific user regardless of which connectionId they currently hold)
+- Use DynamoDB TTL to clean up stale connections
+- For anonymous users: client generates random user ID, sends via `Sec-WebSocket-Protocol` header
+- Backend should echo `Sec-WebSocket-Protocol` in response, as many browser clients will reject the connection if a requested subprotocol is not echoed back
+- Handle `GoneException` from `post_to_connection` to detect stale connections
+
+## Client Resilience Best Practices
+
+- Automatic reconnect: Clients must implement reconnect logic with exponential backoff to handle network interruptions, server-side disconnects, and the 2-hour maximum connection duration limit. The connection will be dropped at 2 hours regardless of activity. Clients should treat this as expected and reconnect transparently
+- Heartbeat / keep-alive: Clients should send a periodic heartbeat message (e.g., every 5-9 minutes) to prevent the 10-minute idle timeout from closing the connection. Use a lightweight message on `$default` or a dedicated `heartbeat` route. Without heartbeats, idle connections are silently closed and the client may not detect the drop until the next send fails
+- Connection state recovery: On reconnect, clients should re-authenticate and restore application state (e.g., re-subscribe to topics, re-join rooms). Store enough context client-side to resume without data loss
+
+## SAM Template: Basic WebSocket API
+
+```yaml
+WebSocketApi:
+  Type: AWS::ApiGatewayV2::Api
+  Properties:
+    Name: !Sub "${AWS::StackName}-ws"
+    ProtocolType: WEBSOCKET
+    RouteSelectionExpression: "$request.body.action"
+
+ConnectRoute:
+  Type: AWS::ApiGatewayV2::Route
+  Properties:
+    ApiId: !Ref WebSocketApi
+    RouteKey: $connect
+    AuthorizationType: NONE
+    Target: !Sub "integrations/${ConnectIntegration}"
+
+ConnectIntegration:
+  Type: AWS::ApiGatewayV2::Integration
+  Properties:
+    ApiId: !Ref WebSocketApi
+    IntegrationType: AWS_PROXY
+    IntegrationUri: !Sub "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${ConnectFunction.Arn}/invocations"
+
+ConnectPermission:
+  Type: AWS::Lambda::Permission
+  Properties:
+    Action: lambda:InvokeFunction
+    FunctionName: !Ref ConnectFunction
+    Principal: apigateway.amazonaws.com
+    SourceArn: !Sub "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${WebSocketApi}/*/$connect"
+
+DisconnectRoute:
+  Type: AWS::ApiGatewayV2::Route
+  Properties:
+    ApiId: !Ref WebSocketApi
+    RouteKey: $disconnect
+    Target: !Sub "integrations/${DisconnectIntegration}"
+
+DisconnectIntegration:
+  Type: AWS::ApiGatewayV2::Integration
+  Properties:
+    ApiId: !Ref WebSocketApi
+    IntegrationType: AWS_PROXY
+    IntegrationUri: !Sub "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${DisconnectFunction.Arn}/invocations"
+
+DisconnectPermission:
+  Type: AWS::Lambda::Permission
+  Properties:
+    Action: lambda:InvokeFunction
+    FunctionName: !Ref DisconnectFunction
+    Principal: apigateway.amazonaws.com
+    SourceArn: !Sub "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${WebSocketApi}/*/$disconnect"
+
+DefaultRoute:
+  Type: AWS::ApiGatewayV2::Route
+  Properties:
+    ApiId: !Ref WebSocketApi
+    RouteKey: $default
+    Target: !Sub "integrations/${DefaultIntegration}"
+
+DefaultIntegration:
+  Type: AWS::ApiGatewayV2::Integration
+  Properties:
+    ApiId: !Ref WebSocketApi
+    IntegrationType: AWS_PROXY
+    IntegrationUri: !Sub "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MessageFunction.Arn}/invocations"
+
+DefaultPermission:
+  Type: AWS::Lambda::Permission
+  Properties:
+    Action: lambda:InvokeFunction
+    FunctionName: !Ref MessageFunction
+    Principal: apigateway.amazonaws.com
+    SourceArn: !Sub "arn:aws:execute-api:${AWS::Region}:${AWS::AccountId}:${WebSocketApi}/*/$default"
+
+Stage:
+  Type: AWS::ApiGatewayV2::Stage
+  Properties:
+    ApiId: !Ref WebSocketApi
+    StageName: prod
+    AutoDeploy: true
+```
+
+## Lambda: Sending Messages via @connections
+
+```python
+import boto3
+import logging
+from botocore.exceptions import ClientError
+
+logger = logging.getLogger()
+
+def send_to_connection(domain_name, stage, connection_id, message):
+    """Send a message to a WebSocket client."""
+    apigw = boto3.client(
+        "apigatewaymanagementapi",
+        endpoint_url=f"https://{domain_name}/{stage}"
+    )
+    try:
+        apigw.post_to_connection(
+            ConnectionId=connection_id,
+            Data=message.encode("utf-8")
+        )
+    except ClientError as e:
+        if e.response["Error"]["Code"] == "GoneException":
+            logger.info("Connection %s is gone, cleaning up", connection_id)
+            # Remove stale connection from DynamoDB
+            return False
+        raise
+    return True
+```
+
+## Limits
+
+- Frame size: 32 KB, message payload: 128 KB
+- Connection duration: 2 hours, idle timeout: 10 minutes
+- New connections: 500/s (adjustable), routes: 300
+- Route-level throttling: Configure `ThrottlingBurstLimit` and `ThrottlingRateLimit` per route via stage `RouteSettings` to protect backend integrations from message floods. Cannot exceed account-level limit
+- Account-level throttle: 10,000 rps / 5,000 burst for WebSocket `@connections` callback, per region (adjustable)
+- These are default quotas; check [latest limits](https://docs.aws.amazon.com/apigateway/latest/developerguide/limits.html) and request increases as needed
+
+## Pricing
+
+- Connection minutes: charged per minute of connection time
+- Messages: charged per million messages (both sent and received)
+- The @connections callback API messages count toward message charges
+- No minimum fees or upfront commitments
+- See [API Gateway pricing](https://aws.amazon.com/api-gateway/pricing/) for current rates
+
+## Multi-Region WebSocket
+
+- DynamoDB Global Tables for connection state tracking
+- Route 53 latency-based or geo-based routing for initial connection
+- ConnectionId is region-specific; messages must be sent via the region that owns the connection
+- Cross-region message propagation via EventBridge or DynamoDB Streams + Lambda
+
+## Related Templates
+
+- Basic WebSocket SAM template: See above
+- Step Functions integration (sync Express + async with @connections callback): See `references/sam-service-integrations.md` (Step Functions section)
+- WebSocket access log format: See `references/observability-logging.md` (WebSocket API Access Log Format section)

--- a/plugins/aws-serverless/skills/aws-serverless-deployment/SKILL.md
+++ b/plugins/aws-serverless/skills/aws-serverless-deployment/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: aws-serverless-deployment
+description: Plan, review, validate, and deploy AWS serverless applications with SAM, CDK, CloudFormation, and serverless CI/CD workflows.
+---
+
+# AWS Serverless Deployment
+
+Use this skill for SAM templates, CDK serverless stacks, CloudFormation review, serverless CI/CD, local Lambda testing, deployment troubleshooting, and production readiness checks.
+
+## Workflow
+
+1. Detect the IaC framework from the repository. Look for `template.yaml`, `template.yml`, `samconfig.toml`, `cdk.json`, `lib/`, `stacks/`, `bin/`, and CI pipeline files.
+2. Keep the existing framework unless the user asks to migrate.
+3. For new projects, prefer CDK TypeScript when the user wants a larger typed app and SAM when the user wants a compact Lambda-first project.
+4. Separate stateful and stateless resources. Add deletion protection, retention policies, backups, or termination protection when appropriate.
+5. Require least-privilege IAM, explicit regions, deterministic names where needed, tagged resources, log retention, and environment-specific config.
+6. Before any deployment, produce a short deployment plan with expected resources, IAM impact, public endpoints, data stores, estimated cost drivers, and rollback path.
+7. Prefer local checks such as `cdk synth`, `sam validate --lint`, `sam build`, or unit tests before deployment. Treat `cdk diff` as a live-account read: ask first and confirm the target account, region, and profile.
+
+## Explicit Validation
+
+Do not run validation automatically after file edits. When the user asks for validation or approves it, use the smallest relevant command:
+
+```bash
+sam validate --template template.yaml --lint
+```
+
+For CDK projects, prefer:
+
+```bash
+cdk synth
+```
+
+Only run commands in the user's workspace after explaining what they do. Ask before `cdk diff` because it can use live AWS account context.
+
+## MCP Use
+
+Use `aws-serverless-mcp` for SAM project initialization, generated serverless templates, deployment helpers, EventBridge schema workflows, and serverless troubleshooting when it is more precise than general shell commands.
+
+Because the MCP server is registered with write access, ask before every MCP operation that can create files, deploy stacks, change domains, update assets, mutate AWS resources, or incur cost.
+
+## Safety
+
+Never deploy, delete, update, or roll back infrastructure without explicit approval. Ask before reading logs, invoking live functions, accessing production accounts, changing DNS, creating certificates, updating IAM, creating public endpoints, or invalidating CloudFront caches.
+
+Do not print or commit credentials. Do not include secrets in CloudFormation, CDK context, SAM config, Lambda environment variables, build logs, or chat output.

--- a/plugins/aws-serverless/skills/aws-serverless-deployment/SKILL.md
+++ b/plugins/aws-serverless/skills/aws-serverless-deployment/SKILL.md
@@ -1,46 +1,108 @@
 ---
 name: aws-serverless-deployment
-description: Plan, review, validate, and deploy AWS serverless applications with SAM, CDK, CloudFormation, and serverless CI/CD workflows.
+description: "AWS SAM and AWS CDK deployment for serverless applications. Triggers on phrases like: use SAM, SAM template, SAM init, SAM deploy, CDK serverless, CDK Lambda construct, NodejsFunction, PythonFunction, SAM and CDK together, serverless CI/CD pipeline. For general app deployment with service selection, use deploy-on-aws plugin instead."
+argument-hint: "[what are you deploying?]"
 ---
 
 # AWS Serverless Deployment
 
-Use this skill for SAM templates, CDK serverless stacks, CloudFormation review, serverless CI/CD, local Lambda testing, deployment troubleshooting, and production readiness checks.
+Deploy serverless applications to AWS using SAM or CDK. This skill covers project scaffolding, IaC templates, CDK constructs and patterns, deployment workflows, CI/CD pipelines, and SAM/CDK coexistence.
 
-## Workflow
+For Lambda runtime behavior, event sources, orchestration, observability, and optimization, see the [aws-serverless-lambda skill](../aws-serverless-lambda/).
 
-1. Detect the IaC framework from the repository. Look for `template.yaml`, `template.yml`, `samconfig.toml`, `cdk.json`, `lib/`, `stacks/`, `bin/`, and CI pipeline files.
-2. Keep the existing framework unless the user asks to migrate.
-3. For new projects, prefer CDK TypeScript when the user wants a larger typed app and SAM when the user wants a compact Lambda-first project.
-4. Separate stateful and stateless resources. Add deletion protection, retention policies, backups, or termination protection when appropriate.
-5. Require least-privilege IAM, explicit regions, deterministic names where needed, tagged resources, log retention, and environment-specific config.
-6. Before any deployment, produce a short deployment plan with expected resources, IAM impact, public endpoints, data stores, estimated cost drivers, and rollback path.
-7. Prefer local checks such as `cdk synth`, `sam validate --lint`, `sam build`, or unit tests before deployment. Treat `cdk diff` as a live-account read: ask first and confirm the target account, region, and profile.
+## When to Load Reference Files
 
-## Explicit Validation
+Load the appropriate reference file based on what the user is working on:
 
-Do not run validation automatically after file edits. When the user asks for validation or approves it, use the smallest relevant command:
+- SAM project setup, templates, deployment workflow, local testing, or container images -> see [references/sam-project-setup.md](references/sam-project-setup.md)
+- CDK project setup, constructs, CDK testing, or CDK pipelines -> see [references/cdk-project-setup.md](references/cdk-project-setup.md)
+- CDK Lambda constructs, NodejsFunction, PythonFunction, or CDK Function -> see [references/cdk-lambda-constructs.md](references/cdk-lambda-constructs.md)
+- CDK serverless patterns, API Gateway CDK, Function URL CDK, EventBridge CDK, DynamoDB CDK, or SQS CDK -> see [references/cdk-serverless-patterns.md](references/cdk-serverless-patterns.md)
+- SAM and CDK coexistence, migrating from SAM to CDK, or using sam build with CDK -> see [references/sam-cdk-coexistence.md](references/sam-cdk-coexistence.md)
 
-```bash
-sam validate --template template.yaml --lint
-```
+## Best Practices
 
-For CDK projects, prefer:
+### SAM
 
-```bash
-cdk synth
-```
+- Do: Use `sam_init` with an appropriate template for your use case
+- Do: Set global defaults for timeout, memory, runtime, and tracing in the `Globals` section
+- Do: Use `samconfig.toml` environment-specific sections for multi-environment deployments
+- Do: Use `sam build --use-container` when native dependencies are involved
+- Don't: Copy-paste templates from the internet without understanding the resource configuration
+- Don't: Hardcode resource ARNs or account IDs in templates -- use `!Ref`, `!GetAtt`, and `!Sub`
 
-Only run commands in the user's workspace after explaining what they do. Ask before `cdk diff` because it can use live AWS account context.
+### CDK
 
-## MCP Use
+- Do: Use TypeScript -- type checking catches errors at synthesis time, before any AWS API calls
+- Do: Prefer L2 constructs and `grant*` methods over L1 and raw IAM statements
+- Do: Separate stateful and stateless resources into different stacks; enable termination protection on stateful stacks
+- Do: Commit `cdk.context.json` to version control -- it caches VPC/AZ lookups for deterministic synthesis
+- Do: Write unit tests with `aws-cdk-lib/assertions`; assert logical IDs of stateful resources to detect accidental replacements
+- Do: Use `cdk diff` in CI before every deployment to review changes
+- Don't: Hardcode account IDs or region strings -- use `this.account` and `this.region`
+- Don't: Use `cdk deploy` directly in production without a pipeline
+- Don't: Skip `cdk bootstrap` -- deployments will fail without the CDK toolkit stack
 
-Use `aws-serverless-mcp` for SAM project initialization, generated serverless templates, deployment helpers, EventBridge schema workflows, and serverless troubleshooting when it is more precise than general shell commands.
+## Configuration
 
-Because the MCP server is registered with write access, ask before every MCP operation that can create files, deploy stacks, change domains, update assets, mutate AWS resources, or incur cost.
+### AWS CLI Setup
 
-## Safety
+This skill requires that AWS credentials are configured on the host machine:
 
-Never deploy, delete, update, or roll back infrastructure without explicit approval. Ask before reading logs, invoking live functions, accessing production accounts, changing DNS, creating certificates, updating IAM, creating public endpoints, or invalidating CloudFront caches.
+Verify access: Run `aws sts get-caller-identity` to confirm credentials are valid
 
-Do not print or commit credentials. Do not include secrets in CloudFormation, CDK context, SAM config, Lambda environment variables, build logs, or chat output.
+### SAM CLI Setup
+
+Verify: Run `sam --version`
+
+### Container Runtime Setup
+
+1. Install a Docker compatible container runtime: Required for `sam_local_invoke` and container-based builds
+2. Verify: Use an appropriate command such as `docker --version` or `finch --version`
+
+### AWS Serverless MCP Server
+
+The Cline plugin registers `aws-serverless-mcp` with `--allow-write`, so the MCP server can create projects, generate IaC, and deploy when Cline uses its tools. Ask for explicit approval before any MCP tool or shell command that writes files, deploys, mutates AWS resources, changes IAM/DNS/certificates, reads logs, invokes functions, or incurs cost.
+
+Sensitive-data access is not enabled by this plugin. It does not pass `--allow-sensitive-data-access`; users who need log-reading MCP tools should configure that intentionally in their own MCP settings.
+
+### SAM Template Validation Hook
+
+This Cline plugin does not install the source automatic validation hook. Treat SAM template validation as an explicit workflow step: after editing `template.yaml` or `template.yml`, ask before running `sam validate --template <path> --lint`.
+
+
+## IaC framework selection
+
+Default: CDK
+
+Override syntax:
+
+- "use CloudFormation" -> Generate YAML templates
+- "use SAM" -> Generate YAML templates
+
+When not specified, ALWAYS use CDK
+
+### Language selection for CDK
+
+Default: TypeScript
+
+Override syntax:
+
+- "use Python" -> Generate Python code
+- "use JavaScript" -> Generate JavaScript code
+
+When not specified, ALWAYS use TypeScript
+
+## Error Scenarios
+
+### Serverless MCP Server Unavailable
+
+- Inform user: "AWS Serverless MCP not responding"
+- Ask: "Proceed without MCP support?"
+- DO NOT continue without user confirmation
+
+## Resources
+
+- [AWS SAM Documentation](https://docs.aws.amazon.com/serverless-application-model/)
+- [AWS CDK Documentation](https://docs.aws.amazon.com/cdk/)
+- [AWS Serverless MCP Server](https://github.com/awslabs/mcp/tree/main/src/aws-serverless-mcp-server)

--- a/plugins/aws-serverless/skills/aws-serverless-deployment/references/cdk-lambda-constructs.md
+++ b/plugins/aws-serverless/skills/aws-serverless-deployment/references/cdk-lambda-constructs.md
@@ -1,0 +1,92 @@
+# CDK Lambda Function Constructs
+
+CDK provides specialized constructs for defining Lambda functions. Always prefer the runtime-specific L2 constructs (`NodejsFunction`, `PythonFunction`) over the base `Function` when available -- they handle bundling automatically.
+
+## Node.js -- `NodejsFunction`
+
+The `NodejsFunction` construct bundles TypeScript/JavaScript with esbuild automatically. No separate build step needed.
+
+```typescript
+import * as cdk from 'aws-cdk-lib';
+import { NodejsFunction } from 'aws-cdk-lib/aws-lambda-nodejs';
+import * as lambda from 'aws-cdk-lib/aws-lambda';
+import { Duration } from 'aws-cdk-lib';
+
+export class MyStack extends cdk.Stack {
+  constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+
+    const orderHandler = new NodejsFunction(this, 'OrderHandler', {
+      entry: 'lambda/order-handler.ts',   // path to TypeScript entry file
+      handler: 'handler',                 // exported function name
+      runtime: lambda.Runtime.NODEJS_24_X,
+      architecture: lambda.Architecture.ARM_64,  // ~20% cheaper than x86_64
+      memorySize: 512,
+      timeout: Duration.seconds(30),
+      tracing: lambda.Tracing.ACTIVE,
+      environment: {
+        TABLE_NAME: myTable.tableName,    // reference, not hardcoded string
+      },
+      bundling: {
+        minify: true,
+        sourceMap: true,
+        externalModules: ['@aws-sdk/*'],  // exclude AWS SDK (provided by runtime)
+      },
+    });
+  }
+}
+```
+
+Entry auto-detection: If `entry` is omitted, CDK looks for `{stack-filename}.{construct-id}.ts` next to the stack file.
+
+Handler resolution: `"handler"` (no dot) resolves to `"index.handler"`.
+
+## Python -- `PythonFunction` (Alpha)
+
+`PythonFunction` is in a separate alpha package and requires Docker for bundling.
+
+```bash
+npm install @aws-cdk/aws-lambda-python-alpha
+```
+
+```typescript
+import { PythonFunction } from '@aws-cdk/aws-lambda-python-alpha';
+import * as lambda from 'aws-cdk-lib/aws-lambda';
+
+const orderHandler = new PythonFunction(this, 'OrderHandler', {
+  entry: 'lambda/order-handler',   // directory containing index.py
+  index: 'index.py',               // default
+  handler: 'handler',              // default
+  runtime: lambda.Runtime.PYTHON_3_14,
+  architecture: lambda.Architecture.ARM_64,
+  memorySize: 512,
+  timeout: Duration.seconds(30),
+  tracing: lambda.Tracing.ACTIVE,
+  environment: {
+    TABLE_NAME: myTable.tableName,
+  },
+});
+```
+
+The `entry` directory should contain a `requirements.txt`, `Pipfile`, or `pyproject.toml`. Docker must be running during `cdk synth` and `cdk deploy`.
+
+> Alpha warning: `@aws-cdk/aws-lambda-python-alpha` can introduce breaking changes without a major version bump. Pin the exact version and test after upgrades.
+
+## Other Runtimes -- Base `Function`
+
+For Java, Go, .NET, or custom runtimes, use the base `Function` construct with `Code.fromAsset()`:
+
+```typescript
+import * as lambda from 'aws-cdk-lib/aws-lambda';
+
+const orderHandler = new lambda.Function(this, 'OrderHandler', {
+  code: lambda.Code.fromAsset('build/distributions/order-handler.zip'),
+  handler: 'com.example.OrderHandler::handleRequest',
+  runtime: lambda.Runtime.JAVA_21,
+  architecture: lambda.Architecture.ARM_64,
+  memorySize: 1024,
+  timeout: Duration.seconds(60),
+  snapStart: lambda.SnapStartConf.ON_PUBLISHED_VERSIONS,  // Java 11+
+  tracing: lambda.Tracing.ACTIVE,
+});
+```

--- a/plugins/aws-serverless/skills/aws-serverless-deployment/references/cdk-project-setup.md
+++ b/plugins/aws-serverless/skills/aws-serverless-deployment/references/cdk-project-setup.md
@@ -1,0 +1,345 @@
+# CDK Project Setup Guide
+
+## SAM vs CDK: When to Use Each
+
+Both SAM and CDK synthesize CloudFormation. Choosing between them is a matter of team preference and project context.
+
+|                          | SAM                                     | CDK                                                       |
+| ------------------------ | --------------------------------------- | --------------------------------------------------------- |
+| Language             | YAML/JSON (declarative)                 | TypeScript, Python, Java, Go, C# (imperative)             |
+| Learning curve       | Lower -- close to CloudFormation         | Higher -- requires familiarity with a programming language |
+| Abstraction level    | Handles wiring for Serverless resources | Rich L2/L3 constructs handle wiring automatically         |
+| Code sharing         | Template fragments only                 | Full reuse via construct libraries (npm, PyPI)            |
+| Loops and conditions | Limited                                 | Native language constructs (`for`, `if`, maps)            |
+| Testing              | Manual template review                  | Unit tests with `aws-cdk-lib/assertions`                  |
+| Best for             | Lambda-centric apps, teams new to IaC   | Large teams building reusable infrastructure patterns     |
+
+Choose SAM when your primary concern is Lambda functions and you want the SAM MCP tools.
+
+Choose CDK when you have complex infrastructure, want to write reusable construct libraries, prefer a programming-language interface, or your team already uses CDK elsewhere.
+
+Both tools support the `get_iac_guidance` MCP tool for additional context:
+
+```text
+get_iac_guidance(iac_tool: "cdk")
+```
+
+---
+
+## Getting Started
+
+### Install and Bootstrap
+
+```bash
+npm install -g aws-cdk
+cdk --version
+
+# One-time account/region bootstrap (creates CDK toolkit stack)
+cdk bootstrap aws://ACCOUNT-ID/REGION
+```
+
+### Initialize a New Project
+
+```bash
+mkdir my-serverless-app && cd my-serverless-app
+cdk init app --language typescript
+npm install
+```
+
+### Project Structure
+
+```text
+my-serverless-app/
++-- bin/
+|   +-- my-serverless-app.ts    # App entry point
++-- lib/
+|   +-- my-serverless-app-stack.ts  # Stack definition
++-- lambda/
+|   +-- handler.ts              # Lambda function code
++-- test/
+|   +-- my-serverless-app.test.ts
++-- cdk.context.json            # Committed to git -- caches lookups
++-- cdk.json                    # CDK config
++-- tsconfig.json
+```
+
+---
+
+## Construct Levels
+
+CDK has three levels of constructs:
+
+| Level             | Description                                                   | Example                           |
+| ----------------- | ------------------------------------------------------------- | --------------------------------- |
+| __L1 (Cfn_)_*     | Direct CloudFormation resource, 1:1 mapping                   | `CfnFunction`, `CfnTable`         |
+| L2            | Opinionated wrapper with sensible defaults and helper methods | `Function`, `Table`, `Queue`      |
+| L3 (Patterns) | Complete patterns that wire multiple resources together       | `LambdaRestApi`, `SqsEventSource` |
+
+Always prefer L2 constructs. Use L1 only when a feature is missing from the L2. Use L3 patterns as a starting point, but understand what they create.
+
+---
+
+## Lambda Functions
+
+For CDK Lambda function constructs -- `NodejsFunction` (TypeScript/JavaScript with esbuild), `PythonFunction` (alpha, Docker-based), and base `Function` (Java, Go, .NET) -- see [cdk-lambda-constructs.md](cdk-lambda-constructs.md).
+
+---
+
+## IAM with `grant*` Methods
+
+CDK L2 constructs expose `grant*` methods that generate least-privilege policies automatically. Prefer these over writing raw `PolicyStatement` objects.
+
+```typescript
+import * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
+import * as sqs from 'aws-cdk-lib/aws-sqs';
+import * as s3 from 'aws-cdk-lib/aws-s3';
+import * as events from 'aws-cdk-lib/aws-events';
+
+// DynamoDB
+table.grantReadWriteData(myFunction);
+table.grantReadData(readOnlyFunction);
+
+// S3
+bucket.grantRead(myFunction);
+bucket.grantPut(myFunction);
+
+// SQS
+queue.grantSendMessages(myFunction);
+queue.grantConsumeMessages(myFunction);
+
+// EventBridge -- put events
+eventBus.grantPutEventsTo(myFunction);
+
+// Lambda -- invoke another function
+otherFunction.grantInvoke(myFunction);
+
+// Secrets Manager
+secret.grantRead(myFunction);
+```
+
+For resources not covered by `grant*`, add a `PolicyStatement` directly:
+
+```typescript
+import * as iam from 'aws-cdk-lib/aws-iam';
+
+myFunction.addToRolePolicy(new iam.PolicyStatement({
+  effect: iam.Effect.ALLOW,
+  actions: ['bedrock:InvokeModel'],
+  resources: [`arn:aws:bedrock:${this.region}::foundation-model/anthropic.claude-3-sonnet*`],
+}));
+```
+
+---
+
+## Common Serverless Patterns
+
+For CDK code examples of common serverless patterns -- API Gateway HTTP API, Lambda Function URL, EventBridge custom bus, DynamoDB table, and SQS queue with Lambda -- see [cdk-serverless-patterns.md](cdk-serverless-patterns.md).
+
+---
+
+## Separating Stateful and Stateless Stacks
+
+Stateful resources (databases, queues, S3 buckets, event buses) should be in a separate stack with termination protection. This prevents accidental deletion during routine deployments.
+
+```typescript
+// bin/my-app.ts
+const app = new cdk.App();
+
+// Stateful stack -- deployed once, termination-protected
+const stateful = new StatefulStack(app, 'StatefulStack', {
+  env: { account: '123456789012', region: 'us-east-1' },
+  terminationProtection: true,
+});
+
+// Stateless stack -- deployed on every code change
+const stateless = new StatelessStack(app, 'StatelessStack', {
+  env: { account: '123456789012', region: 'us-east-1' },
+  // Pass references from stateful stack
+  ordersTable: stateful.ordersTable,
+  orderEventBus: stateful.orderEventBus,
+});
+```
+
+```typescript
+// lib/stateful-stack.ts
+export class StatefulStack extends cdk.Stack {
+  public readonly ordersTable: dynamodb.Table;
+  public readonly orderEventBus: events.EventBus;
+
+  constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+
+    this.ordersTable = new dynamodb.Table(this, 'OrdersTable', {
+      // ...
+      removalPolicy: cdk.RemovalPolicy.RETAIN,
+    });
+
+    this.orderEventBus = new events.EventBus(this, 'OrderEventBus', {
+      eventBusName: 'order-events',
+    });
+  }
+}
+```
+
+---
+
+## CDK Testing
+
+CDK constructs can be unit tested without deploying. Use `aws-cdk-lib/assertions` with Jest.
+
+```bash
+npm install --save-dev jest @types/jest ts-jest
+```
+
+```typescript
+// test/order-stack.test.ts
+import * as cdk from 'aws-cdk-lib';
+import { Template, Match } from 'aws-cdk-lib/assertions';
+import { OrderStack } from '../lib/order-stack';
+
+describe('OrderStack', () => {
+  let template: Template;
+
+  beforeEach(() => {
+    const app = new cdk.App();
+    const stack = new OrderStack(app, 'TestOrderStack');
+    template = Template.fromStack(stack);
+  });
+
+  it('creates Lambda function with ARM64 architecture', () => {
+    template.hasResourceProperties('AWS::Lambda::Function', {
+      Architectures: ['arm64'],
+      Runtime: 'nodejs22.x',
+    });
+  });
+
+  it('grants DynamoDB read-write to order handler', () => {
+    template.hasResourceProperties('AWS::IAM::Policy', {
+      PolicyDocument: {
+        Statement: Match.arrayWith([
+          Match.objectLike({
+            Action: Match.arrayWith([
+              'dynamodb:GetItem',
+              'dynamodb:PutItem',
+            ]),
+          }),
+        ]),
+      },
+    });
+  });
+
+  it('has exactly one DynamoDB table', () => {
+    template.resourceCountIs('AWS::DynamoDB::Table', 1);
+  });
+
+  it('DynamoDB table has retention policy', () => {
+    template.hasResource('AWS::DynamoDB::Table', {
+      DeletionPolicy: 'Retain',
+    });
+  });
+});
+```
+
+Assert logical IDs of stateful resources to catch accidental replacements early -- renaming a CDK construct ID causes CloudFormation to delete and recreate the resource:
+
+```typescript
+it('orders table logical ID is stable', () => {
+  const resources = template.findResources('AWS::DynamoDB::Table');
+  expect(Object.keys(resources)).toContain('OrdersTable1234ABCD');  // update if intentionally renamed
+});
+```
+
+---
+
+## Deployment Workflow
+
+```bash
+# Synthesize CloudFormation template (runs assertions, no AWS calls)
+cdk synth
+
+# Preview changes before deploying
+cdk diff
+
+# Deploy all stacks
+cdk deploy --all
+
+# Deploy a specific stack
+cdk deploy StatelessStack
+
+# Deploy with approval prompt disabled (CI/CD)
+cdk deploy --require-approval never
+
+# CI-only. This does not replace Cline's required user approval before deploys.
+
+# Destroy a stack (respects RemovalPolicy -- RETAIN resources are kept)
+cdk destroy StatelessStack
+```
+
+---
+
+## CDK Pipelines (CI/CD)
+
+CDK Pipelines is a self-mutating CI/CD pipeline construct built on CodePipeline.
+
+```typescript
+import { CodePipeline, CodePipelineSource, ManualApprovalStep, ShellStep } from 'aws-cdk-lib/pipelines';
+
+export class PipelineStack extends cdk.Stack {
+  constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+
+    const pipeline = new CodePipeline(this, 'Pipeline', {
+      pipelineName: 'MyServerlessPipeline',
+      synth: new ShellStep('Synth', {
+        input: CodePipelineSource.gitHub('my-org/my-repo', 'main'),
+        commands: ['npm ci', 'npm run build', 'npx cdk synth'],
+      }),
+    });
+
+    // Staging stage
+    pipeline.addStage(new MyAppStage(this, 'Staging', {
+      env: { account: '111111111111', region: 'us-east-1' },
+    }));
+
+    // Production stage with manual approval
+    pipeline.addStage(new MyAppStage(this, 'Production', {
+      env: { account: '222222222222', region: 'us-east-1' },
+    }), {
+      pre: [new ManualApprovalStep('PromoteToProduction')],
+    });
+  }
+}
+```
+
+The pipeline updates itself: when you push changes to the pipeline stack, the next run applies them before deploying the application.
+
+---
+
+## SAM and CDK Coexistence
+
+For guidance on running SAM and CDK side by side -- incremental migration, using `sam build` on CDK-synthesized templates, and when to use which -- see [sam-cdk-coexistence.md](sam-cdk-coexistence.md).
+
+---
+
+## Best Practices
+
+### Do
+
+- Use TypeScript -- type checking catches errors at synthesis time, before any AWS API calls
+- Prefer L2 constructs and `grant*` methods over L1 and raw IAM statements
+- Never hardcode resource names -- always reference generated names (`table.tableName`, `queue.queueUrl`)
+- Separate stateful and stateless resources into different stacks; enable termination protection on stateful stacks
+- Commit `cdk.context.json` to version control -- it caches VPC/AZ lookups for deterministic synthesis
+- Write unit tests with `aws-cdk-lib/assertions`; assert logical IDs of stateful resources to detect accidental replacements
+- Set `RemovalPolicy.RETAIN` on all databases, S3 buckets, and event buses
+- Use `cdk diff` in CI before every deployment to review changes
+- Pass all configuration to constructs via props; never read environment variables inside construct constructors
+
+### Don't
+
+- Hardcode account IDs or region strings -- use `this.account` and `this.region`
+- Use `cdk deploy` directly in production without a pipeline
+- Skip `cdk bootstrap` -- deployments will fail without the CDK toolkit stack
+- Rely on CloudFormation `Parameters` and `Conditions` when you can express the same logic in TypeScript
+- Mix `RemovalPolicy.DESTROY` into shared/stateful stacks
+- Reference constructs across separate CDK apps using CloudFormation outputs if you can pass object references directly

--- a/plugins/aws-serverless/skills/aws-serverless-deployment/references/cdk-serverless-patterns.md
+++ b/plugins/aws-serverless/skills/aws-serverless-deployment/references/cdk-serverless-patterns.md
@@ -1,0 +1,153 @@
+# CDK Serverless Patterns
+
+Common CDK patterns for serverless applications. Each example uses L2 constructs with `grant*` methods for least-privilege IAM.
+
+## API Gateway HTTP API + Lambda
+
+Creates an HTTP API with CORS configuration and Lambda integration for handling REST endpoints.
+
+```typescript
+import * as apigwv2 from 'aws-cdk-lib/aws-apigatewayv2';
+import { HttpLambdaIntegration } from 'aws-cdk-lib/aws-apigatewayv2-integrations';
+
+const api = new apigwv2.HttpApi(this, 'OrderApi', {
+  corsPreflight: {
+    allowOrigins: ['https://myapp.example.com'],
+    allowMethods: [apigwv2.CorsHttpMethod.GET, apigwv2.CorsHttpMethod.POST],
+    allowHeaders: ['Content-Type', 'Authorization'],
+  },
+});
+
+api.addRoutes({
+  path: '/orders',
+  methods: [apigwv2.HttpMethod.POST],
+  integration: new HttpLambdaIntegration('CreateOrder', createOrderFunction),
+});
+
+new cdk.CfnOutput(this, 'ApiUrl', { value: api.apiEndpoint });
+```
+
+## Lambda Function URL
+
+Exposes a Lambda function directly via HTTPS with optional IAM auth and streaming support.
+
+```typescript
+const fnUrl = myFunction.addFunctionUrl({
+  authType: lambda.FunctionUrlAuthType.NONE,   // or AWS_IAM
+  invokeMode: lambda.InvokeMode.RESPONSE_STREAM,  // for streaming
+  cors: {
+    allowedOrigins: ['https://myapp.example.com'],
+    allowedMethods: [lambda.HttpMethod.POST],
+  },
+});
+
+new cdk.CfnOutput(this, 'FunctionUrl', { value: fnUrl.url });
+```
+
+## EventBridge Custom Bus + Rule
+
+Sets up a custom event bus with archiving, routing rules, and DLQ for event-driven architectures.
+
+```typescript
+import * as events from 'aws-cdk-lib/aws-events';
+import * as targets from 'aws-cdk-lib/aws-events-targets';
+import * as sqs from 'aws-cdk-lib/aws-sqs';
+
+const orderEventBus = new events.EventBus(this, 'OrderEventBus', {
+  eventBusName: 'order-events',
+});
+
+// Archive all events for replay
+new events.Archive(this, 'OrderEventArchive', {
+  sourceEventBus: orderEventBus,
+  archiveName: 'order-events-archive',
+  retention: cdk.Duration.days(30),
+  eventPattern: { source: ['com.mycompany.orders'] },
+});
+
+// DLQ for the rule target
+const processDlq = new sqs.Queue(this, 'ProcessOrderDLQ', {
+  retentionPeriod: cdk.Duration.days(14),
+});
+
+// Rule routing to Lambda
+new events.Rule(this, 'OrderPlacedRule', {
+  eventBus: orderEventBus,
+  eventPattern: {
+    source: ['com.mycompany.orders'],
+    detailType: ['OrderPlaced'],
+  },
+  targets: [
+    new targets.LambdaFunction(processOrderFunction, {
+      retryAttempts: 3,
+      maxEventAge: cdk.Duration.hours(1),
+      deadLetterQueue: processDlq,
+    }),
+  ],
+});
+
+// Allow publisher to send events to the bus
+orderEventBus.grantPutEventsTo(publisherFunction);
+```
+
+## DynamoDB Table + Lambda
+
+Provisions a DynamoDB table with GSI, point-in-time recovery, and least-privilege Lambda access.
+
+```typescript
+import * as dynamodb from 'aws-cdk-lib/aws-dynamodb';
+
+const ordersTable = new dynamodb.Table(this, 'OrdersTable', {
+  partitionKey: { name: 'orderId', type: dynamodb.AttributeType.STRING },
+  sortKey: { name: 'createdAt', type: dynamodb.AttributeType.STRING },
+  billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
+  removalPolicy: cdk.RemovalPolicy.RETAIN,   // never delete in production
+  pointInTimeRecoverySpecification: {
+    pointInTimeRecoveryEnabled: true,
+  },
+});
+
+ordersTable.addGlobalSecondaryIndex({
+  indexName: 'ByUserId',
+  partitionKey: { name: 'userId', type: dynamodb.AttributeType.STRING },
+  sortKey: { name: 'createdAt', type: dynamodb.AttributeType.STRING },
+});
+
+// Least-privilege: read-write for the handler
+ordersTable.grantReadWriteData(orderHandler);
+
+// Pass table name via environment (never hardcode)
+orderHandler.addEnvironment('TABLE_NAME', ordersTable.tableName);
+```
+
+## SQS Queue + Lambda ESM
+
+Configures an SQS queue with DLQ and Lambda event source mapping for asynchronous processing.
+
+```typescript
+import * as sqs from 'aws-cdk-lib/aws-sqs';
+import { SqsEventSource } from 'aws-cdk-lib/aws-lambda-event-sources';
+
+const orderQueue = new sqs.Queue(this, 'OrderQueue', {
+  visibilityTimeout: cdk.Duration.seconds(90),  // >= function timeout
+});
+
+const dlq = new sqs.Queue(this, 'OrderDLQ', {
+  retentionPeriod: cdk.Duration.days(14),
+});
+
+orderQueue.addDeadLetterQueue({
+  queue: dlq,
+  maxReceiveCount: 3,
+});
+
+orderHandler.addEventSource(new SqsEventSource(orderQueue, {
+  batchSize: 10,
+  reportBatchItemFailures: true,  // partial batch success
+  filters: [
+    lambda.FilterCriteria.filter({
+      body: { eventType: lambda.FilterRule.isEqual('ORDER_CREATED') },
+    }),
+  ],
+}));
+```

--- a/plugins/aws-serverless/skills/aws-serverless-deployment/references/sam-cdk-coexistence.md
+++ b/plugins/aws-serverless/skills/aws-serverless-deployment/references/sam-cdk-coexistence.md
@@ -1,0 +1,41 @@
+# SAM and CDK Coexistence
+
+Most teams don't switch from SAM to CDK all at once. Both tools produce CloudFormation templates, so they can coexist in the same project, the same account, and even the same CI/CD pipeline. SAM CLI works with any CloudFormation template, whether it uses the SAM transform or is synthesized by CDK.
+
+## Incremental Migration
+
+The lowest-risk approach is to add CDK alongside SAM rather than replacing it:
+
+1. Start with one new stack in CDK -- a supporting resource (DynamoDB table, SQS queue, event bus) that your SAM functions reference via SSM parameters or CloudFormation exports
+2. Keep existing SAM stacks untouched -- they continue to deploy via `sam build && sam deploy`
+3. Migrate function stacks gradually -- move functions to CDK one stack at a time as you gain confidence
+
+Cross-stack references between SAM and CDK stacks work the same way as any CloudFormation cross-stack reference: export a value from one stack, import it in the other via `Fn::ImportValue` (SAM) or `cdk.Fn.importValue()` (CDK). Alternatively, write values to SSM Parameter Store and read them from either side.
+
+## Using SAM CLI with CDK Templates
+
+SAM CLI can build and locally test functions defined in any CloudFormation template, including one synthesized by CDK:
+
+```bash
+# Synthesize the CDK app to cdk.out/
+cdk synth
+
+# Use SAM CLI to build the synthesized template
+sam build --template cdk.out/MyStack.template.json
+
+# Test a function locally
+sam local invoke MyFunction --template cdk.out/MyStack.template.json
+```
+
+This gives you CDK's construct model for infrastructure while using SAM CLI's `sam local invoke` for local testing.
+
+## When to Use Which
+
+| Scenario                                                                  | Recommendation                                    |
+| ------------------------------------------------------------------------- | ------------------------------------------------- |
+| New Lambda-centric project, small team                                    | SAM -- simpler templates, straightforward workflow |
+| New project with complex infrastructure (VPCs, multiple services)         | CDK -- richer abstractions, `grant*` methods       |
+| Existing SAM project, works fine                                          | Keep SAM -- migration cost isn't justified         |
+| Existing SAM project, hitting limits (no loops, hard to share constructs) | Migrate incrementally to CDK                      |
+| Reusable infrastructure patterns shared across teams                      | CDK construct libraries                           |
+| Need local testing with CDK-defined infrastructure                        | CDK for templates, SAM CLI for `sam local invoke` |

--- a/plugins/aws-serverless/skills/aws-serverless-deployment/references/sam-project-setup.md
+++ b/plugins/aws-serverless/skills/aws-serverless-deployment/references/sam-project-setup.md
@@ -1,0 +1,374 @@
+# SAM Project Setup Guide
+
+## Template Selection
+
+Choose the right template based on your use case:
+
+| Template                     | Best For                                  |
+| ---------------------------- | ----------------------------------------- |
+| `hello-world`                | Basic Lambda function with API Gateway    |
+| `quick-start-web`            | Web application with frontend and backend |
+| `quick-start-cloudformation` | Infrastructure-focused templates          |
+| `quick-start-scratch`        | Minimal template for custom builds        |
+
+Use `get_serverless_templates` to browse additional templates from Serverless Land for specific patterns (e.g., API + DynamoDB, step functions, event processing).
+
+## Architecture Selection
+
+Choose `arm64` (Graviton) for better price-performance unless you have x86-specific dependencies.
+
+## Project Structure
+
+```text
+my-serverless-app/
++-- template.yaml          # SAM template
++-- samconfig.toml         # Deployment configuration
++-- src/                   # Function source code
+|   +-- handlers/          # Lambda function handlers
+|   +-- layers/            # Shared layers
+|   +-- utils/             # Utility functions
++-- events/                # Test event files
++-- tests/                 # Unit and integration tests
+```
+
+Testability tip: Extract pure business logic (calculations, validations, decisions) into plain functions that don't import the AWS SDK. This lets you unit test core logic without mocking -- reserve mocks for the handler-level tests that exercise SDK calls.
+
+## Template Configuration
+
+### Global Settings
+
+Set global defaults in `template.yaml` to apply to all functions:
+
+```yaml
+Globals:
+  Function:
+    Timeout: 30
+    MemorySize: 512
+    Runtime: python3.12
+    Tracing: Active
+    Environment:
+      Variables:
+        LOG_LEVEL: INFO
+        POWERTOOLS_SERVICE_NAME: my-service
+```
+
+### Environment Parameters
+
+Use CloudFormation parameters to make templates environment-aware:
+
+```yaml
+Parameters:
+  Environment:
+    Type: String
+    Default: dev
+    AllowedValues: [dev, staging, prod]
+```
+
+Reference `!Ref Environment` in resource names and configuration to differentiate stacks.
+
+## Development Workflow
+
+### 1. Initialize
+
+Use `sam_init` with chosen runtime, template, and dependency manager.
+
+### 2. Develop
+
+Write handler code in `src/handlers/`. Create test events in `events/`.
+
+### 3. Build
+
+Use `sam_build` before every deployment. Use `--use-container` for consistent builds with Lambda-compatible dependencies.
+
+### 4. Test Locally
+
+Use `sam_local_invoke` with a test event to validate before deploying. For API-triggered functions, use `sam local start-api` to test with real HTTP requests (see [Testing > Local Integration Testing](#local-integration-testing) below).
+
+### 5. Deploy
+
+Use `sam_deploy` with `guided: true` for the first deploy, which generates `samconfig.toml`. For subsequent deploys, `sam_deploy` reads from `samconfig.toml`.
+
+### 6. Monitor
+
+Use `sam_logs` to check function output. Use `get_metrics` to monitor health.
+
+## Deployment Strategies
+
+### Canary and Linear Deployments
+
+For production APIs, use SAM's built-in `DeploymentPreference` to shift traffic gradually and automatically roll back on errors. This uses CodeDeploy and Lambda aliases under the hood.
+
+```yaml
+Globals:
+  Function:
+    AutoPublishAlias: live
+
+Resources:
+  MyFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      DeploymentPreference:
+        Type: Canary10Percent5Minutes  # 10% for 5 min, then 100%
+        Alarms:
+          - !Ref MyFunctionErrorAlarm
+```
+
+Available deployment types:
+
+| Type                            | Traffic shift pattern                            |
+| ------------------------------- | ------------------------------------------------ |
+| `AllAtOnce`                     | Immediate full cutover (no safety, dev/test use) |
+| `Canary10Percent5Minutes`       | 10% for 5 min, then 100%                         |
+| `Canary10Percent30Minutes`      | 10% for 30 min, then 100%                        |
+| `Linear10PercentEvery1Minute`   | +10% every minute                                |
+| `Linear10PercentEvery10Minutes` | +10% every 10 min                                |
+
+Set `DeploymentPreference.Alarms` to a CloudWatch alarm on error rate. CodeDeploy automatically rolls back if the alarm fires during the shift window.
+
+## Lambda Layers
+
+Layers let you share code and dependencies across functions without including them in each deployment package.
+
+When to use layers:
+
+- Shared business logic used by multiple functions
+- Large dependencies (e.g., pandas, Pillow) you want to cache separately
+- AWS Lambda Powertools (AWS provides a managed layer ARN per runtime/region)
+
+Add a layer in SAM template:
+
+```yaml
+MyLayer:
+  Type: AWS::Serverless::LayerVersion
+  Properties:
+    LayerName: my-shared-utils
+    ContentUri: layers/shared-utils/
+    CompatibleRuntimes:
+      - python3.12
+    RetentionPolicy: Retain
+
+MyFunction:
+  Type: AWS::Serverless::Function
+  Properties:
+    Layers:
+      - !Ref MyLayer
+```
+
+Limits: Maximum 5 layers per function. Total uncompressed size of function + layers must be under 250 MB.
+
+## Container Images
+
+Lambda supports container images up to 10 GB as a first-class deployment model alongside zip packages.
+
+### When to Use Container Images
+
+| Criterion                | Zip Package         | Container Image                                 |
+| ------------------------ | ------------------- | ----------------------------------------------- |
+| Max size                 | 250 MB uncompressed | 10 GB                                           |
+| Custom OS dependencies   | Limited (layers)    | Full control via Dockerfile                     |
+| Existing Docker workflow | N/A                 | Reuse Dockerfiles and CI pipelines              |
+| Cold start               | Faster baseline     | Slower baseline, mitigated by SOCI              |
+| Local testing            | `sam local invoke`  | `sam local invoke` (Docker required either way) |
+
+Use container images when your deployment package exceeds 250 MB (ML models, large native dependencies), you need OS-level packages not available in Lambda runtimes, or your team already has Docker build pipelines.
+
+### Dockerfile Examples
+
+Python (multi-stage build):
+
+```dockerfile
+FROM public.ecr.aws/lambda/python:3.12 AS builder
+COPY requirements.txt .
+RUN pip install --target /asset -r requirements.txt
+
+FROM public.ecr.aws/lambda/python:3.12
+COPY --from=builder /asset ${LAMBDA_TASK_ROOT}
+COPY src/ ${LAMBDA_TASK_ROOT}/
+CMD ["app.handler"]
+```
+
+Node.js:
+
+```dockerfile
+FROM public.ecr.aws/lambda/nodejs:22
+COPY package.json package-lock.json ${LAMBDA_TASK_ROOT}/
+RUN npm ci --omit=dev
+COPY src/ ${LAMBDA_TASK_ROOT}/
+CMD ["app.handler"]
+```
+
+### SAM Template Configuration
+
+```yaml
+MyFunction:
+  Type: AWS::Serverless::Function
+  Properties:
+    PackageType: Image
+    Architectures: [arm64]
+    MemorySize: 512
+    Timeout: 30
+  Metadata:
+    Dockerfile: Dockerfile
+    DockerContext: ./src
+    DockerTag: latest
+```
+
+SAM builds the image locally during `sam build` and pushes it to ECR during `sam deploy`. No manual `docker push` needed.
+
+### Seekable OCI (SOCI) Lazy Loading
+
+Container images have longer cold starts than zip because Lambda must download the full image before starting. SOCI creates an index that enables lazy loading -- Lambda pulls only the layers needed at startup and fetches the rest in the background.
+SOCI is most beneficial for images larger than 250 MB. For smaller images, the overhead of maintaining the index may not be worthwhile.
+
+### Best Practices
+
+- [ ] Use multi-stage builds to minimize final image size -- install build dependencies in a builder stage, copy only artifacts to the final stage
+- [ ] Use AWS base images (`public.ecr.aws/lambda/*`) -- they include the Lambda runtime interface client
+- [ ] Choose `arm64` architecture for the same 20% cost savings as zip deployments
+- [ ] Pin base image tags to specific versions in production (e.g., `python:3.12.2024.11.22` not `python:3.12`)
+- [ ] Create SOCI indexes for images larger than 250 MB to reduce cold starts
+
+## Configuration Management
+
+### samconfig.toml
+
+Use environment-specific sections:
+
+```toml
+[default.deploy.parameters]
+stack_name = "my-serverless-app"
+region = "us-east-1"
+capabilities = "CAPABILITY_IAM"
+
+[dev.deploy.parameters]
+stack_name = "my-app-dev"
+parameter_overrides = "Environment=dev LogLevel=DEBUG"
+
+[prod.deploy.parameters]
+stack_name = "my-app-prod"
+parameter_overrides = "Environment=prod LogLevel=WARN"
+```
+
+Deploy to a specific environment with `sam_deploy` using `config_env: prod`.
+
+## Security
+
+- Follow least-privilege IAM: scope each function's role to only the actions and resources it needs
+- Use `AWSLambdaBasicExecutionRole` managed policy for CloudWatch logging
+- Add VPC configuration only when the function needs access to VPC resources (RDS, ElastiCache)
+- Store secrets in Secrets Manager or SSM Parameter Store
+
+## Testing
+
+### Serverless Testing Pyramid
+
+| Level                 | What it tests                 | Speed                  | AWS dependency |
+| --------------------- | ----------------------------- | ---------------------- | -------------- |
+| Unit              | Handler logic, business rules | Fast (ms)              | None (mocked)  |
+| Local integration | Function + event shape        | Medium (seconds)       | Docker only    |
+| Cloud integration | Function + real AWS services  | Slow (seconds-minutes) | Full           |
+| End-to-end        | Complete request path         | Slowest                | Full           |
+
+Invest most effort in unit tests. Use local integration to catch event shape mismatches. Reserve cloud tests for verifying IAM, networking, and service integration behavior.
+
+### Unit Testing
+
+Mock all AWS SDK calls. Use the Arrange-Act-Assert pattern.
+
+Python (pytest):
+
+```python
+from unittest.mock import MagicMock, patch
+
+def test_get_order_returns_item():
+    # Arrange
+    mock_table = MagicMock()
+    mock_table.get_item.return_value = {"Item": {"orderId": "ord-1", "status": "active"}}
+
+    with patch("src.handlers.orders.table", mock_table):
+        from src.handlers.orders import app
+        event = {"httpMethod": "GET", "pathParameters": {"orderId": "ord-1"}}
+        # Act
+        result = app.resolve(event, {})
+        # Assert
+        assert result["statusCode"] == 200
+```
+
+TypeScript (jest + aws-sdk-client-mock):
+
+```typescript
+import { handler } from '../src/handlers/orders';
+import { mockClient } from 'aws-sdk-client-mock';
+import { DynamoDBDocumentClient, GetCommand } from '@aws-sdk/lib-dynamodb';
+
+const ddbMock = mockClient(DynamoDBDocumentClient);
+
+afterEach(() => ddbMock.reset());
+
+it('should return order when it exists', async () => {
+  // Arrange
+  ddbMock.on(GetCommand).resolves({ Item: { orderId: 'ord-1', status: 'active' } });
+  const event = { httpMethod: 'GET', pathParameters: { orderId: 'ord-1' } } as any;
+  // Act
+  const result = await handler(event, {} as any);
+  // Assert
+  expect(result.statusCode).toBe(200);
+});
+```
+
+### Local Integration Testing
+
+```bash
+# Generate a test event template
+sam local generate-event s3 put --bucket my-bucket --key uploads/test.jpg > events/s3_put.json
+
+# Invoke locally with the generated event
+sam local invoke MyFunction --event events/s3_put.json
+
+# Enable Powertools dev mode for verbose local output
+sam local invoke MyFunction --event events/test.json \
+  --env-vars <(echo '{"MyFunction": {"POWERTOOLS_DEV": "true"}}')
+```
+
+`sam local generate-event` supports all Lambda event sources (s3, sqs, sns, kinesis, dynamodb, apigateway, etc.). Use it instead of hand-crafting event JSON.
+
+The `sam local start-api` subcommand runs your AWS Lambda functions locally to test through a local HTTP server host. This lets you test your APIs with real HTTP requests using curl, Postman, or your browser:
+
+```bash
+# Start local API server (default port 3000)
+sam local start-api
+
+# Test with curl
+curl http://localhost:3000/hello
+
+# Use custom port
+sam local start-api --port 8080
+```
+
+### Cloud Integration Testing
+
+Local testing cannot fully replicate IAM policies, VPC networking, or service integrations. Use cloud-based testing for these.
+
+```bash
+# Test a deployed function directly
+sam remote invoke MyFunction --stack-name my-app-dev --event-file events/test.json
+
+# Deploy an ephemeral stack for PR testing
+sam deploy --config-env ci \
+  --parameter-overrides "Environment=pr-${PR_NUMBER}" \
+  --stack-name "my-app-pr-${PR_NUMBER}"
+
+# Tear down after tests pass
+aws cloudformation delete-stack --stack-name "my-app-pr-${PR_NUMBER}"
+```
+
+Ephemeral stacks (one per PR) provide full isolation between test runs without polluting shared environments.
+
+### Testing Checklist
+
+- [ ] Mock all AWS SDK calls in unit tests -- never call real AWS services
+- [ ] Keep test events in `events/` for repeatability
+- [ ] Use `sam local generate-event` rather than hand-crafting event JSON
+- [ ] Set `POWERTOOLS_DEV=true` locally for verbose structured log output
+- [ ] Run unit tests in CI on every commit; cloud integration tests on PR merge
+- [ ] Use ephemeral stacks for integration testing to avoid environment conflicts

--- a/plugins/aws-serverless/skills/aws-serverless-durable-functions/SKILL.md
+++ b/plugins/aws-serverless/skills/aws-serverless-durable-functions/SKILL.md
@@ -1,36 +1,204 @@
 ---
 name: aws-serverless-durable-functions
-description: Build and review AWS Lambda durable functions for resilient, replay-safe, long-running workflows with checkpoints, retries, waits, callbacks, and compensation.
+description: >
+  Build resilient, long-running, multi-step applications with AWS Lambda durable functions with automatic state persistence, retry logic, and orchestration for long-running executions. Covers the critical replay model, step operations, wait/callback patterns, error handling with saga pattern, testing with LocalDurableTestRunner. Triggers on phrases like: lambda durable functions, workflow orchestration, state machines, retry/checkpoint patterns, long-running stateful Lambda functions, saga pattern, human-in-the-loop callbacks, and reliable serverless applications.
 ---
 
-# AWS Serverless Durable Functions
+# AWS Lambda durable functions
 
-Use this skill when the user mentions Lambda durable functions, checkpointed Lambda workflows, replay safety, saga patterns, human callbacks, long-running stateful Lambda executions, retry orchestration, or durable testing.
+Build resilient multi-step applications and AI workflows that can execute for up to 1 year while maintaining reliable progress despite interruptions.
 
-## Workflow
+## Onboarding
 
-1. Confirm language and framework. Prefer TypeScript unless the project or user chooses Python or JavaScript.
-2. Confirm whether the task is architecture, code generation, local tests, cloud tests, or deployment.
-3. Model the workflow as deterministic orchestration plus side-effecting steps. Put non-deterministic code inside named steps.
-4. Treat calls to APIs, databases, queues, email, payments, time, random values, and generated IDs as side effects that need step boundaries or idempotency.
-5. Use explicit retry and timeout behavior for every external dependency.
-6. Add compensation steps for workflows that partially mutate external systems.
-7. Design callback and wait patterns with expiration, correlation IDs, and safe retry behavior.
-8. Add local tests for replay behavior and step failure behavior before suggesting deployment.
+### Step 1: Validate Prerequisites
 
-## Replay Rules
+Before using AWS Lambda durable functions, verify:
 
-- Do not use `Date.now`, random values, network calls, database writes, file writes, or mutable global state directly in the orchestrating path.
-- Do not rely on closure mutations surviving replay.
-- Return values from steps and pass explicit state between steps.
-- Make every step idempotent or guarded by a durable external id.
+1. AWS CLI is installed (2.33.22 or higher) and configured:
 
-## MCP Use
+   ```bash
+   aws --version
+   aws sts get-caller-identity
+   ```
 
-Use `aws-serverless-mcp` for serverless guidance, deployment helpers, and examples only when it materially improves the answer. Keep inputs sanitized and limited to the workflow shape, code snippets, or approved resource identifiers.
+2. Runtime environment is ready:
+   - For TypeScript/JavaScript: Node.js 22+ (`node --version`)
+   - For Python: Python 3.11+ (`python --version`. Note that currently only Lambda runtime environments 3.13+ come with the Durable Execution SDK pre-installed. 3.11 is the min supported Python version by the Durable SDK itself, however, you could use OCI to bring your own container image with your own Python runtime + Durable SDK.)
 
-## Safety
+3. Deployment capability exists (one of):
+   - AWS SAM CLI (`sam --version`) 1.153.1 or higher
+   - AWS CDK (`cdk --version`) v2.237.1 or higher
+   - Direct Lambda deployment access
 
-Ask before installing SDKs, modifying infrastructure, deploying workflows, invoking live executions, reading execution history, reading logs, changing IAM, or touching production resources.
+### Step 2: Select language and IaC framework
 
-For human-in-the-loop or callback workflows, avoid exposing personal data, tokens, callback URLs, or payloads in chat unless the user explicitly provides sanitized examples.
+### Language Selection
+
+Default: TypeScript
+
+Override syntax:
+
+- "use Python" -> Generate Python code
+- "use JavaScript" -> Generate JavaScript code
+
+When not specified, ALWAYS use TypeScript
+
+### IaC framework selection
+
+Default: CDK
+
+Override syntax:
+
+- "use CloudFormation" -> Generate YAML templates
+- "use SAM" -> Generate YAML templates
+
+When not specified, ALWAYS use CDK
+
+### Error Scenarios
+
+#### Unsupported Language
+
+- List detected language
+- State: "Durable Execution SDK is not yet available for [framework]"
+- Suggest supported languages as alternatives
+
+#### Unsupported IaC Framework
+
+- List detected framework
+- State: "[framework] might not support Lambda durable functions yet"
+- Suggest supported frameworks as alternatives
+
+### Serverless MCP Server Unavailable
+
+- Inform user: "AWS Serverless MCP not responding"
+- Ask: "Proceed without MCP support?"
+- DO NOT continue without user confirmation
+
+### Step 3: Install SDK
+
+For TypeScript/JavaScript:
+
+```bash
+npm install @aws/durable-execution-sdk-js
+npm install --save-dev @aws/durable-execution-sdk-js-testing
+```
+
+For Python:
+
+```bash
+pip install aws-durable-execution-sdk-python
+pip install aws-durable-execution-sdk-python-testing
+```
+
+## When to Load Reference Files
+
+Load the appropriate reference file based on what the user is working on:
+
+- Getting started, basic setup, example, ESLint, or Jest setup -> see [getting-started.md](references/getting-started.md)
+- Understanding replay model, determinism, or non-deterministic errors -> see [replay-model-rules.md](references/replay-model-rules.md)
+- Creating steps, atomic operations, or retry logic -> see [step-operations.md](references/step-operations.md)
+- Waiting, delays, callbacks, external systems, or polling -> see [wait-operations.md](references/wait-operations.md)
+- Parallel execution, map operations, batch processing, or concurrency -> see [concurrent-operations.md](references/concurrent-operations.md)
+- Error handling, retry strategies, saga pattern, or compensating transactions -> see [error-handling.md](references/error-handling.md)
+- Advanced error handling, timeout handling, circuit breakers, or conditional retries -> see [advanced-error-handling.md](references/advanced-error-handling.md)
+- Testing, local testing, cloud testing, test runner, or flaky tests -> see [testing-patterns.md](references/testing-patterns.md)
+- Deployment, CloudFormation, CDK, SAM, log groups, deploy, or infrastructure -> see [deployment-iac.md](references/deployment-iac.md)
+- Advanced patterns, GenAI agents, completion policies, step semantics, or custom serialization -> see [advanced-patterns.md](references/advanced-patterns.md)
+- troubleshooting, stuck execution, failed execution, debug execution ID, execution history, execution error, why did my execution fail, execution timed out, callback not received, diagnose execution, or root cause execution -> see [troubleshooting-executions.md](references/troubleshooting-executions.md)
+
+## Quick Reference
+
+### Basic Handler Pattern
+
+TypeScript:
+
+```typescript
+import { withDurableExecution, DurableContext } from '@aws/durable-execution-sdk-js';
+
+export const handler = withDurableExecution(async (event, context: DurableContext) => {
+  const result = await context.step('process', async () => processData(event));
+  return result;
+});
+```
+
+Python:
+
+```python
+from aws_durable_execution_sdk_python import durable_execution, DurableContext
+
+@durable_execution
+def handler(event: dict, context: DurableContext) -> dict:
+    result = context.step(lambda _: process_data(event), name='process')
+    return result
+```
+
+### Critical Rules
+
+1. All non-deterministic code MUST be in steps (Date.now, Math.random, API calls)
+2. Cannot nest durable operations - use `runInChildContext` to group operations
+3. Closure mutations are lost on replay - return values from steps
+4. Side effects outside steps repeat - use `context.logger` (replay-aware)
+
+### Python API Differences
+
+The Python SDK differs from TypeScript in several key areas:
+
+- Steps: Use `@durable_step` decorator + `context.step(my_step(args))`, or inline `context.step(lambda _: ..., name='...')`. Prefer the decorator for automatic step naming.
+- Wait: `context.wait(duration=Duration.from_seconds(n), name='...')`
+- Exceptions: `ExecutionError` (permanent), `InvocationError` (transient), `CallbackError` (callback failures)
+- Testing: Use `DurableFunctionTestRunner` class directly - instantiate with handler, use context manager, call `run(input=...)`
+
+### Invocation Requirements
+
+Durable functions require qualified ARNs (version, alias, or `$LATEST`):
+
+```bash
+# Valid
+aws lambda invoke --function-name my-function:1 output.json
+aws lambda invoke --function-name my-function:prod output.json
+
+# Invalid - will fail
+aws lambda invoke --function-name my-function output.json
+```
+
+## IAM Permissions
+
+Your Lambda execution role MUST have the `AWSLambdaBasicDurableExecutionRolePolicy` managed policy attached. This includes:
+
+- `lambda:CheckpointDurableExecution` - Persist execution state
+- `lambda:GetDurableExecutionState` - Retrieve execution state
+- CloudWatch Logs permissions
+
+Additional permissions needed for:
+
+- Durable invokes: `lambda:InvokeFunction` on target function ARNs
+- External callbacks: Systems need `lambda:SendDurableExecutionCallbackSuccess` and `lambda:SendDurableExecutionCallbackFailure`
+
+## Validation Guidelines
+
+When writing or reviewing durable function code, ALWAYS check for these replay model violations:
+
+1. Non-deterministic code outside steps: `Date.now()`, `Math.random()`, UUID generation, API calls, database queries must all be inside steps
+2. Nested durable operations in step functions: Cannot call `context.step()`, `context.wait()`, or `context.invoke()` inside a step function -- use `context.runInChildContext()` instead
+3. Closure mutations that won't persist: Variables mutated inside steps are NOT preserved across replays -- return values from steps instead
+4. Side effects outside steps that repeat on replay: Use `context.logger` for logging (it is replay-aware and deduplicates automatically)
+
+When implementing or modifying tests for durable functions, ALWAYS verify:
+
+1. All operations have descriptive names
+2. Tests get operations by NAME, never by index
+3. Replay behavior is tested with multiple invocations
+4. Use `LocalDurableTestRunner` for local testing
+
+### MCP Server Configuration
+
+The Cline plugin registers `aws-serverless-mcp` with `--allow-write`, so the MCP server can create projects, generate IaC, and deploy when Cline uses its tools. Ask for explicit approval before any MCP tool or shell command that writes files, deploys, mutates AWS resources, changes IAM/DNS/certificates, reads logs, invokes functions, or incurs cost.
+
+Sensitive-data access is not enabled by this plugin. It does not pass `--allow-sensitive-data-access`; users who need log-reading MCP tools should configure that intentionally in their own MCP settings.
+
+## Resources
+
+- [AWS Lambda durable functions Documentation](https://docs.aws.amazon.com/lambda/latest/dg/durable-functions.html)
+- [JavaScript SDK Repository](https://github.com/aws/aws-durable-execution-sdk-js)
+- [Python SDK Repository](https://github.com/aws/aws-durable-execution-sdk-python)
+- [IAM Policy Reference](https://docs.aws.amazon.com/aws-managed-policy/latest/reference/AWSLambdaBasicDurableExecutionRolePolicy.html)

--- a/plugins/aws-serverless/skills/aws-serverless-durable-functions/SKILL.md
+++ b/plugins/aws-serverless/skills/aws-serverless-durable-functions/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: aws-serverless-durable-functions
+description: Build and review AWS Lambda durable functions for resilient, replay-safe, long-running workflows with checkpoints, retries, waits, callbacks, and compensation.
+---
+
+# AWS Serverless Durable Functions
+
+Use this skill when the user mentions Lambda durable functions, checkpointed Lambda workflows, replay safety, saga patterns, human callbacks, long-running stateful Lambda executions, retry orchestration, or durable testing.
+
+## Workflow
+
+1. Confirm language and framework. Prefer TypeScript unless the project or user chooses Python or JavaScript.
+2. Confirm whether the task is architecture, code generation, local tests, cloud tests, or deployment.
+3. Model the workflow as deterministic orchestration plus side-effecting steps. Put non-deterministic code inside named steps.
+4. Treat calls to APIs, databases, queues, email, payments, time, random values, and generated IDs as side effects that need step boundaries or idempotency.
+5. Use explicit retry and timeout behavior for every external dependency.
+6. Add compensation steps for workflows that partially mutate external systems.
+7. Design callback and wait patterns with expiration, correlation IDs, and safe retry behavior.
+8. Add local tests for replay behavior and step failure behavior before suggesting deployment.
+
+## Replay Rules
+
+- Do not use `Date.now`, random values, network calls, database writes, file writes, or mutable global state directly in the orchestrating path.
+- Do not rely on closure mutations surviving replay.
+- Return values from steps and pass explicit state between steps.
+- Make every step idempotent or guarded by a durable external id.
+
+## MCP Use
+
+Use `aws-serverless-mcp` for serverless guidance, deployment helpers, and examples only when it materially improves the answer. Keep inputs sanitized and limited to the workflow shape, code snippets, or approved resource identifiers.
+
+## Safety
+
+Ask before installing SDKs, modifying infrastructure, deploying workflows, invoking live executions, reading execution history, reading logs, changing IAM, or touching production resources.
+
+For human-in-the-loop or callback workflows, avoid exposing personal data, tokens, callback URLs, or payloads in chat unless the user explicitly provides sanitized examples.

--- a/plugins/aws-serverless/skills/aws-serverless-durable-functions/references/advanced-error-handling.md
+++ b/plugins/aws-serverless/skills/aws-serverless-durable-functions/references/advanced-error-handling.md
@@ -1,0 +1,115 @@
+# Advanced Error Handling
+
+Advanced error handling patterns for durable functions, including timeout handling, circuit breakers, and conditional retry strategies.
+
+## Timeout Handling with Callbacks
+
+Pattern: Wait for an external callback with a timeout, and implement fallback logic if the timeout is reached.
+
+Implementation approach:
+
+1. Use `waitForCallback` (TypeScript) or `wait_for_callback` (Python) with a timeout configuration set in the config argument
+2. Wrap in try-catch to handle timeout errors
+3. Check if the error is a timeout
+4. Implement fallback logic in a step (e.g., escalate to manager, use default value, retry with different parameters)
+5. Return appropriate status indicating timeout occurred
+
+Key considerations:
+
+- Timeout errors are thrown when the callback doesn't complete within the specified duration
+- Fallback logic should be in a step to ensure it's checkpointed
+- Log timeout events for monitoring and debugging
+
+## Local Timeout with Promise.race in Typescript SDK
+
+Pattern: Implement a timeout for a step operation within a single Lambda invocation.
+
+Implementation approach:
+
+1. Use `Promise.race()` to race the step operation against a timeout promise
+2. The timeout promise rejects after the specified duration
+3. Catch the timeout error and implement fallback logic
+4. Execute fallback operation in a separate step
+
+Important limitation:
+In TypeScript, native setTimeout (and patterns like Promise.race using it) will fail during execution replays. To create a reliable timeout that persists across execution (expands over multi invocations), always use the timeout parameter provided by waitForCallback or waitForCondition
+
+## Conditional Retry Based on Error Type
+
+Pattern: Retry operations selectively based on the type of error encountered.
+
+Implementation approach:
+
+1. Define a custom retry strategy function that examines the error
+2. For client errors (4xx): Don't retry - these are permanent failures
+3. For server errors (5xx): Retry with exponential backoff
+4. For network errors: Retry with fixed delay
+5. For unknown errors: Don't retry by default
+
+Key considerations:
+
+- Client errors (400-499) typically indicate bad input and shouldn't be retried
+- Server errors (500-599) are often transient and benefit from retry
+- Network errors (connection refused, timeout) should retry with reasonable limits
+- Use exponential backoff for server errors to avoid overwhelming the service
+- Set maximum retry attempts to prevent infinite loops
+
+## Circuit Breaker Pattern
+
+Pattern: Temporarily stop making requests to a failing external service to prevent cascading failures.
+
+Implementation approach:
+
+1. Track failure count and last failure time (note: these reset on replay due to closure mutations)
+2. Check if circuit is "open" (too many recent failures)
+3. If open, throw a circuit breaker error and wait before retrying
+4. If closed, attempt the operation
+5. On success, reset failure count
+6. On failure, increment failure count and record timestamp
+7. Configure retry strategy to wait longer when circuit is open
+
+Important caveat: The example implementations use closure variables (`failureCount`, `lastFailureTime`) which reset on replay. For production use, store circuit breaker state in:
+
+- A step return value that persists across replays
+- An external store like DynamoDB
+- A durable variable pattern
+
+Key considerations:
+
+- Circuit breaker prevents cascading failures to downstream services
+- The "open" duration should be long enough for the service to recover
+- Reset the circuit on successful operations
+- Log circuit state changes for monitoring
+
+## Error Handling Best Practices
+
+1. Timeout Handling: Always implement fallback logic for callback timeouts - don't let executions fail silently
+2. Conditional Retries: Classify errors as transient vs permanent, only retry transient errors
+3. Circuit Breakers: Protect against cascading failures to external services, especially for high-volume operations
+4. Structured Logging: Log error context (error type, attempt count, operation name) for debugging
+5. Graceful Degradation: Return partial results when possible rather than failing completely
+6. Error Classification: Distinguish between client errors (don't retry), server errors (retry with backoff), and network errors (retry with fixed delay)
+
+## Common Error Patterns
+
+### Transient Errors (Should Retry)
+
+- Network timeouts
+- Service unavailable (503)
+- Rate limiting (429)
+- Database connection failures
+- Temporary infrastructure issues
+
+### Permanent Errors (Should Not Retry)
+
+- Invalid input (400)
+- Authentication failures (401, 403)
+- Resource not found (404)
+- Business logic violations
+- Validation errors
+
+### Timeout Errors (Need Fallback)
+
+- Callback timeouts - external system didn't respond in time
+- External system delays - service is slow or unresponsive
+- Long-running operations - operation exceeded expected duration

--- a/plugins/aws-serverless/skills/aws-serverless-durable-functions/references/advanced-patterns.md
+++ b/plugins/aws-serverless/skills/aws-serverless-durable-functions/references/advanced-patterns.md
@@ -1,0 +1,376 @@
+# Advanced Patterns
+
+Advanced techniques and patterns for sophisticated durable function workflows.
+
+## Advanced GenAI Agent Patterns
+
+### Agent with Reasoning and Dynamic Step Naming
+
+TypeScript:
+
+```typescript
+export const handler = withDurableExecution(async (event, context: DurableContext) => {
+  context.logger.info('Starting AI agent', { prompt: event.prompt });
+  const messages = [{ role: 'user', content: event.prompt }];
+
+  while (true) {
+    // Invoke AI model with reasoning
+    const { response, reasoning, tool } = await context.step(
+      'invoke-model',
+      async (stepCtx) => {
+        stepCtx.logger.info('Invoking AI model', {
+          messageCount: messages.length
+        });
+        return await invokeAIModel(messages);
+      }
+    );
+
+    // Log AI's reasoning
+    if (reasoning) {
+      context.logger.debug('AI reasoning', { reasoning });
+    }
+
+    // If no tool needed, return response
+    if (tool == null) {
+      context.logger.info('AI agent completed - no tool needed');
+      return response;
+    }
+
+    // Execute tool with dynamic step naming
+    const toolResult = await context.step(
+      `execute-tool-${tool.name}`,  // Dynamic step name
+      async (stepCtx) => {
+        stepCtx.logger.info('Executing tool', {
+          toolName: tool.name,
+          toolParams: tool.parameters
+        });
+        return await executeTool(tool, response);
+      }
+    );
+
+    // Add result to conversation
+    messages.push({
+      role: 'assistant',
+      content: toolResult,
+    });
+
+    context.logger.debug('Tool result added', {
+      toolName: tool.name,
+      resultLength: toolResult.length
+    });
+  }
+});
+```
+
+Python:
+
+```python
+# Note: invoke_ai_model and execute_tool are decorated with @durable_step
+@durable_execution
+def handler(event: dict, context: DurableContext) -> str:
+    context.logger.info('Starting AI agent', extra={'prompt': event['prompt']})
+    messages = [{'role': 'user', 'content': event['prompt']}]
+
+    while True:
+        # Invoke AI model
+        result = context.step(invoke_ai_model(messages))
+
+        response = result['response']
+        reasoning = result.get('reasoning')
+        tool = result.get('tool')
+
+        if reasoning:
+            context.logger.debug('AI reasoning', extra={'reasoning': reasoning})
+
+        if tool is None:
+            context.logger.info('AI agent completed')
+            return response
+
+        # Execute tool with dynamic step naming
+        tool_result = context.step(
+            func=execute_tool(tool, response),
+            name=f"execute-tool-{tool['name']}"
+        )
+
+        messages.append({'role': 'assistant', 'content': tool_result})
+        context.logger.debug('Tool result added', extra={'tool': tool['name']})
+```
+
+## Step Semantics Deep Dive
+
+### AtMostOncePerRetry vs AtLeastOncePerRetry
+
+TypeScript:
+
+```typescript
+import { StepSemantics } from '@aws/durable-execution-sdk-js';
+
+// AtMostOncePerRetry (DEFAULT) - For idempotent operations
+// Step executes at most once per retry attempt
+// If step fails partway through, it won't re-execute the same attempt
+await context.step(
+  'update-database',
+  async () => {
+    // This is idempotent - safe to retry
+    return await updateUserRecord(userId, data);
+  },
+  { semantics: StepSemantics.AtMostOncePerRetry }
+);
+
+// AtLeastOncePerRetry - For operations that can execute multiple times
+// Step may execute multiple times per retry attempt
+// Use when idempotency is handled externally
+await context.step(
+  'send-notification',
+  async () => {
+    // External system handles deduplication
+    return await sendEmail(email, message);
+  },
+  { semantics: StepSemantics.AtLeastOncePerRetry }
+);
+```
+
+When to use each:
+
+| Semantic                | Use When                      | Example Operations                                |
+| ----------------------- | ----------------------------- | ------------------------------------------------- |
+| AtMostOncePerRetry  | Operation is idempotent       | Database updates, API calls with idempotency keys |
+| AtLeastOncePerRetry | External deduplication exists | Queuing systems, event streams                    |
+
+## Completion Policies - Interaction and Combination
+
+### Combining Multiple Constraints
+
+Completion policies can be combined, and execution stops when the first constraint is met:
+
+TypeScript:
+
+```typescript
+const results = await context.map(
+  'process-items',
+  items,
+  processFunc,
+  {
+    completionConfig: {
+      minSuccessful: 8,              // Need at least 8 successes
+      toleratedFailureCount: 2,       // OR can tolerate 2 failures
+      toleratedFailurePercentage: 20, // OR can tolerate 20% failures
+    }
+  }
+);
+
+// Execution stops when ANY of these conditions is met:
+// 1. 8 successful items (minSuccessful reached)
+// 2. 2 failures occur (toleratedFailureCount reached)
+// 3. 20% of items fail (toleratedFailurePercentage reached)
+```
+
+### Understanding Stop Conditions
+
+Example with 10 items:
+
+```typescript
+const items = Array.from({ length: 10 }, (_, i) => i);
+
+const results = await context.map(
+  'process',
+  items,
+  processFunc,
+  {
+    maxConcurrency: 3,
+    completionConfig: {
+      minSuccessful: 7,
+      toleratedFailureCount: 3
+    }
+  }
+);
+
+// Scenario 1: 7 successes, 0 failures
+// [OK] Stops after 7th success (minSuccessful reached)
+// Remaining 3 items are not processed
+
+// Scenario 2: 5 successes, 3 failures
+// [Wrong] Stops after 3rd failure (toleratedFailureCount reached)
+// Remaining 2 items are not processed
+// results.throwIfError() will throw because minSuccessful not met
+
+// Scenario 3: 7 successes, 2 failures
+// [OK] Stops after 7th success (minSuccessful reached)
+// 1 item not processed, but completion policy satisfied
+```
+
+### Early Termination Pattern
+
+Use completion policies for early termination when searching:
+
+TypeScript:
+
+```typescript
+// Stop after finding first match
+const results = await context.map(
+  'find-match',
+  candidates,
+  async (ctx, candidate) => {
+    return await ctx.step(async () => checkMatch(candidate));
+  },
+  {
+    completionConfig: {
+      minSuccessful: 1  // Stop after first success
+    }
+  }
+);
+
+// Only one item processed (assuming first succeeds)
+if (results.successCount > 0) {
+  const match = results.getSucceeded()[0];
+  context.logger.info('Found match', { match });
+}
+```
+
+## Advanced Error Handling
+
+For timeout handling (waitForCallback, Promise.race), conditional retries, and circuit breaker patterns, see [advanced-error-handling.md](advanced-error-handling.md).
+
+## Advanced and Retry Strategies
+
+For conditional retry strategies and circuit breaker patterns, see [advanced-error-handling.md](advanced-error-handling.md).
+
+## Custom Serialization Patterns
+
+### Class with Date Fields
+
+TypeScript:
+
+```typescript
+import {
+  createClassSerdesWithDates
+} from '@aws/durable-execution-sdk-js';
+
+class User {
+  constructor(
+    public name: string,
+    public email: string,
+    public createdAt: Date,
+    public updatedAt: Date
+  ) {}
+}
+
+const result = await context.step(
+  'create-user',
+  async () => new User('Alice', 'alice@example.com', new Date(), new Date()),
+  {
+    serdes: createClassSerdesWithDates(User, ['createdAt', 'updatedAt'])
+  }
+);
+
+// result is properly deserialized User instance with Date objects
+console.log(result.createdAt instanceof Date); // true
+```
+
+### Complex Object Graphs
+
+TypeScript:
+
+```typescript
+import { createClassSerdes } from '@aws/durable-execution-sdk-js';
+
+class Order {
+  constructor(
+    public id: string,
+    public items: OrderItem[],
+    public customer: Customer
+  ) {}
+}
+
+class OrderItem {
+  constructor(public sku: string, public quantity: number) {}
+}
+
+class Customer {
+  constructor(public id: string, public name: string) {}
+}
+
+// Create serdes for each class
+const orderSerdes = createClassSerdes(Order);
+const itemSerdes = createClassSerdes(OrderItem);
+const customerSerdes = createClassSerdes(Customer);
+
+const result = await context.step(
+  'process-order',
+  async () => {
+    const customer = new Customer('CUST-123', 'Alice');
+    const items = [
+      new OrderItem('SKU-001', 2),
+      new OrderItem('SKU-002', 1)
+    ];
+    return new Order('ORD-456', items, customer);
+  },
+  { serdes: orderSerdes }
+);
+```
+
+## Nested Workflows
+
+### Parent-Child Workflow Pattern
+
+TypeScript:
+
+```typescript
+// Parent orchestrator
+export const orchestrator = withDurableExecution(
+  async (event, context: DurableContext) => {
+    const childFunctionArn = process.env.CHILD_FUNCTION_ARN!;
+
+    // Invoke child workflows in parallel
+    const results = await context.parallel(
+      'process-batches',
+      [
+        {
+          name: 'batch-1',
+          func: async (ctx) => ctx.invoke(
+            'process-batch-1',
+            childFunctionArn,
+            { batch: event.batches[0] }
+          )
+        },
+        {
+          name: 'batch-2',
+          func: async (ctx) => ctx.invoke(
+            'process-batch-2',
+            childFunctionArn,
+            { batch: event.batches[1] }
+          )
+        }
+      ]
+    );
+
+    return results.getResults();
+  }
+);
+
+// Child worker
+export const worker = withDurableExecution(
+  async (event, context: DurableContext) => {
+    const items = event.batch.items;
+
+    const results = await context.map(
+      'process-items',
+      items,
+      async (ctx, item) => {
+        return await ctx.step(async () => processItem(item));
+      }
+    );
+
+    return results.getResults();
+  }
+);
+```
+
+## Best Practices Summary
+
+1. Dynamic Step Naming: Use template literals for dynamic operation names
+2. Structured Logging: Log reasoning and context with each operation
+3. Error Handling: See [advanced-error-handling.md](advanced-error-handling.md) for timeout, retry, and circuit breaker patterns
+4. Completion Policies: Understand how combined constraints interact
+5. Custom Serialization: Use proper serdes for complex objects
+6. Nested Workflows: Use invoke for modular, composable architectures

--- a/plugins/aws-serverless/skills/aws-serverless-durable-functions/references/concurrent-operations.md
+++ b/plugins/aws-serverless/skills/aws-serverless-durable-functions/references/concurrent-operations.md
@@ -1,0 +1,418 @@
+# Concurrent Operations
+
+Process arrays and run operations in parallel with concurrency control.
+
+## Map Operations
+
+Process arrays with automatic concurrency control and completion policies:
+
+TypeScript:
+
+```typescript
+const items = [1, 2, 3, 4, 5];
+
+const results = await context.map(
+  'process-items',
+  items,
+  async (ctx, item, index) => {
+    return await ctx.step(`process-${index}`, async () =>
+      processItem(item)
+    );
+  },
+  {
+    maxConcurrency: 3,
+    completionConfig: {
+      minSuccessful: 4,
+      toleratedFailureCount: 1
+    }
+  }
+);
+
+results.throwIfError();
+const allResults = results.getResults();
+```
+
+Python:
+
+```python
+# Note: process is decorated with @durable_step
+from aws_durable_execution_sdk_python.config import MapConfig, CompletionConfig
+
+items = [1, 2, 3, 4, 5]
+
+def process_item(ctx: DurableContext, item: int, index: int, items: list):
+    return ctx.step(process(item), name=f'process-{index}')
+
+results = context.map(
+    inputs=items,
+    func=process_item,
+    name='process-items',
+    config=MapConfig(
+        max_concurrency=3,
+        completion_config=CompletionConfig(
+            min_successful=4,
+            tolerated_failure_count=1
+        )
+    )
+)
+
+results.throw_if_error()
+all_results = results.get_results()
+```
+
+## Parallel Operations
+
+Run heterogeneous operations concurrently:
+
+TypeScript:
+
+```typescript
+const results = await context.parallel(
+  'parallel-ops',
+  [
+    {
+      name: 'fetch-user',
+      func: async (ctx) => ctx.step(async () => fetchUser(userId))
+    },
+    {
+      name: 'fetch-orders',
+      func: async (ctx) => ctx.step(async () => fetchOrders(userId))
+    },
+    {
+      name: 'fetch-preferences',
+      func: async (ctx) => ctx.step(async () => fetchPreferences(userId))
+    }
+  ],
+  { maxConcurrency: 3 }
+);
+
+const [user, orders, preferences] = results.getResults();
+```
+
+Python:
+
+```python
+# Note: fetch_user, fetch_orders, fetch_preferences are decorated with @durable_step
+from aws_durable_execution_sdk_python.config import ParallelConfig
+
+def fetch_user_data(ctx: DurableContext):
+    return ctx.step(fetch_user(user_id))
+
+def fetch_orders_data(ctx: DurableContext):
+    return ctx.step(fetch_orders(user_id))
+
+def fetch_prefs_data(ctx: DurableContext):
+    return ctx.step(fetch_preferences(user_id))
+
+results = context.parallel(
+    [fetch_user_data, fetch_orders_data, fetch_prefs_data],
+    name='parallel-ops',
+    config=ParallelConfig(max_concurrency=3)
+)
+
+user, orders, preferences = results.get_results()
+```
+
+## Completion Policies
+
+### Minimum Successful
+
+Require a minimum number of successful operations:
+
+TypeScript:
+
+```typescript
+const results = await context.map(
+  'process-batch',
+  items,
+  async (ctx, item, index) => ctx.step(async () => process(item)),
+  {
+    completionConfig: {
+      minSuccessful: 8  // Need at least 8 successes
+    }
+  }
+);
+```
+
+### Tolerated Failures
+
+Allow a specific number of failures:
+
+TypeScript:
+
+```typescript
+const results = await context.map(
+  'process-batch',
+  items,
+  async (ctx, item, index) => ctx.step(async () => process(item)),
+  {
+    completionConfig: {
+      toleratedFailureCount: 2  // Allow up to 2 failures
+    }
+  }
+);
+```
+
+### Tolerated Failure Percentage
+
+Allow a percentage of failures:
+
+TypeScript:
+
+```typescript
+const results = await context.map(
+  'process-batch',
+  items,
+  async (ctx, item, index) => ctx.step(async () => process(item)),
+  {
+    completionConfig: {
+      toleratedFailurePercentage: 10  // Allow up to 10% failures
+    }
+  }
+);
+```
+
+Python:
+
+```python
+results = context.map(
+    inputs=items,
+    func=process_item,
+    config=MapConfig(
+        completion_config=CompletionConfig(
+            tolerated_failure_percentage=10
+        )
+    ),
+    name='process-batch'
+)
+```
+
+## Batch Result Handling
+
+### Check Status
+
+TypeScript:
+
+```typescript
+const results = await context.map('process', items, processFunc);
+
+console.log(results.status);           // 'COMPLETED' | 'FAILED'
+console.log(results.totalCount);       // Total items
+console.log(results.startedCount);     // Items started
+console.log(results.successCount);     // Successful items
+console.log(results.failureCount);     // Failed items
+console.log(results.hasFailure());     // Boolean
+```
+
+### Get Results
+
+TypeScript:
+
+```typescript
+// Get all results (throws if any failed)
+const allResults = results.getResults();
+
+// Get successful results only
+const successful = results.succeeded.map(item => item.result);
+
+// Get failed items
+const failed = results.failed.map(item => ({
+  index: item.index,
+  error: item.error
+}));
+
+// Get all items with status
+const all = results.all.map(item => ({
+  index: item.index,
+  status: item.status,
+  result: item.result,
+  error: item.error
+}));
+```
+
+### Error Handling
+
+TypeScript:
+
+```typescript
+const results = await context.map('process', items, processFunc);
+
+if (results.hasFailure()) {
+  context.logger.error('Some items failed', {
+    failureCount: results.failureCount,
+    failures: results.failed.map(f => f.index)
+  });
+
+  // Retry failed items
+  const failedItems = results.failed.map(f => items[f.index]);
+  await context.map('retry-failed', failedItems, processFunc);
+}
+```
+
+## Concurrency Control
+
+### Fixed Concurrency
+
+TypeScript:
+
+```typescript
+const results = await context.map(
+  'process',
+  items,
+  processFunc,
+  { maxConcurrency: 5 }  // Process 5 items at a time
+);
+```
+
+### Dynamic Concurrency
+
+Adjust based on item characteristics:
+
+TypeScript:
+
+```typescript
+const results = await context.map(
+  'process',
+  items,
+  async (ctx, item, index) => {
+    // Heavy items get their own processing
+    if (item.size > 1000) {
+      return await ctx.step(`heavy-${index}`, async () =>
+        processHeavy(item)
+      );
+    }
+
+    // Light items can be batched
+    return await ctx.step(`light-${index}`, async () =>
+      processLight(item)
+    );
+  },
+  { maxConcurrency: 10 }
+);
+```
+
+## Advanced Patterns
+
+### Map with Callbacks
+
+TypeScript:
+
+```typescript
+const results = await context.map(
+  'process-with-approval',
+  items,
+  async (ctx, item, index) => {
+    const processed = await ctx.step('process', async () =>
+      process(item)
+    );
+
+    const approved = await ctx.waitForCallback(
+      'approval',
+      async (callbackId) => sendApproval(item, callbackId),
+      { timeout: { hours: 24 } }
+    );
+
+    return { processed, approved };
+  },
+  { maxConcurrency: 3 }
+);
+```
+
+### Nested Map Operations
+
+TypeScript:
+
+```typescript
+const results = await context.map(
+  'process-batches',
+  batches,
+  async (ctx, batch, batchIndex) => {
+    return await ctx.map(
+      `batch-${batchIndex}`,
+      batch.items,
+      async (itemCtx, item, itemIndex) => {
+        return await itemCtx.step(async () => process(item));
+      }
+    );
+  }
+);
+```
+
+### Map with Child Contexts
+
+TypeScript:
+
+```typescript
+const results = await context.map(
+  'complex-process',
+  items,
+  async (ctx, item, index) => {
+    return await ctx.runInChildContext(`item-${index}`, async (childCtx) => {
+      const validated = await childCtx.step('validate', async () =>
+        validate(item)
+      );
+
+      await childCtx.wait({ seconds: 1 });
+
+      const processed = await childCtx.step('process', async () =>
+        process(validated)
+      );
+
+      return processed;
+    });
+  },
+  { maxConcurrency: 5 }
+);
+```
+
+## Performance Optimization
+
+### Batch Size Selection
+
+```typescript
+// Small items: Higher concurrency
+const results = await context.map(
+  'small-items',
+  smallItems,
+  processFunc,
+  { maxConcurrency: 20 }
+);
+
+// Large items: Lower concurrency
+const results = await context.map(
+  'large-items',
+  largeItems,
+  processFunc,
+  { maxConcurrency: 3 }
+);
+```
+
+### Early Termination
+
+Use completion policies to stop early:
+
+```typescript
+const results = await context.map(
+  'find-match',
+  candidates,
+  async (ctx, candidate) => {
+    return await ctx.step(async () => checkMatch(candidate));
+  },
+  {
+    completionConfig: {
+      minSuccessful: 1  // Stop after first success
+    }
+  }
+);
+```
+
+## Best Practices
+
+1. Set appropriate maxConcurrency based on downstream system capacity
+2. Use completion policies to handle partial failures gracefully
+3. Name all operations for debugging
+4. Handle batch results explicitly - check for failures
+5. Consider retry strategies for failed items
+6. Monitor concurrency limits to avoid overwhelming systems
+7. Use child contexts for complex per-item workflows
+8. Implement circuit breakers for external service calls

--- a/plugins/aws-serverless/skills/aws-serverless-durable-functions/references/deployment-iac.md
+++ b/plugins/aws-serverless/skills/aws-serverless-durable-functions/references/deployment-iac.md
@@ -1,0 +1,559 @@
+# Deployment with Infrastructure as Code
+
+Deploy durable functions using CloudFormation, CDK, or SAM.
+
+## IaC framework selection
+
+Default: CDK
+
+Override syntax:
+
+- "use CloudFormation" -> Generate YAML templates
+- "use SAM" -> Generate YAML templates
+
+When not specified, ALWAYS use CDK
+
+### Error Scenario: Unsupported IaC Framework
+
+- List detected framework
+- State: "[framework] might not support Lambda durable functions yet"
+- Suggest supported frameworks as alternatives
+
+## Requirements
+
+All durable functions require:
+
+1. DurableConfig property on the function
+2. AWSLambdaBasicDurableExecutionRolePolicy attached to execution role
+3. Qualified ARN (version or alias) for invocation
+
+## AWS CloudFormation
+
+template.yaml:
+
+```yaml
+AWSTemplateFormatVersion: '2010-09-09'
+Resources:
+  DurableFunctionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: '2012-10-17'
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: lambda.amazonaws.com
+            Action: sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicDurableExecutionRolePolicy
+
+  DurableFunction:
+    Type: AWS::Lambda::Function
+    Properties:
+      FunctionName: myDurableFunction
+      Runtime: nodejs24.x  # or python3.14
+      Handler: index.handler
+      Role: !GetAtt DurableFunctionRole.Arn
+      Code:
+        ZipFile: |
+          // Your durable function code
+      DurableConfig:
+        ExecutionTimeout: 3600        # Max execution time (seconds)
+        RetentionPeriodInDays: 7      # How long to keep execution state
+      Environment:
+        Variables:
+          LOG_LEVEL: INFO
+
+  DurableFunctionVersion:
+    Type: AWS::Lambda::Version
+    Properties:
+      FunctionName: !Ref DurableFunction
+
+  DurableFunctionAlias:
+    Type: AWS::Lambda::Alias
+    Properties:
+      FunctionName: !Ref DurableFunction
+      FunctionVersion: !GetAtt DurableFunctionVersion.Version
+      Name: prod
+
+Outputs:
+  FunctionArn:
+    Value: !GetAtt DurableFunction.Arn
+  AliasArn:
+    Value: !Ref DurableFunctionAlias
+```
+
+Deploy:
+
+```bash
+aws cloudformation deploy \
+  --template-file template.yaml \
+  --stack-name my-durable-function \
+  --capabilities CAPABILITY_IAM
+```
+
+## AWS CDK
+
+TypeScript:
+
+```typescript
+import * as cdk from 'aws-cdk-lib';
+import * as lambda from 'aws-cdk-lib/aws-lambda';
+import * as iam from 'aws-cdk-lib/aws-iam';
+
+export class DurableFunctionStack extends cdk.Stack {
+  constructor(scope: cdk.App, id: string, props?: cdk.StackProps) {
+    super(scope, id, props);
+
+    const durableFunction = new lambda.Function(this, 'DurableFunction', {
+      runtime: lambda.Runtime.NODEJS_24_X,  // or PYTHON_3_14
+      handler: 'index.handler',
+      code: lambda.Code.fromAsset('lambda'),
+      durableConfig: {
+        executionTimeout: cdk.Duration.hours(1),
+        retentionPeriod: cdk.Duration.days(7)
+      },
+      environment: {
+        LOG_LEVEL: 'INFO'
+      }
+    });
+
+    // CDK automatically adds checkpoint permissions when durableConfig is set
+
+    // Create version and alias
+    const version = durableFunction.currentVersion;
+    const alias = new lambda.Alias(this, 'ProdAlias', {
+      aliasName: 'prod',
+      version: version
+    });
+
+    // Output the qualified ARN
+    new cdk.CfnOutput(this, 'FunctionAliasArn', {
+      value: alias.functionArn
+    });
+  }
+}
+```
+
+Deploy:
+
+```bash
+cdk deploy
+```
+
+### CDK Custom Log Group Management
+
+Best Practice: Explicitly create and manage CloudWatch Log Groups for better control over retention, cleanup, and costs.
+
+```typescript
+import * as logs from 'aws-cdk-lib/aws-logs';
+import * as iam from 'aws-cdk-lib/aws-iam';
+
+// 1. Create explicit log group
+const functionLogGroup = new logs.LogGroup(this, 'DurableFunctionLogGroup', {
+  logGroupName: '/aws/lambda/myDurableFunction',
+  retention: logs.RetentionDays.ONE_WEEK,
+  removalPolicy: cdk.RemovalPolicy.DESTROY,  // Delete on stack destroy
+});
+
+// 2. Link to function
+const durableFunction = new lambda.Function(this, 'DurableFunction', {
+  runtime: lambda.Runtime.NODEJS_24_X,
+  handler: 'index.handler',
+  code: lambda.Code.fromAsset('lambda'),
+  logGroup: functionLogGroup,  // Link to managed log group
+  durableConfig: {
+    executionTimeout: cdk.Duration.hours(1),
+    retentionPeriod: cdk.Duration.days(7)
+  }
+});
+
+// 3. Add durable execution policy (required with explicit log groups)
+durableFunction.role?.addManagedPolicy(
+  iam.ManagedPolicy.fromAwsManagedPolicyName(
+    'service-role/AWSLambdaBasicDurableExecutionRolePolicy'
+  )
+);
+```
+
+Benefits:
+
+- Explicit Cleanup: `removalPolicy: cdk.RemovalPolicy.DESTROY` ensures log groups are deleted when stack is destroyed
+- Custom Retention: Set retention periods matching compliance/debugging needs
+- Predictable Naming: Control exact log group name
+- Cost Control: Avoid accumulating costs from orphaned log groups
+
+When to use:
+
+- [OK] Production environments where log retention policies must be enforced
+- [OK] Development/test environments where automatic cleanup saves costs
+- [OK] Multi-function stacks where consistent log management is needed
+
+Important: Don't forget to add `AWSLambdaBasicDurableExecutionRolePolicy` when using explicit log groups.
+
+## AWS SAM
+
+template.yaml:
+
+```yaml
+AWSTemplateFormatVersion: '2010-09-09'
+Transform: AWS::Serverless-2016-10-31
+
+Globals:
+  Function:
+    Timeout: 900
+    MemorySize: 512
+
+Resources:
+  DurableFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      FunctionName: myDurableFunction
+      Runtime: nodejs24.x  # or python3.14
+      Handler: index.handler
+      CodeUri: ./src
+      DurableConfig:
+        ExecutionTimeout: 3600
+        RetentionPeriodInDays: 7
+      Policies:
+        - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicDurableExecutionRolePolicy
+      AutoPublishAlias: prod
+      Environment:
+        Variables:
+          LOG_LEVEL: INFO
+
+Outputs:
+  FunctionArn:
+    Value: !GetAtt DurableFunction.Arn
+  AliasArn:
+    Value: !Ref DurableFunction.Alias
+```
+
+Deploy:
+
+```bash
+sam build
+sam deploy --guided
+```
+
+## Durable Invokes
+
+For functions that invoke other durable functions:
+
+CloudFormation:
+
+```yaml
+DurableFunctionRole:
+  Type: AWS::IAM::Role
+  Properties:
+    AssumeRolePolicyDocument:
+      Version: '2012-10-17'
+      Statement:
+        - Effect: Allow
+          Principal:
+            Service: lambda.amazonaws.com
+          Action: sts:AssumeRole
+    ManagedPolicyArns:
+      - arn:aws:iam::aws:policy/service-role/AWSLambdaBasicDurableExecutionRolePolicy
+    Policies:
+      - PolicyName: InvokeOtherFunctions
+        PolicyDocument:
+          Version: '2012-10-17'
+          Statement:
+            - Effect: Allow
+              Action:
+                - lambda:InvokeFunction
+              Resource:
+                - !GetAtt TargetFunction.Arn
+                - !Sub '${TargetFunction.Arn}:*'  # For versions/aliases
+```
+
+CDK:
+
+```typescript
+const targetFunction = new lambda.Function(this, 'TargetFunction', {
+  // ... configuration
+});
+
+const orchestratorFunction = new lambda.Function(this, 'OrchestratorFunction', {
+  // ... configuration with durableConfig
+});
+
+// Grant invoke permission
+targetFunction.grantInvoke(orchestratorFunction);
+```
+
+## External Callbacks
+
+For external systems to send callbacks:
+
+IAM Policy:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "lambda:SendDurableExecutionCallbackSuccess",
+        "lambda:SendDurableExecutionCallbackFailure",
+        "lambda:SendDurableExecutionCallbackHeartbeat"
+      ],
+      "Resource": "arn:aws:lambda:us-east-1:123456789012:function:myDurableFunction:*"
+    }
+  ]
+}
+```
+
+## Environment Configuration
+
+Development:
+
+```yaml
+DurableFunction:
+  Type: AWS::Lambda::Function
+  Properties:
+    DurableConfig:
+      ExecutionTimeout: 900          # 15 minutes
+      RetentionPeriodInDays: 1       # Short retention
+    Environment:
+      Variables:
+        LOG_LEVEL: DEBUG
+        ENVIRONMENT: development
+```
+
+Production:
+
+```yaml
+DurableFunction:
+  Type: AWS::Lambda::Function
+  Properties:
+    DurableConfig:
+      ExecutionTimeout: 86400        # 24 hours
+      RetentionPeriodInDays: 30      # Long retention
+    Environment:
+      Variables:
+        LOG_LEVEL: INFO
+        ENVIRONMENT: production
+```
+
+## Multi-Environment Deployment
+
+CDK with Stages:
+
+```typescript
+const app = new cdk.App();
+
+new DurableFunctionStack(app, 'DurableFunction-Dev', {
+  env: { account: '123456789012', region: 'us-east-1' },
+  stage: 'dev',
+  durableConfig: {
+    executionTimeout: cdk.Duration.minutes(15),
+    retentionPeriod: cdk.Duration.days(1)
+  }
+});
+
+new DurableFunctionStack(app, 'DurableFunction-Prod', {
+  env: { account: '123456789012', region: 'us-east-1' },
+  stage: 'prod',
+  durableConfig: {
+    executionTimeout: cdk.Duration.hours(24),
+    retentionPeriod: cdk.Duration.days(30)
+  }
+});
+```
+
+## Invocation Examples
+
+### Critical Requirements
+
+Warning: Important Invocation Rules:
+
+1. Qualified Function Name Required: You MUST provide a qualified function name with version, alias, or `:$LATEST`
+2. Idempotency with durable-execution-name: Use this parameter to ensure the same execution name always refers to the same execution
+3. Binary Format: Use `--cli-binary-format raw-in-base64-out` to avoid base64 encoding issues
+
+### Synchronous Invocation (RequestResponse)
+
+Synchronous invocation waits for the function to complete and returns the result immediately. Suitable for short workflows.
+
+```bash
+aws lambda invoke \
+  --function-name 'myDurableFunction:$LATEST' \
+  --invocation-type RequestResponse \
+  --durable-execution-name "execution-123" \
+  --payload '{"userId":"12345","action":"process"}' \
+  --cli-binary-format raw-in-base64-out \
+  --output json \
+  response.json
+
+# View the response
+cat response.json
+```
+
+When to use RequestResponse:
+
+- Short-running workflows (under 15 minutes total)
+- When you need the result immediately
+- Interactive applications requiring synchronous responses
+
+### Asynchronous Invocation (Event)
+
+Asynchronous invocation returns immediately with the execution ID. Ideal for long-running workflows.
+
+```bash
+aws lambda invoke \
+  --function-name 'myDurableFunction:$LATEST' \
+  --invocation-type Event \
+  --durable-execution-name "background-task-456" \
+  --payload '{"orderId":"ORD-789","amount":99.99}' \
+  --cli-binary-format raw-in-base64-out \
+  --output json \
+  response.json
+
+# Response contains execution ID, not the result
+cat response.json
+```
+
+When to use Event:
+
+- Long-running workflows (hours, days, or longer)
+- Background processing tasks
+- Workflows with wait operations or human-in-the-loop steps
+
+### Idempotency with durable-execution-name
+
+The `--durable-execution-name` parameter ensures that the same execution is never created twice:
+
+```bash
+# First invocation - creates new execution
+aws lambda invoke \
+  --function-name 'myDurableFunction:$LATEST' \
+  --invocation-type RequestResponse \
+  --durable-execution-name "order-processing-ORD-123" \
+  --payload '{"orderId":"ORD-123"}' \
+  --cli-binary-format raw-in-base64-out \
+  response.json
+
+# Second invocation with same execution name - returns existing execution result
+aws lambda invoke \
+  --function-name 'myDurableFunction:$LATEST' \
+  --invocation-type RequestResponse \
+  --durable-execution-name "order-processing-ORD-123" \
+  --payload '{"orderId":"ORD-123"}' \
+  --cli-binary-format raw-in-base64-out \
+  response.json
+```
+
+### Using Specific Function Versions
+
+Durable functions require qualified ARNs (version, alias, or `$LATEST`):
+
+```bash
+# [OK] Invoke specific version
+aws lambda invoke \
+  --function-name 'myDurableFunction:1' \
+  --invocation-type RequestResponse \
+  --durable-execution-name "versioned-exec-1" \
+  --payload '{"test":"data"}' \
+  --cli-binary-format raw-in-base64-out \
+  response.json
+
+# [OK] Invoke using alias
+aws lambda invoke \
+  --function-name 'myDurableFunction:production' \
+  --invocation-type RequestResponse \
+  --durable-execution-name "prod-exec-1" \
+  --payload '{"test":"data"}' \
+  --cli-binary-format raw-in-base64-out \
+  response.json
+
+# [Wrong] Unqualified - will fail!
+aws lambda invoke \
+  --function-name 'myDurableFunction' \
+  --payload '{"test":"data"}' \
+  response.json
+# Error: Durable execution requires qualified function identifier
+```
+
+## Monitoring and Observability
+
+CloudWatch Logs:
+
+```yaml
+DurableFunction:
+  Type: AWS::Lambda::Function
+  Properties:
+    # ... other properties
+    LoggingConfig:
+      LogFormat: JSON
+      LogGroup: !Ref DurableFunctionLogGroup
+
+DurableFunctionLogGroup:
+  Type: AWS::Logs::LogGroup
+  Properties:
+    LogGroupName: /aws/lambda/myDurableFunction
+    RetentionInDays: 7
+```
+
+CloudWatch Alarms:
+
+```yaml
+DurableFunctionErrorAlarm:
+  Type: AWS::CloudWatch::Alarm
+  Properties:
+    AlarmName: DurableFunction-Errors
+    MetricName: Errors
+    Namespace: AWS/Lambda
+    Statistic: Sum
+    Period: 300
+    EvaluationPeriods: 1
+    Threshold: 5
+    ComparisonOperator: GreaterThanThreshold
+    Dimensions:
+      - Name: FunctionName
+        Value: !Ref DurableFunction
+```
+
+## Best Practices
+
+1. Always use qualified ARNs (versions or aliases) for invocation
+2. Set appropriate execution timeouts based on workflow duration
+3. Configure retention periods to balance cost and debugging needs
+4. Use aliases for production deployments
+5. Grant minimal IAM permissions - only what's needed
+6. Enable structured logging (JSON format)
+7. Set up CloudWatch alarms for errors and throttles
+8. Use environment variables for configuration
+9. Deploy to multiple environments (dev, staging, prod)
+10. Version your infrastructure code alongside function code
+
+## Common issues
+
+### Function Not Durable
+
+Issue: Function executes but doesn't checkpoint.
+
+Solution: Verify `DurableConfig` is set and role has checkpoint permissions.
+
+### Invocation Fails with "Unqualified ARN"
+
+Issue: `InvalidParameterValueException: Durable execution requires qualified function identifier`
+
+Solution: Use version, alias, or `$LATEST`:
+
+```bash
+# [OK] Correct
+aws lambda invoke --function-name myFunction:prod ...
+aws lambda invoke --function-name myFunction:1 ...
+
+# [Wrong] Wrong
+aws lambda invoke --function-name myFunction ...
+```
+
+### Checkpoint Permission Denied
+
+Issue: `AccessDeniedException: User is not authorized to perform: lambda:CheckpointDurableExecution`
+
+Solution: Add `AWSLambdaBasicDurableExecutionRolePolicy` to execution role.

--- a/plugins/aws-serverless/skills/aws-serverless-durable-functions/references/error-handling.md
+++ b/plugins/aws-serverless/skills/aws-serverless-durable-functions/references/error-handling.md
@@ -1,0 +1,430 @@
+# Error Handling and Retry Strategies
+
+Comprehensive error handling patterns for durable functions.
+
+TypeScript:
+
+```typescript
+import { createRetryStrategy, JitterStrategy } from '@aws/durable-execution-sdk-js';
+
+// Exponential backoff with jitter
+const result = await context.step(
+  'api-call',
+  async () => callAPI(),
+  {
+    retryStrategy: createRetryStrategy({
+      maxAttempts: 5,
+      initialDelay: { seconds: 1 },
+      maxDelay: { seconds: 60 },
+      backoffRate: 2.0,
+      jitter: JitterStrategy.FULL
+    })
+  }
+);
+
+// Fixed delay
+const result = await context.step(
+  'simple-retry',
+  async () => operation(),
+  {
+    retryStrategy: createRetryStrategy({
+      maxAttempts: 3,
+      delay: { seconds: 5 },
+      backoffRate: 1
+    })
+  }
+);
+```
+
+Python:
+
+```python
+from aws_durable_execution_sdk_python.retries import RetryStrategyConfig, create_retry_strategy, JitterStrategy
+
+retry_config = RetryStrategyConfig(
+    max_attempts=5,
+    initial_delay=Duration.from_seconds(1),
+    max_delay=Duration.from_seconds(60),
+    backoff_rate=2.0,
+    jitter_strategy=JitterStrategy.FULL
+)
+
+result = context.step(
+    func=api_call(),
+    config=StepConfig(retry_strategy=create_retry_strategy(retry_config))
+)
+```
+
+## Custom Retry Logic
+
+TypeScript:
+
+```typescript
+const result = await context.step(
+  'custom-retry',
+  async () => riskyOperation(),
+  {
+    retryStrategy: (error, attemptCount) => {
+      // Don't retry client errors
+      if (error.statusCode >= 400 && error.statusCode < 500) {
+        return { shouldRetry: false };
+      }
+
+      // Retry server errors with exponential backoff
+      if (attemptCount < 5) {
+        return {
+          shouldRetry: true,
+          delay: { seconds: Math.pow(2, attemptCount) }
+        };
+      }
+
+      return { shouldRetry: false };
+    }
+  }
+);
+```
+
+Python:
+
+```python
+def custom_retry(error: Exception, attempt: int) -> RetryDecision:
+    if hasattr(error, 'status_code') and 400 <= error.status_code < 500:
+        return RetryDecision(should_retry=False)
+
+    if attempt < 5:
+        return RetryDecision(
+            should_retry=True,
+            delay=Duration.from_seconds(2  attempt)
+        )
+
+    return RetryDecision(should_retry=False)
+```
+
+## Error Classification
+
+### Retryable vs Non-Retryable
+
+TypeScript:
+
+```typescript
+class ValidationError extends Error {
+  name = 'ValidationError';
+}
+
+class NetworkError extends Error {
+  name = 'NetworkError';
+}
+
+const result = await context.step(
+  'selective-retry',
+  async () => operation(),
+  {
+    retryStrategy: createRetryStrategy({
+      maxAttempts: 3,
+      retryableErrorTypes: ['NetworkError', 'TimeoutError'],
+      // ValidationError won't be retried
+    })
+  }
+);
+```
+
+Python:
+
+```python
+retry_config = RetryStrategyConfig(
+    max_attempts=3,
+    retryable_error_types=[NetworkError, TimeoutError]
+)
+```
+
+## Saga Pattern
+
+Implement compensating transactions for distributed workflows:
+
+TypeScript:
+
+```typescript
+export const handler = withDurableExecution(async (event, context: DurableContext) => {
+  const compensations: Array<{
+    name: string;
+    fn: () => Promise<void>;
+  }> = [];
+
+  try {
+    // Step 1: Reserve inventory
+    const reservation = await context.step('reserve-inventory', async () =>
+      inventoryService.reserve(event.items)
+    );
+    compensations.push({
+      name: 'cancel-reservation',
+      fn: () => inventoryService.cancelReservation(reservation.id)
+    });
+
+    // Step 2: Charge payment
+    const payment = await context.step('charge-payment', async () =>
+      paymentService.charge(event.paymentMethod, event.amount)
+    );
+    compensations.push({
+      name: 'refund-payment',
+      fn: () => paymentService.refund(payment.id)
+    });
+
+    // Step 3: Create shipment
+    const shipment = await context.step('create-shipment', async () =>
+      shippingService.createShipment(event.address, event.items)
+    );
+    compensations.push({
+      name: 'cancel-shipment',
+      fn: () => shippingService.cancelShipment(shipment.id)
+    });
+
+    return { success: true, orderId: shipment.orderId };
+
+  } catch (error) {
+    context.logger.error('Order failed, executing compensations', error);
+
+    // Execute compensations in reverse order
+    for (const comp of compensations.reverse()) {
+      try {
+        await context.step(comp.name, async () => comp.fn());
+      } catch (compError) {
+        context.logger.error(`Compensation ${comp.name} failed`, compError);
+        // Continue with other compensations
+      }
+    }
+
+    throw error;
+  }
+});
+```
+
+Python:
+
+```python
+# Note: All service methods are decorated with @durable_step
+@durable_execution
+def handler(event: dict, context: DurableContext) -> dict:
+    compensations = []
+
+    try:
+        # Step 1: Reserve inventory
+        reservation = context.step(reserve_inventory(event['items']))
+        compensations.append(('cancel-reservation', cancel_reservation, reservation['id']))
+
+        # Step 2: Charge payment
+        payment = context.step(charge_payment(event['payment_method'], event['amount']))
+        compensations.append(('refund-payment', refund_payment, payment['id']))
+
+        # Step 3: Create shipment
+        shipment = context.step(create_shipment(event['address'], event['items']))
+
+        return {'success': True, 'order_id': shipment['order_id']}
+
+    except Exception as error:
+        context.logger.error('Order failed, executing compensations', error)
+
+        for name, comp_step, resource_id in reversed(compensations):
+            try:
+                context.step(comp_step(resource_id))
+            except Exception as comp_error:
+                context.logger.error(f'Compensation {name} failed', comp_error)
+
+        raise error
+```
+
+## Unrecoverable Errors
+
+Mark errors as unrecoverable to stop execution immediately:
+
+TypeScript:
+
+```typescript
+import { UnrecoverableInvocationError } from '@aws/durable-execution-sdk-js';
+
+export const handler = withDurableExecution(async (event, context: DurableContext) => {
+  const user = await context.step('fetch-user', async () => {
+    const user = await fetchUser(event.userId);
+
+    if (!user) {
+      // Stop execution immediately - no retry
+      throw new UnrecoverableInvocationError('User not found');
+    }
+
+    return user;
+  });
+
+  // Continue processing...
+});
+```
+
+Python:
+
+```python
+from aws_durable_execution_sdk_python.exceptions import ExecutionError
+
+@durable_execution
+def handler(event: dict, context: DurableContext) -> dict:
+    @durable_step
+    def fetch_user_step(step_ctx: StepContext):
+        user = fetch_user(event['user_id'])
+        if not user:
+            # Stop execution immediately -- permanent failure, no retry
+            raise ExecutionError('User not found')
+        return user
+
+    user = context.step(fetch_user_step())
+    # Continue processing...
+```
+
+The SDK provides these exception types for different failure scenarios:
+
+| Exception                | Retryable       | Use case                                                    |
+| ------------------------ | --------------- | ----------------------------------------------------------- |
+| `ExecutionError`         | No              | Permanent business logic failures (returns FAILED status)   |
+| `InvocationError`        | Yes (by Lambda) | Transient infrastructure issues (Lambda retries invocation) |
+| `CallbackError`          | No              | Callback handling failures                                  |
+| `DurableExecutionsError` | --               | Base class for all SDK exceptions                           |
+
+## Error Determinism
+
+Ensure errors are deterministic across replays:
+
+TypeScript:
+
+```typescript
+class CustomBusinessError extends Error {
+  constructor(
+    message: string,
+    public readonly code: string,
+    public readonly details: any
+  ) {
+    super(message);
+    this.name = 'CustomBusinessError';
+  }
+}
+
+const result = await context.step('validate', async () => {
+  if (!isValid(data)) {
+    // [OK] Deterministic error
+    throw new CustomBusinessError(
+      'Validation failed',
+      'INVALID_DATA',
+      { field: 'email', reason: 'invalid format' }
+    );
+  }
+
+  return processData(data);
+});
+```
+
+## Circuit Breaker Pattern
+
+TypeScript:
+
+```typescript
+class CircuitBreaker {
+  private failures = 0;
+  private lastFailureTime = 0;
+  private readonly threshold = 5;
+  private readonly timeout = 60000; // 1 minute
+
+  async execute<T>(fn: () => Promise<T>): Promise<T> {
+    if (this.isOpen()) {
+      throw new Error('Circuit breaker is open');
+    }
+
+    try {
+      const result = await fn();
+      this.onSuccess();
+      return result;
+    } catch (error) {
+      this.onFailure();
+      throw error;
+    }
+  }
+
+  private isOpen(): boolean {
+    if (this.failures >= this.threshold) {
+      const elapsed = Date.now() - this.lastFailureTime;
+      return elapsed < this.timeout;
+    }
+    return false;
+  }
+
+  private onSuccess() {
+    this.failures = 0;
+  }
+
+  private onFailure() {
+    this.failures++;
+    this.lastFailureTime = Date.now();
+  }
+}
+
+// Use in handler
+const breaker = new CircuitBreaker();
+
+export const handler = withDurableExecution(async (event, context: DurableContext) => {
+  const result = await context.step('api-call', async () => {
+    return await breaker.execute(() => callExternalAPI());
+  });
+
+  return result;
+});
+```
+
+## Partial Failure Handling
+
+TypeScript:
+
+```typescript
+export const handler = withDurableExecution(async (event, context: DurableContext) => {
+  const results = await context.map(
+    'process-items',
+    event.items,
+    async (ctx, item, index) => {
+      return await ctx.step(async () => processItem(item));
+    },
+    {
+      completionConfig: {
+        toleratedFailurePercentage: 10  // Allow 10% failures
+      }
+    }
+  );
+
+  if (results.hasFailure()) {
+    // Log failures but continue
+    context.logger.warn('Some items failed', {
+      failureCount: results.failureCount,
+      failures: results.failed.map(f => ({
+        index: f.index,
+        error: f.error?.message
+      }))
+    });
+
+    // Store failed items for later retry
+    await context.step('store-failures', async () => {
+      const failedItems = results.failed.map(f => event.items[f.index]);
+      return await storeFailedItems(failedItems);
+    });
+  }
+
+  return {
+    totalProcessed: results.successCount,
+    failed: results.failureCount
+  };
+});
+```
+
+## Best Practices
+
+1. Use appropriate retry strategies - exponential backoff for most cases
+2. Classify errors correctly - distinguish retryable from non-retryable
+3. Implement compensating transactions for distributed workflows
+4. Make errors deterministic - same input produces same error
+5. Use unrecoverable errors to stop execution early when appropriate
+6. Log errors with context using `context.logger`
+7. Handle partial failures gracefully in batch operations
+8. Implement circuit breakers for external service calls
+9. Test error scenarios thoroughly with test runners
+10. Monitor error rates and adjust retry strategies accordingly

--- a/plugins/aws-serverless/skills/aws-serverless-durable-functions/references/getting-started.md
+++ b/plugins/aws-serverless/skills/aws-serverless-durable-functions/references/getting-started.md
@@ -1,0 +1,413 @@
+# Getting Started with AWS Lambda durable functions
+
+Quick start guide for building your first durable function.
+
+## Language selection
+
+Default: TypeScript
+
+Override syntax:
+
+- "use Python" -> Generate Python code
+- "use JavaScript" -> Generate JavaScript code
+
+When not specified, ALWAYS use TypeScript
+
+### Error Scenarios: Unsupported Language
+
+- List detected language
+- State: "Durable Execution SDK is not yet available for [framework]"
+- Suggest supported languages as alternatives
+
+## Basic Handler
+
+TypeScript:
+
+```typescript
+import { withDurableExecution, DurableContext } from '@aws/durable-execution-sdk-js';
+
+export const handler = withDurableExecution(async (event, context: DurableContext) => {
+  // Execute a step with automatic retry
+  const userData = await context.step('fetch-user', async () =>
+    fetchUserFromDB(event.userId)
+  );
+
+  // Wait without compute charges
+  await context.wait({ seconds: 5 });
+
+  // Process in another step
+  const result = await context.step('process', async () =>
+    processUser(userData)
+  );
+
+  return { success: true, data: result };
+});
+```
+
+Python:
+
+```python
+from aws_durable_execution_sdk_python import durable_execution, DurableContext, durable_step, StepContext
+from aws_durable_execution_sdk_python.config import Duration
+
+@durable_step
+def fetch_user(step_ctx: StepContext, user_id: str):
+    return fetch_user_from_db(user_id)
+
+@durable_step
+def process_user_data(step_ctx: StepContext, user_data: dict):
+    return process_user(user_data)
+
+@durable_execution
+def handler(event: dict, context: DurableContext) -> dict:
+    user_data = context.step(fetch_user(event['userId']))
+    context.wait(duration=Duration.from_seconds(5))
+    result = context.step(process_user_data(user_data))
+    return {'success': True, 'data': result}
+```
+
+## Common Patterns
+
+### Multi-Step Workflow
+
+TypeScript:
+
+```typescript
+export const handler = withDurableExecution(async (event, context: DurableContext) => {
+  const validated = await context.step('validate', async () =>
+    validateInput(event)
+  );
+
+  const processed = await context.step('process', async () =>
+    processData(validated)
+  );
+
+  await context.wait('cooldown', { seconds: 30 });
+
+  await context.step('notify', async () =>
+    sendNotification(processed)
+  );
+
+  return { success: true };
+});
+```
+
+### GenAI Agent (Agentic Loop)
+
+TypeScript:
+
+```typescript
+export const handler = withDurableExecution(async (event, context: DurableContext) => {
+  const messages = [{ role: 'user', content: event.prompt }];
+
+  while (true) {
+    const { response, tool } = await context.step('invoke-model', async () =>
+      invokeAIModel(messages)
+    );
+
+    if (tool == null) return response;
+
+    const toolResult = await context.step(`tool-${tool.name}`, async () =>
+      executeTool(tool, response)
+    );
+
+    messages.push({ role: 'assistant', content: toolResult });
+  }
+});
+```
+
+Python:
+
+```python
+# Note: invoke_ai_model and execute_tool are decorated with @durable_step
+@durable_execution
+def handler(event: dict, context: DurableContext) -> str:
+    messages = [{"role": "user", "content": event["prompt"]}]
+
+    while True:
+        result = context.step(invoke_ai_model(messages))
+
+        if result.get("tool") is None:
+            return result["response"]
+
+        tool = result["tool"]
+        tool_result = context.step(execute_tool(tool, result["response"]))
+        messages.append({"role": "assistant", "content": tool_result})
+```
+
+### Human-in-the-Loop Approval
+
+TypeScript:
+
+```typescript
+export const handler = withDurableExecution(async (event, context: DurableContext) => {
+  const plan = await context.step('generate-plan', async () =>
+    generatePlan(event)
+  );
+
+  const answer = await context.waitForCallback(
+    'wait-for-approval',
+    async (callbackId) => sendApprovalEmail(event.approverEmail, plan, callbackId),
+    { timeout: { hours: 24 } }
+  );
+
+  if (answer === 'APPROVED') {
+    await context.step('execute', async () => performAction(plan));
+    return { status: 'completed' };
+  }
+
+  return { status: 'rejected' };
+});
+```
+
+Python:
+
+```python
+from aws_durable_execution_sdk_python.config import WaitForCallbackConfig
+
+@durable_execution
+def handler(event: dict, context: DurableContext) -> dict:
+    # Note: generate_plan and perform_action are decorated with @durable_step
+    plan = context.step(generate_plan(event))
+
+    # Wait for external approval
+    def submit_approval(callback_id: str, ctx):
+        send_approval_email(event['approver_email'], plan, callback_id)
+
+    answer = context.wait_for_callback(
+        submitter=submit_approval,
+        name='wait-for-approval',
+        config=WaitForCallbackConfig(timeout=Duration.from_hours(24))
+    )
+
+    if answer == 'APPROVED':
+        context.step(perform_action(plan))
+        return {'status': 'completed'}
+
+    return {'status': 'rejected'}
+```
+
+### Saga Pattern (Compensating Transactions)
+
+TypeScript:
+
+```typescript
+export const handler = withDurableExecution(async (event, context: DurableContext) => {
+  const compensations: Array<{ name: string; fn: () => Promise<void> }> = [];
+
+  try {
+    await context.step('book-flight', async () => flightClient.book(event));
+    compensations.push({
+      name: 'cancel-flight',
+      fn: () => flightClient.cancel(event)
+    });
+
+    await context.step('book-hotel', async () => hotelClient.book(event));
+    compensations.push({
+      name: 'cancel-hotel',
+      fn: () => hotelClient.cancel(event)
+    });
+
+    return { success: true };
+  } catch (error) {
+    for (const comp of compensations.reverse()) {
+      await context.step(comp.name, async () => comp.fn());
+    }
+    throw error;
+  }
+});
+```
+
+## Project Structure
+
+### TypeScript
+
+```
+my-durable-function/
++-- src/
+|   +-- handler.ts              # Main handler
+|   +-- steps/                  # Step functions
+|   |   +-- validate.ts
+|   |   +-- process.ts
+|   +-- utils/                  # Utilities
+|       +-- retry-strategies.ts
++-- tests/
+|   +-- handler.test.ts         # Tests with LocalDurableTestRunner
++-- infrastructure/
+|   +-- template.yaml           # SAM/CloudFormation
++-- eslint.config.js            # ESLint configuration
++-- jest.config.js              # Jest configuration
++-- tsconfig.json               # TypeScript configuration
++-- package.json
+```
+
+### Python
+
+```
+my-durable-function/
++-- src/
+|   +-- handler.py              # Main handler
+|   +-- steps/                  # Step functions
+|   |   +-- __init__.py
+|   |   +-- validate.py
+|   |   +-- process.py
+|   +-- utils/
+|       +-- retry_strategies.py
++-- tests/
+|   +-- test_handler.py         # Tests with DurableFunctionTestRunner
++-- infrastructure/
+|   +-- template.yaml           # SAM/CloudFormation
++-- pyproject.toml              # Project configuration
+```
+
+## ESLint Plugin Setup
+
+Install the ESLint plugin to catch common durable function mistakes at development time:
+
+```bash
+npm install --save-dev @aws/durable-execution-sdk-js-eslint-plugin
+```
+
+### Option A: Flat Config (eslint.config.js)
+
+```javascript
+import durableExecutionPlugin from '@aws/durable-execution-sdk-js-eslint-plugin';
+
+export default [
+  {
+    plugins: {
+      '@aws/durable-execution-sdk-js': durableExecutionPlugin,
+    },
+    rules: {
+      '@aws/durable-execution-sdk-js/no-nested-durable-operations': 'error',
+    },
+  },
+];
+```
+
+### Option B: Recommended Config
+
+```javascript
+import durableExecutionPlugin from '@aws/durable-execution-sdk-js-eslint-plugin';
+
+export default [
+  durableExecutionPlugin.configs.recommended,
+  // Your other configs...
+];
+```
+
+### Option C: Legacy .eslintrc.json
+
+```json
+{
+  "plugins": ["@aws/durable-execution-sdk-js-eslint-plugin"],
+  "extends": ["plugin:@aws/durable-execution-sdk-js-eslint-plugin/recommended"],
+  "rules": {
+    "@aws/durable-execution-sdk-js-eslint-plugin/no-nested-durable-operations": "error"
+  }
+}
+```
+
+What the plugin catches:
+
+- Nested durable operations inside step functions
+- Incorrect usage of durable context outside handler
+- Common replay model violations
+
+## Jest Configuration
+
+jest.config.js:
+
+```javascript
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  roots: ['<rootDir>/src'],
+  testMatch: ['/*.test.ts'],
+  transform: {
+    '^.+\\.ts$': 'ts-jest',
+  },
+  collectCoverageFrom: [
+    'src//*.ts',
+    '!src//*.d.ts',
+  ],
+};
+```
+
+Key Configuration:
+
+- `preset: 'ts-jest'` - Essential for TypeScript support
+- `transform` - Maps .ts files to ts-jest transformer
+- `testMatch` - Specifies test file patterns
+
+## Python Project Setup
+
+Add `aws-durable-execution-sdk-python-testing` to your dev/test dependencies in pyproject.toml.
+
+## Development Workflow
+
+### TypeScript
+
+1. Write handler with durable operations
+2. Test locally with `LocalDurableTestRunner`
+3. Validate replay rules (no non-deterministic code outside steps)
+4. Deploy with qualified ARN (version or alias)
+5. Monitor execution state and logs
+
+### Python
+
+1. Write handler with `@durable_execution` decorator
+2. Test locally with `DurableFunctionTestRunner` and pytest
+3. Validate replay rules (no non-deterministic code outside steps)
+4. Deploy with qualified ARN (version or alias)
+5. Monitor execution state and logs
+
+## Key Concepts
+
+- Steps: Atomic operations with automatic retry and checkpointing
+- Waits: Suspend execution without compute charges (up to 1 year)
+- Child Contexts: Group multiple durable operations
+- Callbacks: Wait for external systems to respond
+- Map/Parallel: Process arrays or run operations concurrently
+
+## Setup Checklist
+
+When starting a new durable function project:
+
+### TypeScript
+
+- [ ] Install dependencies (`@aws/durable-execution-sdk-js`, testing & eslint packages)
+- [ ] Create `jest.config.js` with ts-jest preset
+- [ ] Configure `tsconfig.json` with proper module resolution
+- [ ] Set up ESLint with durable execution plugin
+- [ ] Create handler with `withDurableExecution` wrapper
+- [ ] Write tests using `LocalDurableTestRunner`
+- [ ] Use `skipTime: true` for fast test execution
+- [ ] Verify TypeScript compilation: `npx tsc --noEmit`
+- [ ] Run tests to confirm setup: `npm test`
+- [ ] Review replay model rules (no non-deterministic code outside steps)
+
+### Python
+
+- [ ] Install `aws-durable-execution-sdk-python`
+- [ ] Install `aws-durable-execution-sdk-python-testing` and `pytest` for testing
+- [ ] Create handler with `@durable_execution` decorator
+- [ ] Define step functions with `@durable_step` decorator
+- [ ] Write tests using `DurableFunctionTestRunner` class
+- [ ] Run tests: `pytest`
+- [ ] Review replay model rules (no non-deterministic code outside steps)
+
+## Error Scenarios
+
+### Unsupported Language
+
+- List detected language
+- State: "Durable Execution SDK is not yet available for [language]"
+- List supported languages as alternatives
+
+## Next Steps
+
+- Review replay-model-rules.md to avoid common pitfalls
+- Explore step-operations.md for retry strategies
+- Learn wait-operations.md for external integrations
+- Check testing-patterns.md for comprehensive testing

--- a/plugins/aws-serverless/skills/aws-serverless-durable-functions/references/replay-model-rules.md
+++ b/plugins/aws-serverless/skills/aws-serverless-durable-functions/references/replay-model-rules.md
@@ -1,0 +1,310 @@
+# Replay Model Rules - CRITICAL
+
+The replay model is the foundation of durable functions. Violations cause subtle, hard-to-debug issues. Read this carefully.
+
+## How Replay Works
+
+Durable functions use a "checkpoint and replay" execution model:
+
+1. Code runs from the beginning on every invocation
+2. Steps that already completed return their checkpointed results WITHOUT re-executing
+3. Code OUTSIDE steps executes again on every replay
+4. New steps execute when reached
+
+Example:
+
+```typescript
+// First execution: Runs lines 1-5
+// After wait: Runs lines 1-5 again (line 2 returns cached result)
+const data = await context.step('fetch', async () => fetchAPI());  // Line 2: Executes once, cached
+await context.wait({ seconds: 60 });                                // Line 3: Waits
+const result = await context.step('process', async () => process(data)); // Line 5: Executes after wait
+```
+
+## Rule 1: Deterministic Code Outside Steps
+
+ALL code outside steps MUST produce the same result on every replay.
+
+### [Wrong] WRONG - Non-Deterministic Outside Steps
+
+TypeScript:
+
+```typescript
+// These values change on each replay!
+const id = uuid.v4();                    // Different UUID each time
+const timestamp = Date.now();            // Different timestamp each time
+const random = Math.random();            // Different random number
+const now = new Date();                  // Different date each time
+
+await context.step('save', async () => saveData({ id, timestamp }));
+```
+
+Python:
+
+```python
+# These values change on each replay!
+id = str(uuid.uuid4())                   # Different UUID each time
+timestamp = time.time()                  # Different timestamp each time
+random_val = random.random()             # Different random number
+now = datetime.now()                     # Different datetime each time
+
+context.step(lambda _: save_data({"id": id}), name='save')
+```
+
+### [OK] CORRECT - Non-Deterministic Inside Steps
+
+TypeScript:
+
+```typescript
+const id = await context.step('generate-id', async () => uuid.v4());
+const timestamp = await context.step('get-time', async () => Date.now());
+const random = await context.step('random', async () => Math.random());
+const now = await context.step('get-date', async () => new Date());
+
+await context.step('save', async () => saveData({ id, timestamp }));
+```
+
+Python:
+
+```python
+id = context.step(lambda _: str(uuid.uuid4()), name='generate-id')
+timestamp = context.step(lambda _: time.time(), name='get-time')
+random_val = context.step(lambda _: random.random(), name='random')
+now = context.step(lambda _: datetime.now(), name='get-date')
+
+context.step(lambda _: save_data({"id": id}), name='save')
+```
+
+### Must Be In Steps
+
+- `Date.now()`, `new Date()`, `time.time()`, `datetime.now()`
+- `Math.random()`, `random.random()`
+- UUID generation (`uuid.v4()`, `uuid.uuid4()`)
+- API calls, HTTP requests
+- Database queries
+- File system operations
+- Environment variable reads (if they can change)
+- Any external system interaction
+
+## Rule 2: No Nested Durable Operations
+
+You CANNOT call durable operations inside a step function.
+
+### [Wrong] WRONG - Nested Operations
+
+TypeScript:
+
+```typescript
+await context.step('process', async () => {
+  await context.wait({ seconds: 1 });      // ERROR!
+  await context.step(async () => ...);     // ERROR!
+  await context.invoke('other-fn', ...);   // ERROR!
+  return result;
+});
+```
+
+Python:
+
+```python
+@durable_step
+def process(step_ctx: StepContext):
+    context.wait(duration=Duration.from_seconds(1))  # ERROR!
+    context.step(lambda _: ..., name='nested')       # ERROR!
+    return result
+
+context.step(process())
+```
+
+### [OK] CORRECT - Use Child Context
+
+TypeScript:
+
+```typescript
+await context.runInChildContext('process', async (childCtx) => {
+  await childCtx.wait({ seconds: 1 });
+  const step1 = await childCtx.step('validate', async () => validate());
+  const step2 = await childCtx.step('process', async () => process(step1));
+  return step2;
+});
+```
+
+Python:
+
+```python
+# Note: validate and process are decorated with @durable_step
+def process_child(child_ctx: DurableContext):
+    child_ctx.wait(duration=Duration.from_seconds(1))
+    step1 = child_ctx.step(validate())
+    step2 = child_ctx.step(process(step1))
+    return step2
+
+context.run_in_child_context(func=process_child, name='process')
+```
+
+## Rule 3: Closure Mutations Are Lost
+
+Variables mutated inside steps are NOT preserved across replays.
+
+### [Wrong] WRONG - Lost Mutations
+
+TypeScript:
+
+```typescript
+let counter = 0;
+await context.step('increment', async () => {
+  counter++;  // This mutation is lost!
+});
+console.log(counter);  // Always 0 on replay!
+```
+
+Python:
+
+```python
+counter = 0
+@durable_step
+def increment(step_ctx: StepContext):
+    nonlocal counter
+    counter += 1  # This mutation is lost!
+
+context.step(increment())
+print(counter)  # Always 0 on replay!
+```
+
+### [OK] CORRECT - Return Values
+
+TypeScript:
+
+```typescript
+let counter = 0;
+counter = await context.step('increment', async () => counter + 1);
+console.log(counter);  // Correct value
+```
+
+Python:
+
+```python
+counter = 0
+counter = context.step(lambda _: counter + 1, name='increment')
+print(counter)  # Correct value
+```
+
+## Rule 4: Side Effects Outside Steps Repeat
+
+Side effects outside steps happen on EVERY replay.
+
+### [Wrong] WRONG - Repeated Side Effects
+
+TypeScript:
+
+```typescript
+console.log('Starting process');     // Logs multiple times!
+await sendEmail(user.email);         // Sends multiple emails!
+await updateDatabase(data);          // Updates multiple times!
+
+await context.step('process', async () => process());
+```
+
+Python:
+
+```python
+print('Starting process')            # Prints multiple times!
+send_email(user.email)               # Sends multiple emails!
+update_database(data)                # Updates multiple times!
+
+context.step(lambda _: process(), name='process')
+```
+
+### [OK] CORRECT - Side Effects In Steps
+
+TypeScript:
+
+```typescript
+context.logger.info('Starting process');  // Deduplicated automatically
+await context.step('send-email', async () => sendEmail(user.email));
+await context.step('update-db', async () => updateDatabase(data));
+await context.step('process', async () => process());
+```
+
+Python:
+
+```python
+# Note: Functions are decorated with @durable_step
+context.logger.info('Starting process')  # Deduplicated automatically
+context.step(send_email(user.email))
+context.step(update_database(data))
+context.step(process())
+```
+
+### Exception: context.logger
+
+`context.logger` is replay-aware and safe to use anywhere. It automatically deduplicates logs across replays.
+
+## Common Pitfalls
+
+### Pitfall 1: Reading Environment Variables
+
+```typescript
+// [Wrong] WRONG if env vars can change
+const apiKey = process.env.API_KEY;
+await context.step('call-api', async () => callAPI(apiKey));
+
+// [OK] CORRECT
+const apiKey = await context.step('get-key', async () => process.env.API_KEY);
+await context.step('call-api', async () => callAPI(apiKey));
+```
+
+### Pitfall 2: Array/Object Mutations
+
+```typescript
+// [Wrong] WRONG
+const items = [];
+await context.step('add-item', async () => {
+  items.push(newItem);  // Lost on replay
+});
+
+// [OK] CORRECT
+let items = [];
+items = await context.step('add-item', async () => [...items, newItem]);
+```
+
+### Pitfall 3: Conditional Logic with Non-Deterministic Values
+
+```typescript
+// [Wrong] WRONG
+if (Math.random() > 0.5) {  // Different on each replay!
+  await context.step('path-a', async () => ...);
+} else {
+  await context.step('path-b', async () => ...);
+}
+
+// [OK] CORRECT
+const shouldTakePathA = await context.step('decide', async () => Math.random() > 0.5);
+if (shouldTakePathA) {
+  await context.step('path-a', async () => ...);
+} else {
+  await context.step('path-b', async () => ...);
+}
+```
+
+## Debugging Replay Issues
+
+If you see inconsistent behavior:
+
+1. Check for non-deterministic code outside steps
+2. Verify no nested durable operations
+3. Look for closure mutations
+4. Search for side effects outside steps
+5. Use `context.logger` to trace execution flow
+
+## Testing Replay Behavior
+
+Always test with multiple invocations to simulate replay:
+
+```typescript
+const runner = new LocalDurableTestRunner({ handlerFunction: handler });
+const execution = await runner.run({ payload: { test: true } });
+
+// Verify operations executed correctly
+const step1 = runner.getOperation('step-name');
+expect(step1.getStatus()).toBe(OperationStatus.SUCCEEDED);
+```

--- a/plugins/aws-serverless/skills/aws-serverless-durable-functions/references/step-operations.md
+++ b/plugins/aws-serverless/skills/aws-serverless-durable-functions/references/step-operations.md
@@ -1,0 +1,347 @@
+# Step Operations
+
+Steps are atomic operations with automatic retry and state persistence.
+
+## Basic Step Patterns
+
+### Python: Two Ways to Define Steps
+
+Recommended: `@durable_step` Decorator
+
+```python
+from aws_durable_execution_sdk_python import durable_step, StepContext
+
+@durable_step
+def fetch_user(step_ctx: StepContext, user_id: str):
+    """Fetch user from database - reusable step function."""
+    return fetch_user_from_api(user_id)
+
+# Call it - name is automatically inferred from function name
+result = context.step(fetch_user(user_id))
+```
+
+Alternative: Inline Lambda
+
+```python
+# For simple one-off operations
+result = context.step(
+    func=lambda step_ctx: fetch_user_from_api(user_id),
+    name='fetch-user'
+)
+```
+
+Use `@durable_step` for:
+
+- Reusable step functions
+- Complex logic
+- Better readability and testing
+
+Use lambda for:
+
+- Simple inline operations
+- One-off transformations
+
+### TypeScript: Named Steps
+
+TypeScript:
+
+```typescript
+const result = await context.step('fetch-user', async () => {
+  return await fetchUserFromAPI(userId);
+});
+```
+
+Best Practice: Always name steps for easier debugging and testing.
+
+## Retry Configuration
+
+### Exponential Backoff
+
+TypeScript:
+
+```typescript
+import { createRetryStrategy, JitterStrategy } from '@aws/durable-execution-sdk-js';
+
+const result = await context.step(
+  'api-call',
+  async () => callExternalAPI(),
+  {
+    retryStrategy: createRetryStrategy({
+      maxAttempts: 5,
+      initialDelay: { seconds: 1 },
+      maxDelay: { seconds: 60 },
+      backoffRate: 2.0,
+      jitter: JitterStrategy.FULL
+    })
+  }
+);
+```
+
+Python:
+
+```python
+# Note: api_call is decorated with @durable_step
+from aws_durable_execution_sdk_python.config import StepConfig, Duration
+from aws_durable_execution_sdk_python.retries import RetryStrategyConfig, create_retry_strategy, JitterStrategy
+
+retry_config = RetryStrategyConfig(
+    max_attempts=5,
+    initial_delay=Duration.from_seconds(5),
+    max_delay=Duration.from_seconds(60),
+    backoff_rate=2.0,
+    jitter_strategy=JitterStrategy.FULL
+)
+
+result = context.step(
+    func=api_call(),
+    config=StepConfig(retry_strategy=create_retry_strategy(retry_config))
+)
+```
+
+### Custom Retry Strategy
+
+TypeScript:
+
+```typescript
+const result = await context.step(
+  'custom-retry',
+  async () => riskyOperation(),
+  {
+    retryStrategy: (error, attemptCount) => {
+      // Don't retry validation errors
+      if (error.name === 'ValidationError') {
+        return { shouldRetry: false };
+      }
+
+      // Retry up to 3 times with exponential backoff
+      if (attemptCount < 3) {
+        return {
+          shouldRetry: true,
+          delay: { seconds: Math.pow(2, attemptCount) }
+        };
+      }
+
+      return { shouldRetry: false };
+    }
+  }
+);
+```
+
+Python:
+
+```python
+from aws_durable_execution_sdk_python.retries import RetryDecision
+
+def custom_retry(error: Exception, attempt: int) -> RetryDecision:
+    if isinstance(error, ValidationError):
+        return RetryDecision(should_retry=False)
+
+    if attempt < 3:
+        return RetryDecision(
+            should_retry=True,
+            delay=Duration.from_seconds(2  attempt)
+        )
+
+    return RetryDecision(should_retry=False)
+
+result = context.step(
+    risky_operation(),
+    config=StepConfig(retry_strategy=custom_retry)
+)
+```
+
+### Retryable Error Types
+
+TypeScript:
+
+```typescript
+const result = await context.step(
+  'selective-retry',
+  async () => operation(),
+  {
+    retryStrategy: createRetryStrategy({
+      maxAttempts: 3,
+      retryableErrorTypes: ['NetworkError', 'TimeoutError']
+    })
+  }
+);
+```
+
+Python:
+
+```python
+retry_config = RetryStrategyConfig(
+    max_attempts=3,
+    retryable_error_types=[NetworkError, TimeoutError]
+)
+```
+
+## Step Semantics
+
+### AT_LEAST_ONCE (Default)
+
+Step executes at least once, may execute multiple times on failure/retry.
+
+TypeScript:
+
+```typescript
+const result = await context.step(
+  'idempotent-operation',
+  async () => idempotentAPI(),
+  { semantics: 'AT_LEAST_ONCE' }
+);
+```
+
+### AT_MOST_ONCE
+
+Step executes at most once, never retries. Use for non-idempotent operations.
+
+TypeScript:
+
+```typescript
+const result = await context.step(
+  'charge-payment',
+  async () => chargeCard(amount),
+  { semantics: 'AT_MOST_ONCE' }
+);
+```
+
+Python:
+
+```python
+from aws_durable_execution_sdk_python.config import StepSemantics
+
+result = context.step(
+    charge_card(amount),
+    config=StepConfig(step_semantics=StepSemantics.AT_MOST_ONCE_PER_RETRY)
+)
+```
+
+## Custom Serialization
+
+For complex types, provide custom serialization:
+
+TypeScript:
+
+```typescript
+import { createClassSerdesWithDates } from '@aws/durable-execution-sdk-js';
+
+class User {
+  constructor(
+    public id: string,
+    public name: string,
+    public createdAt: Date
+  ) {}
+}
+
+const userSerdes = createClassSerdesWithDates(User, ['createdAt']);
+
+const user = await context.step(
+  'fetch-user',
+  async () => new User('123', 'Alice', new Date()),
+  { serdes: userSerdes }
+);
+```
+
+Python:
+
+```python
+from dataclasses import dataclass
+from datetime import datetime
+
+@dataclass
+class User:
+    id: str
+    name: str
+    created_at: datetime
+
+# Python SDK handles dataclass serialization automatically
+user = context.step(
+    lambda _: User('123', 'Alice', datetime.now()),
+    name='fetch-user'
+)
+```
+
+## When to Use Steps vs Child Contexts
+
+### Use Steps For:
+
+- Single atomic operations
+- API calls
+- Database queries
+- Data transformations
+- Operations that should retry as a unit
+
+### Use Child Contexts For:
+
+- Grouping multiple durable operations
+- Complex workflows with steps, waits, and invokes
+- Isolating state tracking
+- Organizing related operations
+
+Example:
+
+```typescript
+// [Wrong] WRONG: Cannot nest durable operations in step
+await context.step('process', async () => {
+  await context.wait({ seconds: 1 });  // ERROR!
+});
+
+// [OK] CORRECT: Use child context
+await context.runInChildContext('process', async (childCtx) => {
+  const data = await childCtx.step('fetch', async () => fetch());
+  await childCtx.wait({ seconds: 1 });
+  return await childCtx.step('save', async () => save(data));
+});
+```
+
+## Error Handling
+
+Steps throw errors after all retry attempts are exhausted:
+
+TypeScript:
+
+```typescript
+try {
+  const result = await context.step('risky', async () => riskyOperation());
+} catch (error) {
+  if (error instanceof StepError) {
+    context.logger.error('Step failed', error.cause);
+    // Handle or rethrow
+  }
+}
+```
+
+Python:
+
+```python
+try:
+    # Note: risky_operation is decorated with @durable_step
+    result = context.step(risky_operation())
+except Exception as error:
+    context.logger.error('Step failed: %s', str(error))
+    # Handle or rethrow
+```
+
+For SDK-specific exceptions, use the base class or specific types:
+
+```python
+from aws_durable_execution_sdk_python import DurableExecutionsError
+
+try:
+    result = context.step(risky_operation())
+except DurableExecutionsError as error:
+    context.logger.error('SDK error: %s', str(error))
+except Exception as error:
+    context.logger.error('Application error: %s', str(error))
+```
+
+## Best Practices
+
+1. Always name steps for debugging and testing
+2. Keep steps atomic - one logical operation per step
+3. Make steps idempotent when possible
+4. Use appropriate retry strategies based on operation type
+5. Handle errors explicitly - don't let them propagate unexpectedly
+6. Use custom serialization for complex types
+7. Choose correct semantics (AT_LEAST_ONCE vs AT_MOST_ONCE)

--- a/plugins/aws-serverless/skills/aws-serverless-durable-functions/references/testing-patterns.md
+++ b/plugins/aws-serverless/skills/aws-serverless-durable-functions/references/testing-patterns.md
@@ -1,0 +1,586 @@
+# Testing Patterns
+
+Test durable functions locally and in the cloud with comprehensive test runners.
+
+## Critical Testing Patterns
+
+ALWAYS follow these patterns to avoid flaky tests:
+
+### DO:
+
+- [OK] Name all operations for test reliability
+- [OK] TypeScript: Use `runner.getOperation("name")` to find operations by name
+- [OK] TypeScript: Use `WaitingOperationStatus.STARTED` when waiting for callback operations
+- [OK] TypeScript: JSON.stringify callback parameters: `sendCallbackSuccess(JSON.stringify(data))`
+- [OK] TypeScript: Use `skipTime: true` in setupTestEnvironment for fast tests
+- [OK] TypeScript: Wrap event data in `payload` object: `runner.run({ payload: { ... } })`
+- [OK] TypeScript: Cast `getResult()` to appropriate type: `execution.getResult() as ResultType`
+- [OK] Python: Use `result.get_step("name")` to find step operations by name
+- [OK] Python: Use `result.operations` to iterate and filter operations by type
+- [OK] Python: Instantiate `DurableFunctionTestRunner(handler=my_handler)` directly
+- [OK] Python: Use `runner.run(input={...}, timeout=10)` -- note `input=` not `payload`
+- [OK] Python: The value of result.result is serialized. Deserialize using the appropriate SerDes or default json deserializer.
+
+### DON'T:
+
+- [Wrong] Use `getOperationByIndex()` unless absolutely necessary
+- [Wrong] Assume operation indices are stable (parallel creates nested operations)
+- [Wrong] TypeScript: Send objects to sendCallbackSuccess -- stringify first
+- [Wrong] TypeScript: Forget that callback results are JSON strings -- parse them
+- [Wrong] TypeScript: Test callbacks without proper synchronization (leads to race conditions)
+- [Wrong] Python: Confuse `DurableFunctionTestRunner` (local) with `DurableFunctionCloudTestRunner` (cloud)
+- [Wrong] Python: Forget the `with runner:` context manager -- it manages execution lifecycle
+
+## Local Testing Setup
+
+TypeScript:
+
+```typescript
+import {
+  LocalDurableTestRunner,
+  OperationType,
+  OperationStatus
+} from '@aws/durable-execution-sdk-js-testing';
+
+describe('My Durable Function', () => {
+  beforeAll(() =>
+    LocalDurableTestRunner.setupTestEnvironment({ skipTime: true })
+  );
+
+  afterAll(() =>
+    LocalDurableTestRunner.teardownTestEnvironment()
+  );
+
+  it('should execute workflow', async () => {
+    const runner = new LocalDurableTestRunner({
+      handlerFunction: handler
+    });
+
+    const execution = await runner.run({
+      payload: { userId: '123' }
+    });
+
+    expect(execution.getStatus()).toBe('SUCCEEDED');
+    expect(execution.getResult()).toEqual({ success: true });
+  });
+});
+```
+
+Python:
+
+The Python testing SDK provides `DurableFunctionTestRunner` for local testing and `DurableFunctionCloudTestRunner` for cloud testing.
+
+Install the testing SDK:
+
+```bash
+pip install aws-durable-execution-sdk-python-testing pytest
+```
+
+Example test:
+
+```python
+from aws_durable_execution_sdk_python_testing import DurableFunctionTestRunner
+from aws_durable_execution_sdk_python.execution import InvocationStatus
+from src.my_function import handler
+
+def test_workflow():
+    """Test durable function locally."""
+    runner = DurableFunctionTestRunner(handler=handler)
+
+    with runner:
+        result = runner.run(input={'user_id': '123'}, timeout=10)
+
+    assert result.status is InvocationStatus.SUCCEEDED
+```
+
+## Getting Operations
+
+CRITICAL: Always get operations by NAME, not by index.
+
+TypeScript:
+
+```typescript
+it('should execute steps in order', async () => {
+  const runner = new LocalDurableTestRunner({ handlerFunction: handler });
+  await runner.run({ payload: { test: true } });
+
+  // [OK] CORRECT: Get by name
+  const fetchStep = runner.getOperation('fetch-user');
+  expect(fetchStep.getType()).toBe(OperationType.STEP);
+  expect(fetchStep.getStatus()).toBe(OperationStatus.SUCCEEDED);
+
+  const processStep = runner.getOperation('process-data');
+  expect(processStep.getStatus()).toBe(OperationStatus.SUCCEEDED);
+
+  // [Wrong] WRONG: Get by index (brittle, breaks easily)
+  // const step1 = runner.getOperationByIndex(0);
+});
+```
+
+Python:
+
+```python
+from aws_durable_execution_sdk_python.lambda_service import OperationType
+def test_steps_execute():
+    """Test step execution."""
+    runner = DurableFunctionTestRunner(handler=handler)
+
+    with runner:
+        result = runner.run(input={'test': True}, timeout=10)
+
+    # [OK] CORRECT: Get step by name
+    fetch_step = result.get_step('fetch-user')
+    assert fetch_step is not None
+
+    # [OK] Also valid: filter result.operations by type
+    step_names = {op.name for op in result.operations if op.operation_type == OperationType.STEP}
+    assert step_names >= {'fetch-user', 'process-data'}
+    assert 'process-data' in step_names
+```
+
+## Testing Replay Behavior
+
+TypeScript:
+
+```typescript
+it('should handle replay correctly', async () => {
+  const runner = new LocalDurableTestRunner({ handlerFunction: handler });
+
+  // First execution
+  const execution1 = await runner.run({ payload: { value: 42 } });
+  expect(execution1.getStatus()).toBe('SUCCEEDED');
+
+  // Simulate replay
+  const execution2 = await runner.run({ payload: { value: 42 } });
+  expect(execution2.getStatus()).toBe('SUCCEEDED');
+
+  // Results should be identical
+  expect(execution1.getResult()).toEqual(execution2.getResult());
+});
+```
+
+## Testing with Fake Clock
+
+TypeScript:
+
+```typescript
+it('should wait for specified duration', async () => {
+  const runner = new LocalDurableTestRunner({
+    handlerFunction: handler
+  });
+
+  const executionPromise = runner.run({ payload: {} });
+
+  // Advance time by 60 seconds
+  await runner.skipTime({ seconds: 60 });
+
+  const execution = await executionPromise;
+  expect(execution.getStatus()).toBe('SUCCEEDED');
+
+  const waitOp = runner.getOperation('delay');
+  expect(waitOp.getType()).toBe(OperationType.WAIT);
+  expect(waitOp.getWaitDetails()?.waitSeconds).toBe(60);
+});
+```
+
+## Test Runner API Patterns
+
+CRITICAL: Always wrap event data in `payload` and cast results appropriately.
+
+TypeScript:
+
+```typescript
+it('should use correct test runner API', async () => {
+  const runner = new LocalDurableTestRunner({
+    handlerFunction: handler,
+  });
+
+  // [OK] CORRECT: Wrap event in payload
+  const execution = await runner.run({
+    payload: { name: 'Alice', userId: '123' }
+  });
+
+  // [OK] CORRECT: Type cast result
+  const result = execution.getResult() as {
+    greeting: string;
+    message: string;
+  };
+
+  expect(result.greeting).toBe('Hello, Alice!');
+
+  // [OK] CORRECT: Get operations by name
+  const greetingStep = runner.getOperation('generate-greeting');
+  expect(greetingStep.getStepDetails()?.result).toBe('Hello, Alice!');
+});
+
+// [Wrong] WRONG: Missing payload wrapper and type casting
+it('incorrect api usage', async () => {
+  const runner = new LocalDurableTestRunner({ handlerFunction: handler });
+
+  // [Wrong] Missing payload wrapper
+  const execution = await runner.run({ name: 'Alice' });
+
+  // [Wrong] No type casting - result is 'unknown'
+  const result = execution.getResult();
+  // expect(result.greeting).toBe('...'); // Type error!
+});
+```
+
+## Testing Callbacks
+
+CRITICAL: Use `waitForData()` with `WaitingOperationStatus.STARTED` to avoid flaky tests caused by promise races.
+
+TypeScript:
+
+```typescript
+import { WaitingOperationStatus } from '@aws/durable-execution-sdk-js-testing';
+
+it('should handle callback success', async () => {
+  const runner = new LocalDurableTestRunner({ handlerFunction: handler });
+
+  // Start execution (will pause at callback)
+  const executionPromise = runner.run({
+    payload: { approver: 'alice@example.com' }
+  });
+
+  // [OK] CRITICAL: Get operation by NAME
+  const callbackOp = runner.getOperation('wait-for-approval');
+
+  // [OK] CRITICAL: Wait for operation to reach STARTED status
+  await callbackOp.waitForData(WaitingOperationStatus.STARTED);
+
+  // [OK] CRITICAL: Must JSON.stringify callback data!
+  await callbackOp.sendCallbackSuccess(
+    JSON.stringify({ approved: true, comments: 'Looks good' })
+  );
+
+  const execution = await executionPromise;
+  expect(execution.getStatus()).toBe('SUCCEEDED');
+
+  // [OK] CRITICAL: Parse JSON string result
+  const result: any = execution.getResult();
+  const approval = typeof result.approval === 'string'
+    ? JSON.parse(result.approval)
+    : result.approval;
+
+  expect(approval.approved).toBe(true);
+  expect(approval.comments).toBe('Looks good');
+});
+
+it('should handle callback failure', async () => {
+  const runner = new LocalDurableTestRunner({ handlerFunction: handler });
+
+  const executionPromise = runner.run({ payload: {} });
+
+  await new Promise(resolve => setTimeout(resolve, 100));
+
+  const callbackOp = runner.getOperation('wait-for-approval');
+
+  // Send callback failure
+  await callbackOp.sendCallbackFailure(
+    'ApprovalDenied',
+    'Request was rejected'
+  );
+
+  const execution = await executionPromise;
+  expect(execution.getStatus()).toBe('FAILED');
+});
+```
+
+Python:
+
+Testing callbacks in Python follows the same marker pattern. The callback operation
+appears in `result.operations` with `operation_type == OperationType.CALLBACK`:
+
+```python
+def test_callback_creation():
+    """Test that callback is created correctly."""
+    runner = DurableFunctionTestRunner(handler=handler)
+
+    with runner:
+        result = runner.run(input={'approver': '[email]'}, timeout=10)
+
+    # Find callback operations in the result
+    callback_ops = [
+        op for op in result.operations
+        if op.operation_type == OperationType.CALLBACK
+    ]
+    assert len(callback_ops) == 1
+    assert callback_ops[0].name == 'wait-for-approval'
+    assert callback_ops[0].callback_id is not None
+```
+
+## Testing Callback Heartbeats
+
+TypeScript:
+
+```typescript
+it('should handle callback heartbeats', async () => {
+  const runner = new LocalDurableTestRunner({ handlerFunction: handler });
+
+  const executionPromise = runner.run({ payload: {} });
+
+  await new Promise(resolve => setTimeout(resolve, 100));
+
+  const callbackOp = runner.getOperation('long-running-process');
+
+  // Send heartbeats
+  await callbackOp.sendCallbackHeartbeat();
+  await runner.skipTime({ minutes: 2 });
+  await callbackOp.sendCallbackHeartbeat();
+  await runner.skipTime({ minutes: 2 });
+
+  // Complete callback
+  await callbackOp.sendCallbackSuccess(JSON.stringify({ status: 'completed' }));
+
+  const execution = await executionPromise;
+  expect(execution.getStatus()).toBe('SUCCEEDED');
+});
+```
+
+## Testing Error Scenarios
+
+TypeScript:
+
+```typescript
+it('should retry on failure', async () => {
+  let attemptCount = 0;
+
+  const testHandler = withDurableExecution(async (event, context: DurableContext) => {
+    return await context.step('flaky-operation', async () => {
+      attemptCount++;
+      if (attemptCount < 3) {
+        throw new Error('Temporary failure');
+      }
+      return { success: true };
+    });
+  });
+
+  const runner = new LocalDurableTestRunner({ handlerFunction: testHandler });
+  const execution = await runner.run({ payload: {} });
+
+  expect(execution.getStatus()).toBe('SUCCEEDED');
+  expect(attemptCount).toBe(3);
+
+  const step = runner.getOperation('flaky-operation');
+  expect(step.getStatus()).toBe(OperationStatus.SUCCEEDED);
+});
+
+it('should fail after max retries', async () => {
+  const testHandler = withDurableExecution(async (event, context: DurableContext) => {
+    return await context.step(
+      'always-fails',
+      async () => {
+        throw new Error('Permanent failure');
+      },
+      {
+        retryStrategy: createRetryStrategy({ maxAttempts: 3 })
+      }
+    );
+  });
+
+  const runner = new LocalDurableTestRunner({ handlerFunction: testHandler });
+  const execution = await runner.run({ payload: {} });
+
+  expect(execution.getStatus()).toBe('FAILED');
+  expect(execution.getError()?.errorMessage).toContain('Permanent failure');
+});
+```
+
+## Testing Concurrent Operations
+
+TypeScript:
+
+```typescript
+it('should process items concurrently', async () => {
+  const runner = new LocalDurableTestRunner({ handlerFunction: handler });
+
+  const execution = await runner.run({
+    payload: { items: [1, 2, 3, 4, 5] }
+  });
+
+  expect(execution.getStatus()).toBe('SUCCEEDED');
+
+  const mapOp = runner.getOperation('process-items');
+  expect(mapOp.getType()).toBe(OperationType.MAP);
+
+  // Check individual item operations
+  const item0 = runner.getOperation('process-0');
+  expect(item0.getStatus()).toBe(OperationStatus.SUCCEEDED);
+});
+```
+
+## Cloud Testing
+
+For integration tests against real Lambda:
+
+TypeScript:
+
+```typescript
+import { CloudDurableTestRunner } from '@aws/durable-execution-sdk-js-testing';
+
+describe('Integration Tests', () => {
+  it('should execute in real Lambda', async () => {
+    const runner = new CloudDurableTestRunner({
+      functionName: 'my-durable-function:1',  // Qualified ARN required
+      client: new LambdaClient({ region: 'us-east-1' })
+    });
+
+    const execution = await runner.run({
+      payload: { userId: '123' },
+      config: { pollInterval: 1000 }
+    });
+
+    expect(execution.getStatus()).toBe('SUCCEEDED');
+
+    const step = runner.getOperation('fetch-user');
+    expect(step.getStatus()).toBe(OperationStatus.SUCCEEDED);
+  });
+});
+```
+
+Python:
+
+Cloud mode uses `DurableFunctionCloudTestRunner` with the same API:
+
+```bash
+# Set environment variables for cloud mode
+export AWS_REGION=us-west-2
+export QUALIFIED_FUNCTION_NAME="my-durable-function:$LATEST"
+export LAMBDA_FUNCTION_TEST_NAME="my_function"
+
+# Run in cloud mode
+pytest --runner-mode=cloud -k test_workflow
+```
+
+The same test works in both modes:
+
+```python
+def test_workflow_cloud():
+    """Test against deployed Lambda function."""
+    runner = DurableFunctionCloudTestRunner(
+        function_name='my-function:$LATEST',
+        region='us-west-2'
+    )
+
+    with runner:
+        result = runner.run(input={'user_id': '123'}, timeout=60)
+
+    assert result.status is InvocationStatus.SUCCEEDED
+```
+
+## Test Assertions
+
+TypeScript:
+
+```typescript
+it('should validate operation details', async () => {
+  const runner = new LocalDurableTestRunner({ handlerFunction: handler });
+  await runner.run({ payload: {} });
+
+  const step = runner.getOperation('process-data');
+
+  // Check operation type
+  expect(step.getType()).toBe(OperationType.STEP);
+
+  // Check status
+  expect(step.getStatus()).toBe(OperationStatus.SUCCEEDED);
+
+  // Check timing
+  expect(step.getStartTimestamp()).toBeDefined();
+  expect(step.getEndTimestamp()).toBeDefined();
+
+  // Check result
+  const stepDetails = step.getStepDetails();
+  expect(stepDetails?.result).toEqual({ processed: true });
+});
+```
+
+## Best Practices
+
+1. Always name operations for reliable test assertions
+2. Get operations by name, never by index
+3. Test replay behavior with multiple invocations
+4. Use fake clock for time-dependent tests
+5. Test error scenarios including retries and failures
+6. Test callbacks with success, failure, and timeout cases
+7. Validate operation details (type, status, timing, results)
+8. Use cloud tests for integration testing
+9. Mock external dependencies in unit tests
+10. Test concurrent operations individually and as a group
+
+## Common Pitfalls
+
+### [Wrong] Getting Operations by Index
+
+```typescript
+// Brittle - breaks when operations change
+const step = runner.getOperationByIndex(0);
+```
+
+### [OK] Getting Operations by Name
+
+```typescript
+// Robust - works even if operation order changes
+const step = runner.getOperation('fetch-user');
+```
+
+### [Wrong] Not Waiting for Callbacks
+
+```typescript
+// Race condition - callback might not exist yet
+const callbackOp = runner.getOperation('wait-approval');
+await callbackOp.sendCallbackSuccess('{}');
+```
+
+### [OK] Waiting for Callbacks
+
+```typescript
+// Use waitForData with proper status
+import { WaitingOperationStatus } from '@aws/durable-execution-sdk-js-testing';
+
+const callbackOp = runner.getOperation('wait-approval');
+await callbackOp.waitForData(WaitingOperationStatus.STARTED);
+await callbackOp.sendCallbackSuccess(JSON.stringify({}));
+```
+
+## Common Testing Errors
+
+### TypeScript
+
+| Error                                 | Cause                                 | Solution                                          |
+| ------------------------------------- | ------------------------------------- | ------------------------------------------------- |
+| `'result' is of type 'unknown'`       | Missing type casting in tests         | Cast result: `as any` or specific type            |
+| `'payload' does not exist in type`    | Wrong test runner API                 | Wrap event in `payload: {}` object                |
+| `Cannot find operation at index`      | Using index for unstable operations   | Use `getOperation("name")` instead                |
+| Flaky callback tests                  | Race condition with callback creation | Use `waitForData(WaitingOperationStatus.STARTED)` |
+| `Unexpected token` in callback result | Forgot to JSON.stringify              | Always stringify: `JSON.stringify(data)`          |
+| Callback result parsing error         | Result is JSON string                 | Parse result: `JSON.parse(result.value)`          |
+| Operation not found by name           | Missing operation name                | Always name operations in handler                 |
+
+## Jest Configuration
+
+jest.config.js:
+
+```javascript
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  roots: ['<rootDir>/src'],
+  testMatch: ['/*.test.ts'],
+  transform: {
+    '^.+\\.ts$': 'ts-jest',
+  },
+  collectCoverageFrom: [
+    'src//*.ts',
+    '!src//*.d.ts',
+  ],
+};
+```
+
+Key points:
+
+- `preset: 'ts-jest'` is essential for TypeScript support
+- `transform` maps .ts files to ts-jest transformer
+- `testMatch` specifies test file patterns
+- Use `skipTime: true` in test setup for fast execution

--- a/plugins/aws-serverless/skills/aws-serverless-durable-functions/references/troubleshooting-executions.md
+++ b/plugins/aws-serverless/skills/aws-serverless-durable-functions/references/troubleshooting-executions.md
@@ -1,0 +1,172 @@
+# Troubleshooting Executions
+
+PROACTIVE AGENT: When users report issues with durable function executions, spawn a specialized troubleshooting agent.
+
+## When to Spawn Troubleshooting Agent
+
+Spawn the agent when users mention:
+
+- "My execution is stuck"
+- "Execution failed with ID xyz"
+- "Debug execution abc123"
+- "Troubleshoot execution"
+- "Why is my durable function not completing"
+- Provide an execution ID and need diagnosis
+
+## Agent Instructions
+
+When spawning the troubleshooting agent, provide:
+
+```
+Diagnose durable function execution issue:
+- Durable Execution ARN: <durable-execution-arn>
+- Region: <region> (infer from ARN)
+
+CRITICAL SAFETY RULES:
+- This is READ-ONLY diagnosis
+- NEVER call StopDurableExecution or any termination APIs
+- NEVER modify execution state
+- Only suggest manual remediation if user explicitly requests it
+
+Steps:
+
+0. If the user provides a function name + alias (e.g., my-function:prod) instead of a full ARN:
+   - Resolve the alias to a version: aws lambda get-alias --function-name <functionName> --name <alias> --region <region> --query 'FunctionVersion' --output text
+   - List executions for that function: aws lambda list-durable-executions-by-function --function-name <functionName>:<version> --region <region>
+   - Ask the user to identify the execution, or use the most recent one.
+
+1. Fetch the execution history directly:
+   Run: aws lambda get-durable-execution-history --durable-execution-arn <durable-execution-arn> --region <region> --include-execution-data
+
+2. If the command succeeds, analyze and provide a user-friendly diagnosis:
+   a. Report the execution status (RUNNING/SUCCEEDED/FAILED/STOPPED/TIMED_OUT)
+   b. Identify the root cause by looking for these key events in the history:
+
+      Execution-level failures:
+      - `ExecutionFailed` -- entire execution crashed; extract the error and cause fields
+      - `ExecutionTimedOut` -- the execution exceeded its configured timeout
+      - `ExecutionStopped` -- execution was manually stopped via StopDurableExecution
+
+      Context and step failures:
+      - `ContextFailed` -- a child context threw an unhandled error; check the parent context for what triggered it
+      - `StepFailed` -- an individual step failed; includes RetryDetails (CurrentAttempt, NextAttemptDelaySeconds) showing retry state
+
+      Callback issues:
+      - `CallbackStarted` with a Timeout field -- confirms a timeout was registered; correlate with any subsequent `CallbackTimedOut`
+      - `CallbackTimedOut` -- a timeout fired but may not have been caught by the function code
+      - `CallbackFailed` -- the callback was resolved with an error
+
+      Chained invocation failures:
+      - `ChainedInvokeFailed` -- a chained (child) durable execution failed
+      - `ChainedInvokeTimedOut` -- a chained execution exceeded its timeout
+      - `ChainedInvokeStopped` -- a chained execution was stopped
+
+      Other signals:
+      - `WaitCancelled` -- a scheduled wait was cancelled before completing
+      - `InvocationCompleted` with an Error field -- the Lambda invocation itself errored (e.g., runtime crash)
+
+      Diagnosis patterns:
+      - Failed operations: Show the EXACT error message verbatim in a code block
+      - Stuck in WAIT_FOR_CALLBACK: Extract callback ID, show how long it's been waiting
+      - Timeout: Show which operation was running when timeout occurred
+      - Unexpected behavior: Compare operation order with expected flow
+   c. Calculate operation durations and timeline
+   d. Provide a clear, plain-language explanation of what went wrong and why
+
+3. If the command fails:
+   - Execution not found: Tell the user the execution ID may be incorrect or the execution may have been purged. Ask them to verify the ARN.
+   - Permissions/network error: check that your caller identity has lambda:GetDurableExecutionHistory on the function ARN.
+   - In either case, direct them to the console as a fallback (see step 4)
+
+4. ALWAYS provide a direct link to the Execution Details page in the Lambda console.
+   Parse the ARN (arn:<partition>:lambda:<region>:<accountId>:function:<functionName>:<functionVersion>/durable-execution/<executionName>/<invocationId>)
+   to extract region, functionName, functionVersion, executionName, and invocationId, then construct:
+   https://<region>.console.aws.amazon.com/lambda/home?region=<region>#/functions/<functionName>/versions/<functionVersion>/executions/<executionName>/<invocationId>
+
+   Frame it as: "[View this execution in the console](<url>)"
+
+5. Provide specific, actionable next steps based on the diagnosis.
+
+6. If unable to determine the root cause from execution history:
+   - Provide the console link (step 4)
+   - Offer to fetch the log group and pull relevant logs:
+     a. Get the log group:
+        aws lambda get-function-configuration --function-name <functionName>:<functionVersion> --region <region> --query 'LoggingConfig.LogGroup'
+     b. Query logs filtered by invocation ID (parsed from the ARN):
+        aws logs filter-log-events --log-group-name <logGroup> --region <region> --filter-pattern '"<invocationId>"'
+     c. If the function uses SDK structured logging (context.logger), query for step-level logs.
+        Use execution start time from step 2 as start-time, and execution end time (or current time if still running) as end-time:
+        QUERY_ID=$(aws logs start-query --log-group-name <logGroup> --region <region> \
+          --start-time <startEpoch> --end-time <endEpoch> \
+          --query-string 'fields @timestamp, @message | filter executionName = "<executionName>" | sort @timestamp asc' \
+          --query 'queryId' --output text)
+        Then poll for results:
+        aws logs get-query-results --query-id $QUERY_ID --region <region>
+   - If unable to determine the log group, ask the user to check the function's logs
+
+OUTPUT FORMAT:
+- Lead with a short summary: "Your execution [status] because [reason]."
+- Show the error message verbatim in a code block if one exists.
+- Explain what this means in plain language.
+- Provide the console link for visual debugging.
+- List recommended next steps.
+
+Use jq for JSON parsing if available, otherwise use --query (AWS CLI built-in JMESPath) or python -m json.tool.
+```
+
+## Example Usage
+
+````
+User: "My durable function execution abc-123 is stuck on my-function:prod in us-west-2"
+
+Agent: [Runs get-durable-execution-history command]
+Agent: [Analyzes with jq queries]
+
+Example response: Your execution is waiting for an external callback that hasn't arrived yet.
+
+The operation `wait-for-approval` has been pending since 2026-02-14 (3 days).
+It will time out in 12 hours if no callback is received.
+
+Callback ID: `xyz789`
+
+[View this execution in the console](https://us-west-2.console.aws.amazon.com/lambda/home?region=us-west-2#/functions/my-function/versions/3/executions/abc-123/inv-456)
+
+```
+https://us-west-2.console.aws.amazon.com/lambda/home?region=us-west-2#/functions/my-function/versions/3/executions/abc-123/inv-456
+```
+
+Next steps:
+1. Check if the approval email was sent to the recipient
+2. Verify the callback ID `xyz789` was included in the email
+3. If you'd like me to help send the callback manually, let me know
+````
+
+````
+User: "Execution def-456 failed on order-processor:live in us-east-1"
+
+Agent: [Runs get-durable-execution-history command]
+Agent: [Analyzes with jq queries]
+
+Example response: Your execution failed at the `charge-payment` step after 3 retry attempts.
+
+Error message:
+
+```
+PaymentGatewayError: Card declined - insufficient funds (code: card_declined)
+```
+
+This means the payment provider rejected the charge. The durable function
+retried 3 times with exponential backoff but the error persisted because
+it's a permanent failure (not a transient network issue).
+
+[View this execution in the console](https://us-east-1.console.aws.amazon.com/lambda/home?region=us-east-1#/functions/order-processor/versions/5/executions/def-456/inv-789)
+
+```
+https://us-east-1.console.aws.amazon.com/lambda/home?region=us-east-1#/functions/order-processor/versions/5/executions/def-456/inv-789
+```
+
+Next steps:
+1. This is a business logic failure, not an infrastructure issue
+2. Consider adding a non-retryable error classification for `card_declined`
+3. Implement a compensation step to release the reserved inventory
+````

--- a/plugins/aws-serverless/skills/aws-serverless-durable-functions/references/wait-operations.md
+++ b/plugins/aws-serverless/skills/aws-serverless-durable-functions/references/wait-operations.md
@@ -1,0 +1,396 @@
+# Wait Operations
+
+Suspend execution without compute charges for delays, external callbacks, and polling.
+
+## Simple Waits
+
+Pause execution for a duration (no compute charges during wait):
+
+TypeScript:
+
+```typescript
+await context.wait({ seconds: 30 });
+await context.wait({ minutes: 5 });
+await context.wait({ hours: 1, minutes: 30 });
+await context.wait({ days: 7 });
+
+// Named wait (recommended)
+await context.wait('rate-limit-delay', { seconds: 60 });
+```
+
+Python:
+
+```python
+from aws_durable_execution_sdk_python.config import Duration
+
+context.wait(duration=Duration.from_seconds(30))
+context.wait(duration=Duration.from_minutes(5))
+context.wait(duration=Duration.from_hours(1))
+context.wait(duration=Duration.from_days(7))
+
+# Named wait (recommended)
+context.wait(duration=Duration.from_seconds(60), name='rate-limit-delay')
+```
+
+Max wait duration: Up to 1 year
+
+## Wait for Callback
+
+Wait for external systems to respond (human approval, webhook, async job):
+
+TypeScript:
+
+```typescript
+const result = await context.waitForCallback(
+  'wait-for-approval',
+  async (callbackId, ctx) => {
+    // Send callback ID to external system
+    await sendApprovalEmail(approverEmail, callbackId);
+  },
+  {
+    timeout: { hours: 24 },
+    heartbeatTimeout: { minutes: 5 }
+  }
+);
+
+// External system calls back with:
+// aws lambda send-durable-execution-callback-success \
+//   --callback-id <callbackId> \
+//   --payload '{"approved": true}'
+```
+
+Python:
+
+```python
+from aws_durable_execution_sdk_python.config import WaitForCallbackConfig
+
+# Wait for external approval
+def submit_approval(callback_id: str, ctx):
+    ctx.logger.info('Sending approval request')
+    send_approval_email(approver_email, callback_id)
+
+result = context.wait_for_callback(
+    submitter=submit_approval,
+    name='wait-for-approval',
+    config=WaitForCallbackConfig(
+        timeout=Duration.from_hours(24),
+        heartbeat_timeout=Duration.from_minutes(5)
+    )
+)
+```
+
+### Callback Success
+
+CLI:
+
+```bash
+aws lambda send-durable-execution-callback-success \
+  --callback-id <callbackId> \
+  --payload '{"status": "approved", "comments": "Looks good"}'
+```
+
+SDK (TypeScript):
+
+```typescript
+import { LambdaClient, SendDurableExecutionCallbackSuccessCommand } from '@aws-sdk/client-lambda';
+
+const client = new LambdaClient({});
+await client.send(new SendDurableExecutionCallbackSuccessCommand({
+  CallbackId: callbackId,
+  Payload: JSON.stringify({ status: 'approved' })
+}));
+```
+
+SDK (Python / boto3):
+
+```python
+import boto3
+import json
+
+lambda_client = boto3.client('lambda')
+lambda_client.send_durable_execution_callback_success(
+    CallbackId=callback_id,
+    Result=json.dumps({'status': 'approved'})
+)
+```
+
+### Callback Failure
+
+CLI:
+
+```bash
+aws lambda send-durable-execution-callback-failure \
+  --callback-id <callbackId> \
+  --error-type "ApprovalDenied" \
+  --error-message "Request denied by approver"
+```
+
+### Heartbeats
+
+Keep callback alive during long-running external processes:
+
+TypeScript:
+
+```typescript
+const result = await context.waitForCallback(
+  'long-process',
+  async (callbackId) => {
+    await startLongRunningJob(callbackId);
+  },
+  {
+    timeout: { hours: 24 },
+    heartbeatTimeout: { minutes: 5 }  // Must receive heartbeat every 5 min
+  }
+);
+
+// External system sends heartbeats:
+// aws lambda send-durable-execution-callback-heartbeat --callback-id <callbackId>
+```
+
+CLI Heartbeat:
+
+```bash
+aws lambda send-durable-execution-callback-heartbeat \
+  --callback-id <callbackId>
+```
+
+## Wait for Condition
+
+Poll until a condition is met (job completion, resource availability):
+
+TypeScript:
+
+```typescript
+const finalState = await context.waitForCondition(
+  'wait-for-job',
+  async (currentState, ctx) => {
+    const status = await checkJobStatus(currentState.jobId);
+    return { ...currentState, status };
+  },
+  {
+    initialState: { jobId: 'job-123', status: 'pending' },
+    waitStrategy: createWaitStrategy({
+        maxAttempts: 60,
+        initialDelaySeconds: 5,
+        maxDelaySeconds: 30,
+        backoffRate: 1.5,
+        shouldContinuePolling: (result) => result.status !== "completed"
+    }),
+    timeout: { hours: 1 }
+  }
+);
+```
+
+Python:
+
+```python
+# Note: get_job_status is decorated with @durable_step
+from aws_durable_execution_sdk_python.waits import WaitForConditionConfig, create_wait_strategy, WaitStrategyConfig
+from aws_durable_execution_sdk_python.config import Duration
+
+def check_job(state: dict, check_ctx):
+    status = get_job_status(state['job_id'])
+    return {'job_id': state['job_id'], 'status': status}
+
+wait_strategy = create_wait_strategy(
+    WaitStrategyConfig(
+        should_continue_polling=lambda state: state['status'] != 'completed',
+        max_attempts=60,
+        initial_delay=Duration.from_seconds(2),
+        max_delay=Duration.from_seconds(60),
+        backoff_rate=1.5
+    )
+)
+
+result = context.wait_for_condition(
+    check=check_job,
+    config=WaitForConditionConfig(
+        initial_state={'job_id': 'job-123', 'status': 'pending'},
+        wait_strategy=wait_strategy
+    ),
+    name='wait-for-job'
+)
+```
+
+### Custom Wait Strategy
+
+TypeScript:
+
+```typescript
+const result = await context.waitForCondition(
+  'custom-poll',
+  async (state) => {
+    const data = await fetchData();
+    return { ...state, data, attempts: state.attempts + 1 };
+  },
+  {
+    initialState: { attempts: 0 },
+    waitStrategy: (state, attempt) => {
+      // Stop after 10 attempts
+      if (state.attempts >= 10) {
+        return { shouldContinue: false };
+      }
+
+      // Exponential backoff with max 60s
+      return {
+        shouldContinue: !state.data?.ready,
+        delay: { seconds: Math.min(Math.pow(2, attempt), 60) }
+      };
+    }
+  }
+);
+```
+
+## Callback Patterns
+
+### Human Approval Workflow
+
+TypeScript:
+
+```typescript
+export const handler = withDurableExecution(async (event, context: DurableContext) => {
+  const request = await context.step('create-request', async () =>
+    createApprovalRequest(event)
+  );
+
+  const decision = await context.waitForCallback(
+    'wait-approval',
+    async (callbackId) => {
+      await sendEmail({
+        to: event.approver,
+        subject: 'Approval Required',
+        body: `Approve: ${approvalUrl}?callback=${callbackId}&action=approve\n` +
+              `Reject: ${approvalUrl}?callback=${callbackId}&action=reject`
+      });
+    },
+    { timeout: { hours: 48 } }
+  );
+
+  if (decision.action === 'approve') {
+    await context.step('execute', async () => executeRequest(request));
+    return { status: 'approved' };
+  }
+
+  return { status: 'rejected' };
+});
+```
+
+### Webhook Integration
+
+TypeScript:
+
+```typescript
+export const handler = withDurableExecution(async (event, context: DurableContext) => {
+  const order = await context.step('create-order', async () =>
+    createOrder(event)
+  );
+
+  const payment = await context.waitForCallback(
+    'wait-payment',
+    async (callbackId) => {
+      await paymentProvider.createPayment({
+        orderId: order.id,
+        amount: order.total,
+        webhookUrl: `${webhookUrl}?callback=${callbackId}`
+      });
+    },
+    { timeout: { minutes: 15 } }
+  );
+
+  if (payment.status === 'success') {
+    await context.step('fulfill', async () => fulfillOrder(order));
+  }
+
+  return { orderId: order.id, paymentStatus: payment.status };
+});
+```
+
+### Async Job Polling
+
+TypeScript:
+
+```typescript
+export const handler = withDurableExecution(async (event, context: DurableContext) => {
+  const jobId = await context.step('start-job', async () =>
+    startBatchJob(event.data)
+  );
+
+  const result = await context.waitForCondition(
+    'poll-job',
+    async (state) => {
+      const job = await getJobStatus(state.jobId);
+      return { jobId: state.jobId, status: job.status, result: job.result };
+    },
+    {
+      initialState: { jobId, status: 'running' },
+      waitStrategy: createWaitStrategy({
+          maxAttempts: 60,
+          initialDelaySeconds: 5,
+          maxDelaySeconds: 30,
+          backoffRate: 1.5,
+          shouldContinuePolling: (result) => result.status === "running"
+      }),
+      timeout: { hours: 2 }
+    }
+  );
+
+  return result;
+});
+```
+
+## Best Practices
+
+1. Always name wait operations for debugging
+2. Set appropriate timeouts to prevent indefinite waits
+3. Use heartbeats for long-running external processes
+4. Handle callback failures explicitly
+5. Implement exponential backoff for polling
+6. Keep check functions lightweight in waitForCondition
+7. Store callback IDs securely when sending to external systems
+8. Validate callback payloads before processing
+
+## Error Handling
+
+TypeScript:
+
+```typescript
+try {
+  const result = await context.waitForCallback(
+    'wait-approval',
+    async (callbackId) => sendApproval(callbackId),
+    { timeout: { hours: 24 } }
+  );
+} catch (error) {
+  if (error instanceof CallbackError) {
+    if (error.errorType === 'Timeout') {
+      context.logger.warn('Approval timed out');
+      // Handle timeout
+    } else {
+      context.logger.error('Callback failed', error);
+      // Handle failure
+    }
+  }
+}
+```
+
+Python:
+
+```python
+from aws_durable_execution_sdk_python.exceptions import CallbackError
+from aws_durable_execution_sdk_python.config import WaitForCallbackConfig
+
+try:
+    def submit_approval(callback_id: str, ctx):
+        send_approval(callback_id)
+
+    result = context.wait_for_callback(
+        submitter=submit_approval,
+        name='wait-approval',
+        config=WaitForCallbackConfig(timeout=Duration.from_hours(24))
+    )
+except CallbackError as error:
+    if error.error_type == 'Timeout':
+        context.logger.warn('Approval timed out')
+    else:
+        context.logger.error('Callback failed', error)
+```

--- a/plugins/aws-serverless/skills/aws-serverless-lambda/SKILL.md
+++ b/plugins/aws-serverless/skills/aws-serverless-lambda/SKILL.md
@@ -1,0 +1,33 @@
+---
+name: aws-serverless-lambda
+description: Design, build, test, debug, and optimize AWS Lambda applications, including event sources, Step Functions, EventBridge, observability, Powertools, and production readiness.
+---
+
+# AWS Serverless Lambda
+
+Use this skill when the user is working on Lambda functions, event-driven architecture, Step Functions, EventBridge, Lambda Web Adapter, Lambda Powertools, Lambda performance, or Lambda troubleshooting.
+
+## Workflow
+
+1. Identify the workload, runtime, deployment framework, target account or region, and whether the task is design-only or should touch local files or AWS.
+2. Inspect the repository before generating code. Look for `template.yaml`, `template.yml`, `samconfig.toml`, `cdk.json`, `package.json`, `pyproject.toml`, function handlers, event schemas, and CI workflows.
+3. Prefer TypeScript for new examples unless the project or user chooses another runtime.
+4. Prefer IaC for production resources. Use SAM for SAM projects, CDK for CDK projects, and do not mix frameworks unless the user asks.
+5. For event sources, design idempotent handlers. Lambda delivery is at least once, so duplicate events must be safe.
+6. Add observability early: structured logs, metrics, traces, correlation IDs, alarmable metrics, and bounded log retention.
+7. Keep IAM least privilege. Avoid wildcard actions and wildcard resources unless the user explicitly accepts the risk.
+8. When changing code, include local validation commands the user can approve, such as unit tests, `sam build`, `sam local invoke`, `cdk synth`, or linting.
+
+## MCP Use
+
+Use `aws-serverless-mcp` when serverless-specific tooling would help with SAM initialization, Lambda testing, EventBridge schema workflows, deployment guidance, or generated templates.
+
+Before calling MCP tools, explain what will be sent and why. Use the minimum necessary project names, template snippets, resource identifiers, and payloads. Do not send secrets, credentials, customer data, full logs, or unrelated private code.
+
+## Safety
+
+Ask before live AWS API calls, Lambda invokes, deployments, stack changes, IAM changes, network changes, log reads, CloudWatch queries, cost-bearing actions, or any MCP write operation.
+
+Do not assume `--allow-sensitive-data-access` is enabled for the MCP server. If a task needs logs or other sensitive runtime data, ask the user to approve the access path and prefer targeted AWS CLI commands over broad data dumps.
+
+Never place credentials in Lambda environment variables, templates, prompts, generated examples, or committed files. Prefer Secrets Manager, SSM Parameter Store, IAM roles, and short-lived credentials.

--- a/plugins/aws-serverless/skills/aws-serverless-lambda/SKILL.md
+++ b/plugins/aws-serverless/skills/aws-serverless-lambda/SKILL.md
@@ -1,33 +1,172 @@
 ---
 name: aws-serverless-lambda
-description: Design, build, test, debug, and optimize AWS Lambda applications, including event sources, Step Functions, EventBridge, observability, Powertools, and production readiness.
+description: "Design, build, deploy, test, and debug serverless applications with AWS Lambda. Triggers on phrases like: Lambda function, event source, serverless application, API Gateway, EventBridge, Step Functions, serverless API, event-driven architecture, Lambda trigger. For deploying non-serverless apps to AWS, use deploy-on-aws plugin instead."
+argument-hint: "[what are you building?]"
 ---
 
-# AWS Serverless Lambda
+# AWS Lambda Serverless Development
 
-Use this skill when the user is working on Lambda functions, event-driven architecture, Step Functions, EventBridge, Lambda Web Adapter, Lambda Powertools, Lambda performance, or Lambda troubleshooting.
+Design, build, deploy, and debug serverless applications with AWS serverless services. This skill provides access to serverless development guidance through the AWS Serverless MCP Server, helping you to build production-ready serverless applications with best practices built-in.
 
-## Workflow
+Use SAM CLI for project initialization and deployment, Lambda Web Adapter for web applications, or Event Source Mappings for event-driven architectures. AWS handles infrastructure provisioning, scaling, and monitoring automatically.
 
-1. Identify the workload, runtime, deployment framework, target account or region, and whether the task is design-only or should touch local files or AWS.
-2. Inspect the repository before generating code. Look for `template.yaml`, `template.yml`, `samconfig.toml`, `cdk.json`, `package.json`, `pyproject.toml`, function handlers, event schemas, and CI workflows.
-3. Prefer TypeScript for new examples unless the project or user chooses another runtime.
-4. Prefer IaC for production resources. Use SAM for SAM projects, CDK for CDK projects, and do not mix frameworks unless the user asks.
-5. For event sources, design idempotent handlers. Lambda delivery is at least once, so duplicate events must be safe.
-6. Add observability early: structured logs, metrics, traces, correlation IDs, alarmable metrics, and bounded log retention.
-7. Keep IAM least privilege. Avoid wildcard actions and wildcard resources unless the user explicitly accepts the risk.
-8. When changing code, include local validation commands the user can approve, such as unit tests, `sam build`, `sam local invoke`, `cdk synth`, or linting.
+Key capabilities:
 
-## MCP Use
+- SAM CLI Integration: Initialize, build, deploy, and test serverless applications
+- Web Application Deployment: Deploy full-stack applications with Lambda Web Adapter
+- Event Source Mappings: Configure Lambda triggers for DynamoDB, Kinesis, SQS, Kafka
+- Lambda durable functions: Resilient multi-step applications with checkpointing -- see the [aws-serverless-durable-functions skill](../aws-serverless-durable-functions/) for guidance
+- Lambda Managed Instances: Run Lambda on dedicated EC2 instances with managed lifecycle -- see the [aws-serverless-managed-instances skill](../aws-serverless-managed-instances/) for evaluation, configuration, and migration guidance
+- Schema Management: Type-safe EventBridge integration with schema registry
+- Observability: CloudWatch logs, metrics, and X-Ray tracing
+- Performance Optimization: Right-sizing, cost optimization, and troubleshooting
 
-Use `aws-serverless-mcp` when serverless-specific tooling would help with SAM initialization, Lambda testing, EventBridge schema workflows, deployment guidance, or generated templates.
+## When to Load Reference Files
 
-Before calling MCP tools, explain what will be sent and why. Use the minimum necessary project names, template snippets, resource identifiers, and payloads. Do not send secrets, credentials, customer data, full logs, or unrelated private code.
+Load the appropriate reference file based on what the user is working on:
 
-## Safety
+- Getting started, what to build, project type decision, or working with existing projects -> see [references/getting-started.md](references/getting-started.md)
+- SAM, CDK, deployment, IaC templates, CDK constructs, or CI/CD pipelines -> see the [aws-serverless-deployment skill](../aws-serverless-deployment/) (separate skill in this plugin)
+- Web app deployment, Lambda Web Adapter, API endpoints, CORS, authentication, custom domains, or sam local start-api -> see [references/web-app-deployment.md](references/web-app-deployment.md)
+- Event sources, DynamoDB Streams, Kinesis, SQS, Kafka, S3 notifications, or SNS -> see [references/event-sources.md](references/event-sources.md)
+- EventBridge, event bus, event patterns, event design, Pipes, or schema registry -> see [references/event-driven-architecture.md](references/event-driven-architecture.md)
+- Durable functions, checkpointing, replay model, saga pattern, or long-running Lambda workflows -> see the [aws-serverless-durable-functions skill](../aws-serverless-durable-functions/) (separate skill in this plugin with full SDK reference, testing, and deployment guides)
+- Lambda Managed Instances, LMI, capacity providers, multi-concurrency, EC2-backed Lambda, cold start elimination, or Lambda cost optimization with Reserved Instances -> see the [aws-serverless-managed-instances skill](../aws-serverless-managed-instances/) (separate skill in this plugin for evaluation, configuration, and migration)
+- Orchestration, workflows, or Durable Functions vs Step Functions -> see [references/orchestration-and-workflows.md](references/orchestration-and-workflows.md)
+- Step Functions, ASL, state machines, JSONata, Distributed Map, or SDK integrations -> see [references/step-functions.md](references/step-functions.md)
+- Step Functions testing, TestState API, mocking service integrations, or state machine unit tests -> see [references/step-functions-testing.md](references/step-functions-testing.md)
+- Observability, logging, tracing, metrics, alarms, or dashboards -> see [references/observability.md](references/observability.md)
+- Optimization, cold starts, memory tuning, cost, or streaming -> see [references/optimization.md](references/optimization.md)
+- Powertools, idempotency, feature flags, parameters, parser, batch processing, or data masking -> see [references/powertools.md](references/powertools.md)
+- Troubleshooting, errors, debugging, or deployment failures -> see [references/troubleshooting.md](references/troubleshooting.md)
 
-Ask before live AWS API calls, Lambda invokes, deployments, stack changes, IAM changes, network changes, log reads, CloudWatch queries, cost-bearing actions, or any MCP write operation.
+## Best Practices
 
-Do not assume `--allow-sensitive-data-access` is enabled for the MCP server. If a task needs logs or other sensitive runtime data, ask the user to approve the access path and prefer targeted AWS CLI commands over broad data dumps.
+### Project Setup
 
-Never place credentials in Lambda environment variables, templates, prompts, generated examples, or committed files. Prefer Secrets Manager, SSM Parameter Store, IAM roles, and short-lived credentials.
+- Do: Use `sam_init` or `cdk init` with an appropriate template for your use case
+- Do: Set global defaults for timeout, memory, runtime, and tracing (`Globals` in SAM, construct props in CDK)
+- Do: Use AWS Lambda Powertools for structured logging, tracing, metrics (EMF), idempotency, and batch processing -- available for Python, TypeScript, Java, and .NET
+- Don't: Copy-paste templates from the internet without understanding the resource configuration
+- Don't: Use the same memory and timeout values for all functions regardless of workload
+
+### Security
+
+- Do: Follow least-privilege IAM policies scoped to specific resources and actions
+- Do: Use `secure_esm_*` tools to generate correct IAM policies for event source mappings
+- Do: Store secrets in AWS Secrets Manager or SSM Parameter Store, never in environment variables
+- Do: Use VPC endpoints instead of NAT Gateways for AWS service access when possible
+- Do: Enable Amazon GuardDuty Lambda Protection to monitor function network activity for threats (cryptocurrency mining, data exfiltration, C2 callbacks)
+- Don't: Use wildcard (`*`) resource ARNs or actions in IAM policies
+- Don't: Hardcode credentials or secrets in application code or templates
+- Don't: Store user data or sensitive information in module-level variables -- execution environments can be reused across different callers
+
+### Idempotency
+
+- Do: Write idempotent function code -- Lambda delivers events at least once, so duplicate invocations must be safe
+- Do: Use the AWS Lambda Powertools Idempotency utility (backed by DynamoDB) for critical operations
+- Do: Validate and deduplicate events at the start of the handler before performing side effects
+- Don't: Assume an event will only ever be processed once
+
+For topic-specific best practices, see the dedicated guide files in the reference table above.
+
+## Lambda Limits Quick Reference
+
+Limits that developers commonly hit:
+
+| Resource                                     | Limit                               |
+| -------------------------------------------- | ----------------------------------- |
+| Function timeout                             | 900 seconds (15 minutes)            |
+| Memory                                       | 128 MB - 10,240 MB                  |
+| 1 vCPU equivalent                            | 1,769 MB memory                     |
+| Synchronous payload (request + response)     | 6 MB each                           |
+| Async invocation payload                     | 1 MB                                |
+| Streamed response                            | 200 MB                              |
+| Deployment package (.zip, uncompressed)      | 250 MB                              |
+| Deployment package (.zip upload, compressed) | 50 MB                               |
+| Container image                              | 10 GB                               |
+| Layers per function                          | 5                                   |
+| Environment variables (aggregate)            | 4 KB                                |
+| `/tmp` ephemeral storage                     | 512 MB - 10,240 MB                  |
+| Account concurrent executions (default)      | 1,000 (requestable increase)        |
+| Burst scaling rate                           | 1,000 new executions per 10 seconds |
+
+Check Service Quotas for your account limits: `aws lambda get-account-settings`
+
+## Troubleshooting Quick Reference
+
+| Error                               | Cause                          | Solution                                                                                                                                        |
+| ----------------------------------- | ------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------- |
+| `Build Failed`                      | Missing dependencies           | Run `sam_build` with `use_container: true`                                                                                                      |
+| `Stack is in ROLLBACK_COMPLETE`     | Previous deploy failed         | Delete stack with `aws cloudformation delete-stack`, redeploy                                                                                   |
+| `IteratorAge` increasing            | Stream consumer falling behind | Increase `ParallelizationFactor` and `BatchSize`. Use `esm_optimize`                                                                            |
+| EventBridge events silently dropped | No DLQ, retries exhausted      | Add `RetryPolicy` + `DeadLetterConfig` to rule target                                                                                           |
+| Step Functions failing silently     | No retry on Task state         | Add `Retry` with `Lambda.ServiceException`, `Lambda.AWSLambdaException`                                                                         |
+| Durable Function not resuming       | Missing IAM permissions        | Add `lambda:CheckpointDurableExecution` and `lambda:GetDurableExecutionState` -- see [aws-serverless-durable-functions skill](../aws-serverless-durable-functions/) |
+
+For detailed troubleshooting, see [references/troubleshooting.md](references/troubleshooting.md).
+
+## Configuration
+
+### AWS CLI Setup
+
+This skill requires that AWS credentials are configured on the host machine:
+
+Verify access: Run `aws sts get-caller-identity` to confirm credentials are valid
+
+### SAM CLI Setup
+
+1. Install SAM CLI: Follow the [SAM CLI installation guide](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/install-sam-cli.html)
+2. Verify: Run `sam --version`
+
+### Container Runtime Setup
+
+1. Install a Docker compatible container runtime: Required for `sam_local_invoke` and container-based builds
+2. Verify: Use an appropriate command such as `docker --version` or `finch --version`
+
+### MCP Server Configuration
+
+The Cline plugin registers `aws-serverless-mcp` with `--allow-write`, so the MCP server can create projects, generate IaC, and deploy when Cline uses its tools. Ask for explicit approval before any MCP tool or shell command that writes files, deploys, mutates AWS resources, changes IAM/DNS/certificates, reads logs, invokes functions, or incurs cost.
+
+Sensitive-data access is not enabled by this plugin. It does not pass `--allow-sensitive-data-access`; users who need log-reading MCP tools should configure that intentionally in their own MCP settings.
+
+### SAM Template Validation Hook
+
+This Cline plugin does not install the source automatic validation hook. Treat SAM template validation as an explicit workflow step: after editing `template.yaml` or `template.yml`, ask before running `sam validate --template <path> --lint`.
+
+
+## Language selection
+
+Default: TypeScript
+
+Override syntax:
+
+- "use Python" -> Generate Python code
+- "use JavaScript" -> Generate JavaScript code
+
+When not specified, ALWAYS use TypeScript
+
+## IaC framework selection
+
+Default: CDK
+
+Override syntax:
+
+- "use CloudFormation" -> Generate YAML templates
+- "use SAM" -> Generate YAML templates
+
+When not specified, ALWAYS use CDK
+
+### Serverless MCP Server Unavailable
+
+- Inform user: "AWS Serverless MCP not responding"
+- Ask: "Proceed without MCP support?"
+- DO NOT continue without user confirmation
+
+## Resources
+
+- [AWS SAM Documentation](https://docs.aws.amazon.com/serverless-application-model/)
+- [AWS Lambda Documentation](https://docs.aws.amazon.com/lambda/)
+- [AWS Lambda Powertools](https://docs.aws.amazon.com/powertools/)
+- [AWS CDK Documentation](https://docs.aws.amazon.com/cdk/)
+- [AWS Serverless MCP Server](https://github.com/awslabs/mcp/tree/main/src/aws-serverless-mcp-server)

--- a/plugins/aws-serverless/skills/aws-serverless-lambda/references/event-driven-architecture.md
+++ b/plugins/aws-serverless/skills/aws-serverless-lambda/references/event-driven-architecture.md
@@ -1,0 +1,425 @@
+# Event-Driven Architecture Guide
+
+## Choreography vs Orchestration
+
+The most important architectural decision in an event-driven system is whether services coordinate through choreography or orchestration.
+
+|                      | Choreography                                             | Orchestration                                                                           |
+| -------------------- | -------------------------------------------------------- | --------------------------------------------------------------------------------------- |
+| How it works     | Services emit events; other services react independently | A central coordinator (Step Functions, Durable Functions) directs each step             |
+| Coupling         | Loose -- publisher doesn't know about consumers           | Tighter -- coordinator knows about each step                                             |
+| Visibility       | Distributed; hard to see the full flow                   | Centralized; execution history in one place                                             |
+| Failure handling | Each service handles its own failures                    | Central error handling and retry logic                                                  |
+| Best for         | Independent services reacting to facts about the world   | Business-critical workflows requiring audit trails, visibility, and reliable sequencing |
+
+Use choreography (EventBridge + Lambda) when services are genuinely independent and don't need to know the outcome of each other's processing.
+
+Use orchestration (Step Functions / Lambda durable functions) when you need reliable sequencing, compensating transactions, human approval steps, or the ability to visualize and debug the full workflow.
+
+In practice, most systems use both: orchestration within a bounded context, choreography between bounded contexts.
+
+---
+
+## EventBridge Concepts
+
+### Event Bus Types
+
+| Type            | Use Case                                                                       |
+| --------------- | ------------------------------------------------------------------------------ |
+| Default bus | Receives AWS service events (EC2 state changes, S3 events, CodePipeline, etc.) |
+| Custom bus  | Your application events; recommended for all custom event routing              |
+| Partner bus | Receives events from SaaS partners (Datadog, Zendesk, Stripe, etc.)            |
+
+Always use a custom event bus for application events -- keeps your events separate from AWS service noise and simplifies IAM and monitoring.
+
+### Standard EventBridge Event Structure
+
+Every event on the bus has this envelope (added automatically by EventBridge):
+
+```json
+{
+  "version": "0",
+  "id": "12345678-1234-1234-1234-123456789012",
+  "source": "com.mycompany.orders",
+  "detail-type": "OrderPlaced",
+  "account": "123456789012",
+  "time": "2025-01-15T10:30:00Z",
+  "region": "us-east-1",
+  "resources": [],
+  "detail": {
+    "orderId": "ord-987",
+    "userId": "usr-123",
+    "total": 49.99
+  }
+}
+```
+
+- `source` -- identifies the publishing service (`com.mycompany.orders`)
+- `detail-type` -- identifies the event type (`OrderPlaced`)
+- `detail` -- your business payload (up to 1 MB per event entry)
+
+### SAM Configuration
+
+Custom event bus:
+
+```yaml
+OrderEventBus:
+  Type: AWS::Events::EventBus
+  Properties:
+    Name: order-events
+
+OrderEventBusArn:
+  Type: AWS::SSM::Parameter
+  Properties:
+    Name: /myapp/order-event-bus-arn
+    Value: !GetAtt OrderEventBus.Arn
+    Type: String
+```
+
+Lambda publishing events:
+
+```yaml
+MyFunction:
+  Type: AWS::Serverless::Function
+  Properties:
+    Policies:
+      - Statement:
+          - Effect: Allow
+            Action: events:PutEvents
+            Resource: !GetAtt OrderEventBus.Arn
+    Environment:
+      Variables:
+        EVENT_BUS_ARN: !GetAtt OrderEventBus.Arn
+```
+
+Lambda subscribing via rule:
+
+```yaml
+ProcessOrderFunction:
+  Type: AWS::Serverless::Function
+  Properties:
+    Events:
+      OrderPlaced:
+        Type: EventBridgeRule
+        Properties:
+          EventBusName: !Ref OrderEventBus
+          Pattern:
+            source:
+              - com.mycompany.orders
+            detail-type:
+              - OrderPlaced
+          RetryPolicy:
+            MaximumRetryAttempts: 3
+            MaximumEventAgeInSeconds: 3600
+          DeadLetterConfig:
+            Type: SQS
+            QueueLogicalId: ProcessOrderDLQ
+
+ProcessOrderDLQ:
+  Type: AWS::SQS::Queue
+  Properties:
+    MessageRetentionPeriod: 1209600  # 14 days
+```
+
+### Publishing Events from Lambda
+
+Python:
+
+```python
+import json
+import os
+from datetime import datetime, timezone
+import uuid
+import boto3
+from aws_lambda_powertools import Logger
+
+logger = Logger()
+events_client = boto3.client("events")
+event_bus_arn = os.environ["EVENT_BUS_ARN"]
+
+def publish_order_placed(order: dict):
+    events_client.put_events(
+        Entries=[{
+            "EventBusName": event_bus_arn,
+            "Source": "com.mycompany.orders",
+            "DetailType": "OrderPlaced",
+            "Detail": json.dumps({
+                "metadata": {
+                    "id": str(uuid.uuid4()),
+                    "version": "1",
+                    "timestamp": datetime.now(timezone.utc).isoformat(),
+                    "correlationId": logger.get_correlation_id(),
+                    "service": "order-service",
+                },
+                "data": order,
+            }),
+        }]
+    )
+```
+
+TypeScript:
+
+```typescript
+import { EventBridgeClient, PutEventsCommand } from '@aws-sdk/client-eventbridge';
+import { randomUUID } from 'crypto';
+
+const client = new EventBridgeClient({});
+const eventBusArn = process.env.EVENT_BUS_ARN!;
+
+async function publishOrderPlaced(order: Record<string, unknown>): Promise<void> {
+  await client.send(new PutEventsCommand({
+    Entries: [{
+      EventBusName: eventBusArn,
+      Source: 'com.mycompany.orders',
+      DetailType: 'OrderPlaced',
+      Detail: JSON.stringify({
+        metadata: {
+          id: randomUUID(),
+          version: '1',
+          timestamp: new Date().toISOString(),
+          service: 'order-service',
+        },
+        data: order,
+      }),
+    }],
+  }));
+}
+```
+
+---
+
+## Event Patterns (Content-Based Routing)
+
+EventBridge rules use event patterns to filter which events reach a target. Patterns match against the standard envelope fields and anything inside `detail`.
+
+All values are arrays -- a field matches if the event value equals any element in the array:
+
+```json
+{
+  "source": ["com.mycompany.orders"],
+  "detail-type": ["OrderPlaced", "OrderUpdated"],
+  "detail": {
+    "status": ["CONFIRMED"],
+    "total": [{ "numeric": [">", 100] }]
+  }
+}
+```
+
+Common pattern operators:
+
+| Operator        | Example                                         | Matches                   |
+| --------------- | ----------------------------------------------- | ------------------------- |
+| Exact match     | `"status": ["ACTIVE"]`                          | status equals "ACTIVE"    |
+| Multiple values | `"status": ["ACTIVE", "PENDING"]`               | status is either          |
+| Prefix          | `"id": [{"prefix": "ord-"}]`                    | id starts with "ord-"     |
+| Anything-but    | `"status": [{"anything-but": ["CANCELLED"]}]`   | status is not "CANCELLED" |
+| Exists          | `"refundId": [{"exists": true}]`                | refundId field is present |
+| Numeric range   | `"amount": [{"numeric": [">=", 0, "<", 1000]}]` | 0 <= amount < 1000         |
+| Null            | `"coupon": [null]`                              | coupon field is null      |
+
+Up to 5 targets per rule. If you need to fan out to more consumers, route to an SNS topic or use the rule to fan out via SQS.
+
+---
+
+## Event Design
+
+### Event Envelopes
+
+Wrap your business payload in a custom metadata layer inside `detail`. This provides consistent fields for filtering, deduplication, and observability across all events regardless of the transport (EventBridge, SNS, SQS, Kinesis):
+
+```json
+{
+  "metadata": {
+    "id": "01HXHMF28A94NS7NSHC5GM80F4",
+    "version": "1",
+    "timestamp": "2025-01-15T10:30:00Z",
+    "domain": "orders",
+    "service": "order-service",
+    "correlationId": "req-abc123"
+  },
+  "data": {
+    "orderId": "ord-987",
+    "userId": "usr-123",
+    "total": 49.99
+  }
+}
+```
+
+Key metadata fields:
+
+- `id` -- unique event identifier; use for idempotency deduplication
+- `version` -- schema version of the `data` payload
+- `timestamp` -- when the event occurred (not when it was received)
+- `correlationId` -- trace ID that flows through the entire request chain
+- `domain` / `service` -- for filtering and observability
+
+### Light Events vs Rich Events
+
+Light events carry only IDs and directly relevant fields. Consumers fetch additional data they need.
+
+Rich events include expanded entities -- the complete state of the object at the time of the event.
+
+|                           | Light events                              | Rich events                           |
+| ------------------------- | ----------------------------------------- | ------------------------------------- |
+| Payload size          | Small                                     | Large                                 |
+| Subscriber complexity | Higher (must hydrate)                     | Lower (self-contained)                |
+| Race conditions       | Risk between event publish and data fetch | None                                  |
+| Coupling              | Consumer coupled to publisher's API       | Consumer coupled to event schema only |
+
+Guidance:
+
+- Within a bounded context (same team, same domain): light events are fine -- you control both sides
+- Across bounded contexts (different teams, different domains): prefer rich events -- unknown consumers shouldn't need to call back into your service to understand what happened
+
+### Event Versioning
+
+Prefer the no-breaking-changes policy: always add new fields, never remove or rename existing fields, never change a field's type. Consumers that ignore unknown fields continue working without any changes.
+
+When a breaking change is unavoidable, the cleanest approach is versioning in the `detail-type`:
+
+```text
+OrderPlaced.v1   ->   OrderPlaced.v2
+```
+
+Consumers subscribe to specific versions. The publisher emits both versions during the migration window, then retires `v1` once all consumers have migrated.
+
+Avoid: using Lambda versions/aliases or API Gateway stages to version event-driven integrations -- IAM roles don't version alongside function versions, which creates subtle permission bugs.
+
+---
+
+## Retry Policy and Dead-Letter Queues
+
+EventBridge retries failed Lambda invocations with exponential backoff. Configure both `RetryPolicy` and a DLQ on every rule target that processes important events:
+
+```yaml
+Events:
+  OrderEvent:
+    Type: EventBridgeRule
+    Properties:
+      Pattern:
+        source: [com.mycompany.orders]
+      RetryPolicy:
+        MaximumRetryAttempts: 3         # 0-185; default 185
+        MaximumEventAgeInSeconds: 3600  # 60-86400; default 86400 (24h)
+      DeadLetterConfig:
+        Type: SQS
+        QueueLogicalId: MyDLQ
+```
+
+- `MaximumRetryAttempts` -- how many times EventBridge retries before sending to DLQ
+- `MaximumEventAgeInSeconds` -- EventBridge stops retrying after this age, even if retries remain
+- Without a DLQ, events that exhaust retries are silently dropped
+
+Process your DLQ actively. Set a CloudWatch alarm on `ApproximateNumberOfMessagesVisible` and reprocess events by replaying them back to the event bus.
+
+---
+
+## Archive and Replay
+
+EventBridge can archive all events (or a filtered subset) and replay them at any time. This is invaluable for:
+
+- Reprocessing events after deploying a bug fix
+- Bootstrapping new consumers with historical events
+- Disaster recovery
+
+Create an archive in SAM:
+
+```yaml
+OrderEventArchive:
+  Type: AWS::Events::Archive
+  Properties:
+    SourceArn: !GetAtt OrderEventBus.Arn
+    EventPattern:
+      source:
+        - com.mycompany.orders
+    RetentionDays: 30
+```
+
+Replay from the console, CLI, or API by specifying the archive, a time range, and optionally a different target bus.
+
+---
+
+## EventBridge Pipes
+
+Pipes provide point-to-point integrations following a Source -> Filter -> Enrich -> Target pattern. Use Pipes when you need to:
+
+- Connect a stream/queue source to a target with enrichment (e.g., add customer data before sending to Step Functions)
+- Filter events before they reach the target (you only pay for events that pass the filter)
+- Transform payloads without writing a Lambda function
+
+```yaml
+OrderPipe:
+  Type: AWS::Pipes::Pipe
+  Properties:
+    Source: !GetAtt OrderQueue.Arn
+    SourceParameters:
+      SqsQueueParameters:
+        BatchSize: 10
+    Filter:
+      Filters:
+        - Pattern: '{"body": {"eventType": ["ORDER_CREATED"]}}'
+    Enrichment: !GetAtt EnrichOrderFunction.Arn
+    Target: !Ref OrderProcessingStateMachine
+    TargetParameters:
+      StepFunctionStateMachineParameters:
+        InvocationType: FIRE_AND_FORGET
+    RoleArn: !GetAtt PipeRole.Arn
+```
+
+Pipes vs Rules:
+
+- Use Pipes for point-to-point (one source -> one target) with enrichment or transformation
+- Use Rules for fan-out (one event -> multiple targets) or when the source is the event bus itself
+
+---
+
+## Schema Registry
+
+The EventBridge Schema Registry discovers and stores schemas for events on your bus. Use it to generate typed code bindings and enforce contracts.
+
+Discover schemas automatically by enabling schema discovery on your event bus:
+
+```yaml
+OrderBusDiscovery:
+  Type: AWS::EventSchemas::Discoverer
+  Properties:
+    SourceArn: !GetAtt OrderEventBus.Arn
+```
+
+Once events flow through the bus, schemas appear in the registry. Then use the MCP tools to work with them:
+
+1. `list_registries` -- browse available registries
+2. `search_schema` with keywords (e.g., `"order"`) -- find relevant schemas
+3. `describe_schema` -- get the full schema definition
+4. Download code bindings from the console (Java, Python, TypeScript) -- generates typed event classes
+
+Use schemas as contracts: consumer teams reference a specific schema version. The publisher must not make breaking changes to a versioned schema without bumping the version.
+
+---
+
+## Push vs Poll
+
+| Pattern  | Services                           | Characteristics                                                                        |
+| -------- | ---------------------------------- | -------------------------------------------------------------------------------------- |
+| Push | EventBridge, SNS                   | Low latency; event delivered as soon as it occurs; minimal compute waste at low volume |
+| Poll | SQS+ESM, Kinesis, DynamoDB Streams | Full throughput control; ordered processing; higher latency; better for batching       |
+
+Choose push (EventBridge) when:
+
+- You need real-time fan-out to multiple independent consumers
+- Services are loosely coupled and don't need ordering guarantees
+- You want content-based routing without consumer-side filtering code
+
+Choose poll (SQS/Kinesis) when:
+
+- You need strict ordering within a partition or message group
+- Consumer needs to control throughput (e.g., protect a downstream database)
+- You need large batch sizes for cost efficiency (e.g., bulk database writes)
+
+---
+
+## Observability
+
+For EventBridge metrics to alarm on, CloudWatch Logs Insights queries, and correlation ID propagation patterns, see [observability.md](observability.md).
+
+Key principle: X-Ray traces Lambda execution but does not automatically connect publisher to consumer across the event bus. Propagate `correlationId` in the event `metadata` envelope (see Event Envelopes above) and use CloudWatch Logs Insights to reconstruct cross-service request chains.

--- a/plugins/aws-serverless/skills/aws-serverless-lambda/references/event-sources.md
+++ b/plugins/aws-serverless/skills/aws-serverless-lambda/references/event-sources.md
@@ -1,0 +1,460 @@
+# Lambda Event Sources Guide
+
+## Overview
+
+This guide covers the most common Lambda event sources -- both polling-based (Event Source Mappings) and push-based (S3 notifications, SNS subscriptions). Use `esm_guidance` for polling source setup recommendations and `esm_optimize` for performance tuning.
+
+Delivery guarantee: All Lambda event sources deliver events at least once. Your function must be idempotent -- the same record may be processed more than once. Use the AWS Lambda Powertools Idempotency utility (backed by DynamoDB) to handle duplicates safely.
+
+## Polling-Based Event Sources (ESM)
+
+Event Source Mappings use a Lambda-managed poller that reads from the source, batches records, and invokes your function. You control throughput via batch size, concurrency, and parallelization.
+
+### DynamoDB Streams
+
+Use case: React to data changes in DynamoDB tables
+
+Key configuration:
+
+- `StartingPosition`: `LATEST` for new records only, `TRIM_HORIZON` for all
+- `BatchSize`: 1-10000 (default 100)
+- `ParallelizationFactor`: 1-10 (default 1, increase for throughput)
+- `BisectBatchOnFunctionError`: Enable to isolate poison records
+- `MaximumRetryAttempts`: Set to prevent infinite retries (default unlimited)
+- `MaximumBatchingWindowInSeconds`: Buffer time before invoking (0-300)
+
+Best practices:
+
+- Enable `BisectBatchOnFunctionError` and set `MaximumRetryAttempts` to 3
+- Configure a dead-letter queue for records that exhaust retries
+- Use `ParallelizationFactor` > 1 when processing can't keep up
+
+### Kinesis Streams
+
+Use case: Process real-time streaming data
+
+Key configuration:
+
+- `BatchSize`: 1-10000 (default 100)
+- `ParallelizationFactor`: 1-10 (should not exceed shard count)
+- `MaximumBatchingWindowInSeconds`: Buffer time (0-300)
+- `TumblingWindowInSeconds`: For aggregation scenarios (0-900)
+- `StartingPosition`: `LATEST` or `TRIM_HORIZON`
+
+Best practices:
+
+- Higher batch sizes reduce invocation costs but increase timeout risk
+- Use tumbling windows for time-based aggregation (counts, sums, averages)
+- Enable enhanced fan-out when multiple consumers read from the same stream
+
+### SQS Queues
+
+Use case: Decouple components with reliable messaging
+
+Key configuration:
+
+- `BatchSize`: 1-10000 (default 10)
+- `MaximumBatchingWindowInSeconds`: Buffer time (0-300)
+- `MaximumConcurrency`: Limit concurrent Lambda invocations
+- `FunctionResponseTypes`: Set to `["ReportBatchItemFailures"]` to avoid reprocessing successful messages
+
+FIFO queue considerations:
+
+- Use `BatchSize: 1` for strict ordering
+- Limit `MaximumConcurrency` to prevent out-of-order processing
+- Use message group IDs for parallel processing within groups
+
+Python SQS batch processor with partial failure reporting:
+
+```python
+from aws_lambda_powertools import Logger
+from aws_lambda_powertools.utilities.batch import (
+    BatchProcessor, EventType, process_partial_response,
+)
+from aws_lambda_powertools.utilities.data_classes.sqs_event import SQSRecord
+
+logger = Logger()
+processor = BatchProcessor(event_type=EventType.SQS)
+
+def process_record(record: SQSRecord):
+    body = record.json_body
+    logger.info("Processing order", order_id=body["orderId"])
+    # Business logic here -- raise to mark this record as failed
+    return {"orderId": body["orderId"], "status": "processed"}
+
+@logger.inject_lambda_context
+def handler(event, context):
+    return process_partial_response(
+        event=event, record_handler=process_record, processor=processor, context=context,
+    )
+```
+
+TypeScript SQS batch processor:
+
+```typescript
+import {
+  BatchProcessor,
+  EventType,
+  processPartialResponse,
+} from '@aws-lambda-powertools/batch';
+import { Logger } from '@aws-lambda-powertools/logger';
+import type { SQSHandler, SQSRecord } from 'aws-lambda';
+
+const processor = new BatchProcessor(EventType.SQS);
+const logger = new Logger();
+
+const recordHandler = async (record: SQSRecord): Promise<void> => {
+  const body = JSON.parse(record.body);
+  logger.info('Processing order', { orderId: body.orderId });
+};
+
+export const handler: SQSHandler = async (event, context) =>
+  processPartialResponse(event, recordHandler, processor, { context });
+```
+
+Both examples require `FunctionResponseTypes: ["ReportBatchItemFailures"]` in the ESM configuration.
+
+Best practices:
+
+- Always enable `ReportBatchItemFailures` for partial failure handling
+- Set queue `VisibilityTimeout` >= Lambda function timeout
+- Configure a DLQ with `maxReceiveCount` of 3-5
+
+### MSK/Kafka
+
+Use case: Process high-throughput streaming data from Kafka
+
+Key configuration:
+
+- `Topics`: List of Kafka topics to consume
+- `BatchSize`: 1-10000 (default 100)
+- `MaximumBatchingWindowInSeconds`: Buffer time (0-300)
+- `StartingPosition`: `LATEST` or `TRIM_HORIZON`
+- `ConsumerGroupId`: Consumer group identifier
+
+Network requirements:
+
+- Lambda must have VPC access to the MSK cluster
+- Security groups must allow traffic on ports 9092 (plaintext) or 9094 (TLS)
+- Use IAM authentication or SASL/SCRAM for authentication
+
+Best practices:
+
+- Use `esm_kafka_troubleshoot` for connectivity issues
+- Generate IAM policies with `secure_esm_msk_policy`
+
+Powertools Kafka Consumer: For Kafka events with Avro, Protobuf, or JSON Schema payloads, use the Kafka Consumer utility to deserialize records automatically instead of manually parsing byte arrays:
+
+```python
+from aws_lambda_powertools.utilities.kafka import KafkaConsumer, SchemaConfig
+
+schema_config = SchemaConfig(schema_type="AVRO", schema_registry_url="https://my-registry.example.com")
+consumer = KafkaConsumer(schema_config=schema_config)
+
+@consumer.handler
+def handler(event, context):
+    for record in consumer.records:
+        # record.value is already deserialized from Avro
+        order = record.value
+        print(f"Order: {order['orderId']}")
+```
+
+Available for Python, TypeScript, Java, and .NET. Supports Avro, Protobuf, and JSON Schema with both AWS Glue Schema Registry and Confluent Schema Registry.
+
+### Amazon MQ
+
+Use case: Process messages from ActiveMQ or RabbitMQ brokers
+
+Lambda connects to Amazon MQ using a VPC-attached ESM. Configure the broker in a private subnet and ensure Lambda's security group can reach the broker port (61614 for ActiveMQ over STOMP/TLS, 5671 for RabbitMQ over AMQP/TLS).
+
+### Self-Managed Kafka
+
+Use case: Process messages from a Kafka cluster you operate (not MSK)
+
+Use a self-managed Kafka ESM when your cluster is not AWS-managed. Lambda connects via the network configuration you provide. Supports SASL/PLAIN, SASL/SCRAM, mTLS, and VPC connectivity.
+
+### Amazon DocumentDB (with change streams)
+
+Use case: React to changes in DocumentDB collections
+
+Similar to DynamoDB Streams -- Lambda polls the DocumentDB change stream. Requires DocumentDB change streams to be enabled on the collection and Lambda to have VPC access to the cluster.
+
+## Push-Based Event Sources
+
+These sources invoke Lambda directly via asynchronous invocation -- no ESM poller involved. Lower latency than polling sources, but less control over throughput and concurrency.
+
+### S3 Event Notifications
+
+Use case: React to object uploads, deletions, or modifications -- image processing, file validation, data import, thumbnail generation
+
+SAM template:
+
+```yaml
+ImageProcessor:
+  Type: AWS::Serverless::Function
+  Properties:
+    Handler: src/handlers/process_image.handler
+    Runtime: python3.12
+    Architectures: [arm64]
+    Policies:
+      - S3ReadPolicy:
+          BucketName: !Ref UploadBucket
+    Events:
+      ImageUploaded:
+        Type: S3
+        Properties:
+          Bucket: !Ref UploadBucket
+          Events: s3:ObjectCreated:*
+          Filter:
+            S3Key:
+              Rules:
+                - Name: prefix
+                  Value: uploads/
+                - Name: suffix
+                  Value: .jpg
+
+UploadBucket:
+  Type: AWS::S3::Bucket
+```
+
+Key configuration:
+
+- `Events`: Event types to trigger on -- `s3:ObjectCreated:*`, `s3:ObjectRemoved:*`, `s3:ObjectCreated:Put`, etc.
+- `Filter.S3Key.Rules`: Prefix and/or suffix filters to limit which objects trigger the function
+- `Bucket`: Must reference an `AWS::S3::Bucket` declared in the same SAM template
+
+Best practices:
+
+- Avoid recursive triggers -- if your function writes back to the same bucket that triggers it, Lambda will loop infinitely. Use a separate output bucket or a different prefix
+- S3 delivers events at least once and NOT in order -- write idempotent handlers and don't depend on event sequencing
+- URL-decode the object key (`urllib.parse.unquote_plus` in Python, `decodeURIComponent` in JS) -- S3 URL-encodes special characters in keys
+- Use prefix/suffix filters to limit invocations to relevant objects
+- For complex routing (multiple consumers, content-based filtering, cross-account), use S3 -> EventBridge instead -- enable EventBridge notifications on the bucket and create rules
+
+Python S3 event handler:
+
+```python
+import json
+import urllib.parse
+import boto3
+from aws_lambda_powertools import Logger
+
+logger = Logger()
+s3 = boto3.client('s3')
+
+@logger.inject_lambda_context
+def handler(event, context):
+    for record in event['Records']:
+        bucket = record['s3']['bucket']['name']
+        key = urllib.parse.unquote_plus(record['s3']['object']['key'])
+        size = record['s3']['object']['size']
+        logger.info("Processing object", bucket=bucket, key=key, size=size)
+
+        response = s3.get_object(Bucket=bucket, Key=key)
+        # Process the object content
+```
+
+TypeScript S3 event handler:
+
+```typescript
+import { Logger } from '@aws-lambda-powertools/logger';
+import { Tracer } from '@aws-lambda-powertools/tracer';
+import type { S3Event, Context } from 'aws-lambda';
+import { S3Client, GetObjectCommand } from '@aws-sdk/client-s3';
+
+const logger = new Logger();
+const tracer = new Tracer();
+const s3 = tracer.captureAWSv3Client(new S3Client({}));
+
+export const handler = async (event: S3Event, context: Context): Promise<void> => {
+  logger.addContext(context);
+  for (const record of event.Records) {
+    const bucket = record.s3.bucket.name;
+    const key = decodeURIComponent(record.s3.object.key.replace(/\+/g, ' '));
+    const size = record.s3.object.size;
+    logger.info('Processing object', { bucket, key, size });
+
+    const response = await s3.send(new GetObjectCommand({ Bucket: bucket, Key: key }));
+    // Process the object content
+  }
+};
+```
+
+### SNS Subscriptions
+
+Use case: Fan-out processing -- one published message triggers multiple independent Lambda consumers
+
+SAM template:
+
+```yaml
+OrderNotifier:
+  Type: AWS::Serverless::Function
+  Properties:
+    Handler: src/handlers/notify.handler
+    Runtime: python3.12
+    Architectures: [arm64]
+    Events:
+      OrderEvent:
+        Type: SNS
+        Properties:
+          Topic: !Ref OrderTopic
+          FilterPolicy:
+            event_type:
+              - order_placed
+              - order_shipped
+          FilterPolicyScope: MessageAttributes
+          RedrivePolicy:
+            deadLetterTargetArn: !GetAtt OrderDLQ.Arn
+
+OrderTopic:
+  Type: AWS::SNS::Topic
+
+OrderDLQ:
+  Type: AWS::SQS::Queue
+  Properties:
+    MessageRetentionPeriod: 1209600  # 14 days
+```
+
+Key configuration:
+
+- `Topic`: ARN or reference to the SNS topic
+- `FilterPolicy`: JSON filter to receive only matching messages -- reduces invocations and cost
+- `FilterPolicyScope`: `MessageAttributes` (default) or `MessageBody`
+- `RedrivePolicy`: DLQ ARN for messages that fail delivery -- configured at the subscription level, not the topic
+
+Best practices:
+
+- Use filter policies to reduce invocations -- filter at the subscription level, not in handler code
+- Configure a redrive policy (DLQ) on every subscription -- SNS retries server-side errors up to 100,015 times over 23 days; client-side errors (deleted function) go directly to DLQ
+- Set DLQ `MessageRetentionPeriod` to 14 days (maximum) for investigation time
+- SNS delivers at least once; write idempotent handlers
+- FIFO SNS topics do NOT support Lambda subscriptions -- use standard topics only
+- For simple point-to-point delivery, prefer SQS -> Lambda (ESM) over SNS -> Lambda
+- For complex event routing with pattern matching, prefer EventBridge over SNS
+
+Python SNS event handler:
+
+```python
+import json
+from aws_lambda_powertools import Logger
+
+logger = Logger()
+
+@logger.inject_lambda_context
+def handler(event, context):
+    for record in event['Records']:
+        message = json.loads(record['Sns']['Message'])
+        subject = record['Sns'].get('Subject', '')
+        message_id = record['Sns']['MessageId']
+        logger.info("Processing SNS message", message_id=message_id, subject=subject)
+
+        # Process the message
+```
+
+TypeScript SNS event handler:
+
+```typescript
+import { Logger } from '@aws-lambda-powertools/logger';
+import type { SNSEvent, Context } from 'aws-lambda';
+
+const logger = new Logger();
+
+export const handler = async (event: SNSEvent, context: Context): Promise<void> => {
+  logger.addContext(context);
+  for (const record of event.Records) {
+    const message = JSON.parse(record.Sns.Message);
+    const subject = record.Sns.Subject ?? '';
+    const messageId = record.Sns.MessageId;
+    logger.info('Processing SNS message', { messageId, subject });
+
+    // Process the message
+  }
+};
+```
+
+## Event Filtering
+
+### ESM Filtering (Polling Sources)
+
+ESM event filtering lets Lambda evaluate filter criteria before invoking your function, reducing unnecessary invocations and costs.
+
+Add filters in SAM template:
+
+```yaml
+MyFunction:
+  Type: AWS::Serverless::Function
+  Events:
+    MySQSEvent:
+      Type: SQS
+      Properties:
+        Queue: !GetAtt MyQueue.Arn
+        FilterCriteria:
+          Filters:
+            - Pattern: '{"body": {"eventType": ["ORDER_CREATED"]}}'
+```
+
+Filter pattern syntax matches against the event structure:
+
+- Exact match: `{"body": {"status": ["ACTIVE"]}}`
+- Prefix match: `{"body": {"id": [{"prefix": "order-"}]}}`
+- Numeric range: `{"body": {"amount": [{"numeric": [">", 100]}]}}`
+- Exists check: `{"body": {"metadata": [{"exists": true}]}}`
+
+Filtering is supported for SQS, Kinesis, DynamoDB Streams, MSK, self-managed Kafka, and MQ. Records that don't match filters are dropped before Lambda is invoked -- SQS messages are deleted, stream records are skipped.
+
+### Push Source Filtering
+
+Push-based sources use their own filtering mechanisms (not ESM FilterCriteria):
+
+- S3: Prefix/suffix filters on the object key via `Filter.S3Key.Rules` in the SAM template
+- SNS: Subscription filter policies via `FilterPolicy` -- supports matching on `MessageAttributes` (default) or `MessageBody`
+
+## ESM Provisioned Mode
+
+For high-throughput Kafka (MSK or self-managed) and SQS workloads, provisioned mode provides:
+
+- 3x faster autoscaling compared to default mode
+- 16x higher maximum capacity
+- Manual control over minimum and maximum event pollers
+
+Enable in SAM template:
+
+```yaml
+MySQSEvent:
+  Type: SQS
+  Properties:
+    Queue: !GetAtt MyQueue.Arn
+    ProvisionedPollerConfig:
+      MinimumPollers: 2
+      MaximumPollers: 20
+```
+
+Use provisioned mode when default autoscaling is too slow to absorb traffic spikes without message backlog.
+
+## Batch Size Guidelines
+
+| Priority         | Small (1-10)              | Medium (10-100) | Large (100-1000+)                       |
+| ---------------- | ------------------------- | --------------- | --------------------------------------- |
+| Latency      | Lowest                    | Moderate        | Higher                                  |
+| Cost         | Higher (more invocations) | Balanced        | Lower (fewer invocations)               |
+| Timeout risk | Low                       | Low             | Higher (more processing per invocation) |
+
+## Error Handling
+
+- Stream sources (DynamoDB, Kinesis): Records retry until success, expiry, or max retries. Enable `BisectBatchOnFunctionError` and set `MaximumRetryAttempts`.
+- SQS: Failed messages return to the queue after visibility timeout. Use `ReportBatchItemFailures` for partial batch success.
+- Kafka: Similar to stream sources. Failed batches retry based on ESM configuration.
+
+Always configure a dead-letter queue or on-failure destination to capture records that cannot be processed.
+
+## Monitoring
+
+For event source metrics to alarm on (IteratorAge, Errors, Throttles, DLQ depth), alarm thresholds, and dashboard setup, see [observability.md](observability.md).
+
+## Schema Integration
+
+For type-safe event processing with EventBridge:
+
+1. Use `search_schema` to find event schemas
+2. Use `describe_schema` to get the full definition
+3. Generate typed handlers based on the schema

--- a/plugins/aws-serverless/skills/aws-serverless-lambda/references/getting-started.md
+++ b/plugins/aws-serverless/skills/aws-serverless-lambda/references/getting-started.md
@@ -1,0 +1,152 @@
+# Getting Started with AWS Serverless Development
+
+## Prerequisites
+
+Verify these tools before proceeding:
+
+```bash
+aws --version                  # AWS CLI
+aws sts get-caller-identity    # Credentials configured
+sam --version                  # SAM CLI
+```
+
+Verify that any Docker-compatible container runtime is installed (Docker, Finch, Podman, etc.). Use the appropriate command for your runtime (e.g., `finch --version`).
+
+If `aws sts get-caller-identity` fails, ask user to set up credentials. If using CDK instead of SAM, also run `cdk --version` -- see [cdk-project-setup.md](../../aws-serverless-deployment/references/cdk-project-setup.md).
+
+## What Are You Building?
+
+### REST/HTTP API
+
+An API backend serving JSON over HTTPS -- the most common serverless pattern.
+
+Quick start:
+
+- Template: `hello-world` (single function + API Gateway) or `quick-start-web` (web framework)
+- Runtime: `nodejs22.x` or `python3.12`
+- Architecture: `arm64`
+
+Read next:
+
+- [sam-project-setup.md](../../aws-serverless-deployment/references/sam-project-setup.md) -- project scaffolding, deployment workflow, handler examples, container image packaging for large dependencies
+- [web-app-deployment.md](web-app-deployment.md) -- API endpoint selection (HTTP API vs REST API vs Function URL vs ALB), CORS, custom domains, authentication
+
+### Full-Stack Web Application
+
+A frontend (React, Vue, Angular, Next.js) with a backend API, deployed together.
+
+Quick start:
+
+- Template: `quick-start-web`
+- Use `deploy_webapp` with `deployment_type: "fullstack"` for S3 + CloudFront + Lambda + API Gateway
+
+Read next:
+
+- [web-app-deployment.md](web-app-deployment.md) -- Lambda Web Adapter, project structure, frontend updates
+
+### Event Processor
+
+A Lambda function triggered by a queue, stream, or database change -- SQS, Kinesis, DynamoDB Streams, Kafka, or DocumentDB.
+
+Quick start:
+
+- Template: `hello-world` (then add an event source in `template.yaml`)
+- Use `esm_guidance` to get the correct ESM configuration for your source
+- Use `secure_esm_*` tools to generate least-privilege IAM policies
+
+Read next:
+
+- [event-sources.md](event-sources.md) -- source-specific configuration, event filtering, batch processing examples
+- [observability.md](observability.md) -- structured logging, tracing, and monitoring for event processors
+- [optimization.md](optimization.md) -- ESM tuning parameters
+
+### File/Object Processor
+
+A Lambda function triggered when files are uploaded to or deleted from S3 -- image processing, file validation, data import, thumbnail generation.
+
+Quick start:
+
+- Template: `hello-world` (then add an S3 event in `template.yaml`)
+- Use prefix/suffix filters to limit triggers to specific paths or file types
+
+Read next:
+
+- [event-sources.md](event-sources.md) -- S3 event notification configuration and recursive trigger prevention
+
+### Notification Fan-Out
+
+One event triggers multiple independent consumers -- order notifications, alert distribution, cross-service communication.
+
+Quick start:
+
+- Create an SNS topic and subscribe multiple Lambda functions
+- Use filter policies to route subsets of messages to specific consumers
+
+Read next:
+
+- [event-sources.md](event-sources.md) -- SNS subscription configuration, filter policies, and DLQ setup
+- [event-driven-architecture.md](event-driven-architecture.md) -- for complex routing with EventBridge instead of SNS
+
+### Event-Driven Architecture
+
+Multiple services communicating through events on EventBridge -- decoupled, independently deployable.
+
+Quick start:
+
+- Create a custom event bus (never use the default bus for application events)
+- Define event schemas with `metadata` envelope for idempotency and tracing
+- Use `search_schema` and `describe_schema` for schema discovery
+
+Read next:
+
+- [event-driven-architecture.md](event-driven-architecture.md) -- event bus setup, event patterns, event design, Pipes, archive and replay
+- [observability.md](observability.md) -- correlation ID propagation, EventBridge metrics, and alarm strategy
+- [orchestration-and-workflows.md](orchestration-and-workflows.md) -- if you need reliable sequencing or human-in-the-loop
+
+### Multi-Step Workflow or AI Pipeline
+
+A workflow with sequential steps, parallel execution, human approval, or checkpointing -- order processing, document pipelines, agentic AI.
+
+Quick start:
+
+- Python 3.11+ or Node.js 22+: Use Lambda durable functions for workflows expressed as code -- see the [aws-serverless-durable-functions skill](../../aws-serverless-durable-functions/) for comprehensive guidance
+- Any runtime: Use Step Functions for visual orchestration with 200+ AWS service integrations
+- High-throughput, short-lived: Use Step Functions Express (100k+ exec/sec)
+
+Read next:
+
+- [orchestration-and-workflows.md](orchestration-and-workflows.md) -- Step Functions ASL, testing, patterns, and a Durable Functions vs Step Functions comparison
+
+### Scheduled Job
+
+A Lambda function triggered on a cron schedule -- reports, cleanup tasks, data sync.
+
+Add a `Schedule` event to your function in `template.yaml`:
+
+```yaml
+MyScheduledFunction:
+  Type: AWS::Serverless::Function
+  Properties:
+    Handler: src/handlers/report.handler
+    Events:
+      DailyReport:
+        Type: Schedule
+        Properties:
+          Schedule: cron(0 8 * * ? *)   # 8:00 AM UTC daily
+          Enabled: true
+```
+
+Read next:
+
+- [sam-project-setup.md](../../aws-serverless-deployment/references/sam-project-setup.md) -- project setup and deployment workflow
+
+## Working with Existing Projects
+
+When joining or modifying an existing SAM project:
+
+1. Look for `template.yaml` (or `template.yml`) at the project root
+2. Check `samconfig.toml` for deployment configuration and environment profiles
+3. Run `sam_build` to verify the project builds
+4. Use `sam_logs` and `get_metrics` to understand current behavior before making changes
+
+For CDK projects, look for `cdk.json` and run `cdk synth` to verify synthesis. See [cdk-project-setup.md](../../aws-serverless-deployment/references/cdk-project-setup.md).

--- a/plugins/aws-serverless/skills/aws-serverless-lambda/references/observability.md
+++ b/plugins/aws-serverless/skills/aws-serverless-lambda/references/observability.md
@@ -1,0 +1,521 @@
+# Observability Guide
+
+## Strategy
+
+Serverless observability relies on three pillars -- logs, metrics, and traces -- but the approach differs from traditional infrastructure. There are no servers to SSH into, functions are distributed by nature, and cold starts create visibility gaps. Every function should emit structured logs, publish custom metrics, and participate in distributed traces from day one.
+
+Use AWS Lambda Powertools as the consistent instrumentation layer across all functions. It handles Logger, Tracer, and Metrics with minimal boilerplate. For installation and the full utilities reference, see [powertools.md](powertools.md).
+
+### Decorator Stacking Order
+
+When combining multiple Powertools decorators on a single handler, order matters. Decorators execute outer-to-inner on invocation, inner-to-outer on return. Stack them in this order so that logging context is available first, metrics flush after business logic, and tracing wraps the entire execution:
+
+Python:
+
+```python
+from aws_lambda_powertools import Logger, Metrics, Tracer
+
+logger = Logger()
+metrics = Metrics()
+tracer = Tracer()
+
+@logger.inject_lambda_context(correlation_id_path="requestContext.requestId")
+@metrics.log_metrics(capture_cold_start_metric=True)
+@tracer.capture_lambda_handler
+def handler(event, context):
+    # Logger context available first (outermost)
+    # Tracer captures the full handler execution (innermost)
+    # Metrics flush after handler returns (middle, on exit)
+    ...
+```
+
+TypeScript (middy middleware):
+
+```typescript
+import { Logger, injectLambdaContext } from '@aws-lambda-powertools/logger';
+import { Metrics, logMetrics } from '@aws-lambda-powertools/metrics';
+import { Tracer, captureLambdaHandler } from '@aws-lambda-powertools/tracer';
+import middy from '@middy/core';
+
+const logger = new Logger();
+const metrics = new Metrics();
+const tracer = new Tracer();
+
+const lambdaHandler = async (event: any, context: any) => {
+  // Business logic
+};
+
+export const handler = middy(lambdaHandler)
+  .use(injectLambdaContext(logger))
+  .use(logMetrics(metrics))
+  .use(captureLambdaHandler(tracer));
+```
+
+Middy middleware executes in registration order (top-to-bottom on request, bottom-to-top on response), achieving the same effect as the Python decorator stack.
+
+## Structured Logging
+
+Use structured JSON logging so CloudWatch Logs Insights can query across fields rather than parsing free-text messages.
+
+Required fields in every log entry:
+
+- `request_id` -- Lambda request ID for correlating logs to a single invocation
+- `function_name` -- identifies which function emitted the log
+- `level` -- DEBUG, INFO, WARN, ERROR
+- Business context (user ID, order ID, operation type) as fields, not embedded in message strings
+
+Python:
+
+```python
+from aws_lambda_powertools import Logger
+
+logger = Logger()  # Reads POWERTOOLS_SERVICE_NAME from env
+
+@logger.inject_lambda_context(correlation_id_path="requestContext.requestId")
+def handler(event, context):
+    logger.info("Processing order", order_id=event["orderId"], amount=event["total"])
+    # Output: {"level":"INFO","message":"Processing order","order_id":"ord-123",
+    #          "amount":49.99,"request_id":"...","function_name":"...","correlation_id":"..."}
+```
+
+TypeScript:
+
+```typescript
+import { Logger } from '@aws-lambda-powertools/logger';
+import type { Context } from 'aws-lambda';
+
+const logger = new Logger();
+
+export const handler = async (event: any, context: Context) => {
+  logger.addContext(context);
+  logger.info('Processing order', { orderId: event.orderId, amount: event.total });
+};
+```
+
+Log level strategy:
+
+| Environment | Level | Rationale                                                 |
+| ----------- | ----- | --------------------------------------------------------- |
+| Development | DEBUG | Full visibility during development                        |
+| Staging     | INFO  | Verify behavior without noise                             |
+| Production  | WARN  | Minimize log volume and cost; drop to INFO when debugging |
+
+Set `LOG_LEVEL` or `POWERTOOLS_LOG_LEVEL` via environment variable -- no code changes needed to adjust per environment.
+
+Enable `POWERTOOLS_LOG_DEDUPLICATION_DISABLED=true` in test environments to prevent log deduplication issues with test frameworks.
+
+## Distributed Tracing
+
+X-Ray traces the execution path through your Lambda function and all downstream AWS SDK calls. Enable it globally in your SAM template:
+
+```yaml
+Globals:
+  Function:
+    Tracing: Active
+```
+
+Python:
+
+```python
+from aws_lambda_powertools import Tracer
+
+tracer = Tracer()
+
+@tracer.capture_lambda_handler
+def handler(event, context):
+    order = get_order(event["orderId"])
+    return order
+
+@tracer.capture_method
+def get_order(order_id: str):
+    tracer.put_annotation(key="orderId", value=order_id)
+    tracer.put_metadata(key="orderSource", value="dynamodb")
+    # Annotations are indexed and searchable in X-Ray console
+    # Metadata is attached but not indexed
+    return table.get_item(Key={"orderId": order_id})["Item"]
+```
+
+TypeScript:
+
+```typescript
+import { Tracer } from '@aws-lambda-powertools/tracer';
+import { DynamoDBClient } from '@aws-sdk/client-dynamodb';
+import { DynamoDBDocumentClient } from '@aws-sdk/lib-dynamodb';
+
+const tracer = new Tracer();
+const client = tracer.captureAWSv3Client(
+  DynamoDBDocumentClient.from(new DynamoDBClient({}))
+);
+
+export const handler = async (event: any, context: any) => {
+  tracer.putAnnotation('orderId', event.orderId);
+
+  const subsegment = tracer.getSegment()!.addNewSubsegment('processOrder');
+  try {
+    // Custom logic traced as a subsegment
+  } finally {
+    subsegment.close();
+  }
+};
+```
+
+Key concepts:
+
+- Annotations -- indexed key-value pairs you can filter on in the X-Ray console (e.g., find all traces for `orderId=ord-123`)
+- Metadata -- non-indexed data attached to a segment for debugging context
+- `captureAWSv3Client` -- automatically traces all AWS SDK calls (DynamoDB, S3, SQS, etc.) without manual subsegments
+- Subsegments -- wrap custom logic blocks to measure their duration separately
+- Cold start annotation -- add `ColdStart: true/false` as an annotation so you can filter X-Ray traces by cold start status and measure cold start impact on latency separately from warm invocations. Use the `capture_cold_start_metric=True` option on `@metrics.log_metrics` to track cold starts automatically via EMF metrics.
+
+Sampling rules: X-Ray defaults to 1 request/second reservoir + 5% of additional requests. For high-throughput functions, this is usually sufficient. Lower the percentage if tracing costs are a concern. Configure custom rules via the X-Ray console or API.
+
+Limitation: X-Ray trace context does not propagate across EventBridge, SQS, or SNS. The publisher and consumer appear as separate traces. Use correlation IDs (see below) to reconstruct cross-service request chains in logs.
+
+## CloudWatch Application Signals
+
+Application Signals provides APM-style capabilities on top of X-Ray, giving you service-level visibility without building custom dashboards or alarms from scratch. It uses the AWS Distro for OpenTelemetry (ADOT) Lambda layer to auto-instrument your functions.
+
+What it provides:
+
+- Service dependency map -- visual topology showing how your Lambda functions connect to downstream services (DynamoDB, S3, SQS, other Lambda functions, external APIs)
+- Pre-built service dashboards -- per-service latency (p50, p90, p99), error rate, throughput, and fault breakdown without manual widget configuration
+- SLO tracking -- define Service Level Objectives (latency p99 < 500ms, availability > 99.9%) and monitor compliance over rolling windows
+- Anomaly detection -- automatic alerting when a service deviates from its learned baseline
+
+Enable via SAM template:
+
+```yaml
+Globals:
+  Function:
+    Tracing: Active
+    Layers:
+      - !Sub arn:aws:lambda:${AWS::Region}:901920570463:layer:aws-otel-python-amd64-ver-1-25-0:1
+    Environment:
+      Variables:
+        AWS_LAMBDA_EXEC_WRAPPER: /opt/otel-instrument
+        OTEL_AWS_APPLICATION_SIGNALS_ENABLED: "true"
+        OTEL_METRICS_EXPORTER: none
+        OTEL_TRACES_SAMPLER: xray
+```
+
+Layer ARNs vary by runtime and architecture. Check the [ADOT Lambda layer documentation](https://aws-otel.github.io/docs/getting-started/lambda/) for the correct ARN for your runtime (Python, Node.js, Java, .NET) and architecture (amd64, arm64).
+
+SLO configuration happens in the CloudWatch console or via API after deployment -- define SLIs (latency percentile, error rate, availability) and set objectives with burn rate alerting.
+
+When to use Application Signals vs plain X-Ray:
+
+| Scenario                               | Recommendation                                                 |
+| -------------------------------------- | -------------------------------------------------------------- |
+| Single function, basic tracing         | X-Ray with Powertools Tracer                                   |
+| Multi-service system, need service map | Application Signals                                            |
+| SLO tracking and compliance reporting  | Application Signals                                            |
+| Custom trace annotations and filtering | X-Ray with Powertools Tracer (complements Application Signals) |
+
+Application Signals and Powertools Tracer are complementary -- ADOT handles auto-instrumentation and service-level metrics, while Powertools adds custom annotations, metadata, and fine-grained subsegments. Use both together for full coverage.
+
+Pricing: Application Signals charges per service signal ingested. For low-traffic services the cost is negligible; for high-throughput services, review the [Application Signals pricing page](https://aws.amazon.com/cloudwatch/pricing/) and use X-Ray sampling rules to control trace volume.
+
+## Custom Metrics
+
+Use Embedded Metric Format (EMF) instead of calling `cloudwatch:PutMetricData`. EMF writes metrics as structured log entries that CloudWatch parses asynchronously -- zero latency overhead and no extra API cost.
+
+Python:
+
+```python
+from aws_lambda_powertools import Metrics
+from aws_lambda_powertools.metrics import MetricUnit
+
+metrics = Metrics()  # Reads POWERTOOLS_METRICS_NAMESPACE from env
+
+@metrics.log_metrics(capture_cold_start_metric=True)
+def handler(event, context):
+    metrics.add_dimension(name="environment", value="prod")
+    metrics.add_metric(name="OrdersProcessed", unit=MetricUnit.Count, value=1)
+    metrics.add_metric(name="OrderTotal", unit=MetricUnit.Count, value=event["total"])
+```
+
+TypeScript:
+
+```typescript
+import { Metrics, MetricUnit } from '@aws-lambda-powertools/metrics';
+
+const metrics = new Metrics();
+
+export const handler = async (event: any) => {
+  metrics.addDimension('environment', 'prod');
+  metrics.addMetric('OrdersProcessed', MetricUnit.Count, 1);
+  metrics.addMetric('OrderTotal', MetricUnit.Count, event.total);
+  metrics.publishStoredMetrics();
+};
+```
+
+Dimensions: Standard dimensions should include service name and environment. Avoid high-cardinality dimensions (user IDs, request IDs) -- each unique combination creates a separate CloudWatch metric and incurs cost.
+
+Resolution: Standard resolution (60-second aggregation) is appropriate for most use cases. Use high resolution (1-second) only for latency-sensitive SLAs where you need sub-minute granularity.
+
+`capture_cold_start_metric=True` (Python) automatically publishes a `ColdStart` metric so you can track cold start frequency without manual instrumentation.
+
+### Technical Metrics vs Business KPIs
+
+Distinguish between technical metrics (errors, duration, throttles) and business KPI metrics (orders processed, revenue, user signups). Both are emitted via EMF, but they serve different audiences and alarm strategies.
+
+Technical metrics are infrastructure-facing -- they tell you whether the system is healthy. AWS provides most of these automatically; you supplement with custom metrics for gaps (e.g., cold start count).
+
+Business KPI metrics are product-facing -- they tell you whether the system is doing its job. These must be explicitly instrumented:
+
+```python
+# Technical metric -- system health
+metrics.add_metric(name="OrderProcessingErrors", unit=MetricUnit.Count, value=1)
+
+# Business KPI metric -- product health
+metrics.add_metric(name="OrdersPlaced", unit=MetricUnit.Count, value=1)
+metrics.add_metric(name="OrderRevenue", unit=MetricUnit.Count, value=order["total"])
+```
+
+Alarm differently: Technical metric alarms page the on-call engineer. Business KPI alarms (e.g., orders drop to zero) should notify the product team and may indicate a business issue rather than an infrastructure failure.
+
+Metric aggregation limit: CloudWatch EMF supports up to 100 metrics per log entry. If a single invocation emits more than 100 metrics, split them across multiple EMF blobs by calling `metrics.publish_stored_metrics()` (Python) or `metrics.publishStoredMetrics()` (TypeScript) mid-handler, then continuing to add metrics.
+
+## CloudWatch Alarms
+
+### Lambda Metrics
+
+| Metric                 | What it means                      | Recommended alarm          |
+| ---------------------- | ---------------------------------- | -------------------------- |
+| `Errors`               | Invocations that returned an error | Error rate > 1% over 5 min |
+| `Duration` (p90)       | Latency affecting most users       | p90 > 1.5x your baseline   |
+| `Duration` (p99)       | Latency outliers                   | p99 > 3x your baseline     |
+| `Throttles`            | Rejected due to concurrency limits | > 0                        |
+| `ConcurrentExecutions` | Current concurrent invocations     | > 80% of account limit     |
+
+Use p90 for early warning (catches widespread degradation) and p99 for tail latency (catches outlier slowness). Alert on p90 first -- if p90 is breaching, most users are affected.
+
+### Event Source Metrics
+
+| Metric                                   | What it means                                | Alarm |
+| ---------------------------------------- | -------------------------------------------- | ----- |
+| `IteratorAge` (streams)                  | Lag between record production and processing | > 60s |
+| DLQ `ApproximateNumberOfMessagesVisible` | Messages that exhausted retries              | > 0   |
+
+### EventBridge Metrics
+
+| Metric                  | What it means                                | Alarm             |
+| ----------------------- | -------------------------------------------- | ----------------- |
+| `FailedInvocations`     | Target invocations that failed after retries | > 0               |
+| `ThrottledRules`        | Rules throttled due to target limits         | > 0               |
+| `DeadLetterInvocations` | Events sent to DLQ                           | > 0               |
+| `MatchedEvents`         | Events that matched a rule                   | Anomaly detection |
+
+### Alarm Best Practices
+
+- Use anomaly detection for functions with variable traffic instead of static thresholds -- CloudWatch learns the expected pattern and alerts on deviations
+- Use composite alarms to reduce alert fatigue -- combine multiple signals (e.g., error rate AND duration spike) before paging
+- Set alarm actions to SNS for notifications; chain SNS -> Lambda for auto-remediation (e.g., increase reserved concurrency on throttle alarm)
+- Use `get_metrics` to retrieve current values before setting thresholds -- base alarms on observed behavior, not guesses
+
+## CloudWatch Logs Insights
+
+Useful queries for serverless debugging and analysis.
+
+Trace a correlation ID across services:
+
+```text
+fields @timestamp, @message
+| filter @message like /corr-id-value/
+| sort @timestamp asc
+```
+
+Run this query across multiple log groups simultaneously to follow a request through the entire service chain.
+
+Cold start frequency:
+
+```text
+filter @message like /REPORT/ and @message like /Init Duration/
+| stats count() as coldStarts, avg(@initDuration) as avgInitMs by bin(1h)
+```
+
+Error patterns:
+
+```text
+filter @message like /ERROR/
+| stats count() as errors by @message
+| sort errors desc
+| limit 20
+```
+
+Duration percentiles over time:
+
+```text
+filter @type = "REPORT"
+| stats avg(@duration) as avgMs, pct(@duration, 99) as p99Ms by bin(5m)
+```
+
+Slowest invocations:
+
+```text
+filter @type = "REPORT"
+| sort @duration desc
+| limit 10
+```
+
+## Lambda Insights
+
+Lambda Insights provides enhanced monitoring with per-function CPU utilization, memory usage, network throughput, and disk I/O -- metrics that standard Lambda monitoring does not expose.
+
+Enable via SAM template:
+
+```yaml
+Globals:
+  Function:
+    Layers:
+      - !Sub arn:aws:lambda:${AWS::Region}:580247275435:layer:LambdaInsightsExtension:53
+    Policies:
+      - CloudWatchLambdaInsightsExecutionRolePolicy
+```
+
+When to use:
+
+- Diagnosing memory leaks (memory usage grows across invocations)
+- Identifying CPU-bound functions that need more memory (and thus more CPU)
+- Network bottlenecks from slow downstream calls
+- Understanding disk I/O patterns for `/tmp`-heavy workloads
+
+Pricing: Lambda Insights writes performance log events to CloudWatch Logs and publishes enhanced metrics -- you pay standard CloudWatch Logs ingestion and metrics pricing based on invocation volume. Enable selectively for functions you are actively troubleshooting, not across all functions by default.
+
+## Dashboards
+
+### Two-Tier Dashboard Strategy
+
+Build two dashboards per service, each serving a different audience:
+
+High-level dashboard (for SREs, managers, stakeholders):
+
+- Overall error rate and availability (SLO compliance)
+- Business KPI trends (orders placed, revenue, active users)
+- Cross-service health summary (one row per service: green/yellow/red)
+- Time range: 24 hours or 7 days
+
+Low-level dashboard (for developers debugging issues):
+
+- Per-function: Errors, Duration p90/p99, ConcurrentExecutions, Throttles, ColdStarts
+- Per-API: 4xx rate, 5xx rate, Latency p99, Request count
+- Per-table: ThrottledReadRequests, ThrottledWriteRequests, ConsumedReadCapacityUnits
+- Per-stream: IteratorAge, GetRecords.IteratorAgeMilliseconds
+- Time range: 1 hour or 3 hours
+
+The high-level dashboard answers "is the system healthy?" The low-level dashboard answers "why is the system unhealthy?"
+
+### Dashboard as Code
+
+SAM template:
+
+```yaml
+ServerlessDashboard:
+  Type: AWS::CloudWatch::Dashboard
+  Properties:
+    DashboardName: !Sub "${AWS::StackName}-health"
+    DashboardBody: !Sub |
+      {
+        "widgets": [
+          {
+            "type": "metric",
+            "properties": {
+              "metrics": [
+                ["AWS/Lambda", "Errors", "FunctionName", "${MyFunction}", {"stat": "Sum"}],
+                ["AWS/Lambda", "Duration", "FunctionName", "${MyFunction}", {"stat": "p99"}],
+                ["AWS/Lambda", "Throttles", "FunctionName", "${MyFunction}", {"stat": "Sum"}]
+              ],
+              "period": 300,
+              "region": "${AWS::Region}",
+              "title": "Lambda Health"
+            }
+          }
+        ]
+      }
+```
+
+## Correlation ID Propagation
+
+X-Ray traces break at async boundaries (EventBridge, SQS, SNS). Propagate a `correlationId` through event metadata to reconstruct the full request chain in logs.
+
+Pattern: The producing function generates or forwards a correlation ID. The consuming function extracts it and injects it into Logger. All log entries from both functions share the same correlation ID, queryable via Logs Insights.
+
+Producer (Python):
+
+```python
+import json
+import boto3
+from aws_lambda_powertools import Logger
+
+logger = Logger()
+events_client = boto3.client("events")
+
+@logger.inject_lambda_context
+def handler(event, context):
+    events_client.put_events(Entries=[{
+        "Source": "orders.service",
+        "DetailType": "OrderPlaced",
+        "EventBusName": "my-app-bus",
+        "Detail": json.dumps({
+            "metadata": {
+                "correlationId": logger.get_correlation_id() or context.aws_request_id,
+            },
+            "data": {"orderId": "ord-123", "total": 49.99},
+        }),
+    }])
+```
+
+Consumer (Python):
+
+```python
+from aws_lambda_powertools import Logger
+
+logger = Logger()
+
+@logger.inject_lambda_context(correlation_id_path="detail.metadata.correlationId")
+def handler(event, context):
+    logger.info("Processing event")
+    # Every log entry now includes correlation_id from the producer
+```
+
+This pattern works identically for SQS (inject in message attributes) and SNS (inject in message attributes). The key is consistency: always inject `correlationId` in the same location so consumers can extract it with a predictable path.
+
+For the event envelope structure (including `correlationId`, `domain`, `service` fields), see the Event Envelopes section in [event-driven-architecture.md](event-driven-architecture.md).
+
+## Environment Variables
+
+| Variable                       | Purpose                                     |
+| ------------------------------ | ------------------------------------------- |
+| `POWERTOOLS_SERVICE_NAME`      | Service name for Logger, Tracer, Metrics    |
+| `POWERTOOLS_LOG_LEVEL`         | Log level (DEBUG, INFO, WARN, ERROR)        |
+| `POWERTOOLS_METRICS_NAMESPACE` | CloudWatch Metrics namespace                |
+| `POWERTOOLS_DEV`               | Enable verbose output for local development |
+
+Set these in the `Globals.Function.Environment.Variables` section of your SAM template. `POWERTOOLS_SERVICE_NAME` and `POWERTOOLS_METRICS_NAMESPACE` are required for Metrics; Logger and Tracer will use `POWERTOOLS_SERVICE_NAME` but fall back to the function name if unset.
+
+## Cost Management
+
+Observability has a cost. Manage it deliberately.
+
+Log retention: Set CloudWatch log retention per environment -- don't pay to store debug logs forever.
+
+| Environment | Retention | Rationale                     |
+| ----------- | --------- | ----------------------------- |
+| Development | 7 days    | Short-lived debugging         |
+| Staging     | 30 days   | Enough for release validation |
+| Production  | 90 days   | Incident investigation window |
+| Compliance  | 365+ days | Regulatory requirements       |
+
+```yaml
+MyFunctionLogGroup:
+  Type: AWS::Logs::LogGroup
+  Properties:
+    LogGroupName: !Sub "/aws/lambda/${MyFunction}"
+    RetentionInDays: 90
+```
+
+X-Ray sampling: The default (1 req/sec + 5%) is fine for most workloads. For functions processing thousands of requests per second, the 5% creates significant trace volume. Create a custom sampling rule with a lower fixed rate.
+
+Metrics cardinality: Every unique combination of dimensions creates a separate CloudWatch metric. A dimension with 10,000 unique values (like `userId`) creates 10,000 metrics. Use annotations in X-Ray traces for high-cardinality identifiers, not metric dimensions.
+
+Lambda Insights: Adds CloudWatch Logs ingestion and metrics costs per enabled function. The cost scales with invocation volume, so high-throughput functions cost more. Enable for functions you're actively investigating, disable when done.

--- a/plugins/aws-serverless/skills/aws-serverless-lambda/references/optimization.md
+++ b/plugins/aws-serverless/skills/aws-serverless-lambda/references/optimization.md
@@ -1,0 +1,330 @@
+# Optimization Guide
+
+## Memory and CPU Right-Sizing
+
+Lambda allocates CPU proportionally to memory. The goal is to find the configuration where cost-per-invocation is minimized while meeting latency requirements.
+
+Strategy:
+
+1. Use `get_metrics` to measure current duration, memory utilization, and invocation count
+2. Test with different memory settings using AWS Lambda Power Tuning
+3. Choose the memory level where cost (duration x memory price) is lowest
+
+General guidelines:
+
+- 128 MB: Lightweight tasks (routing, simple transformations)
+- 512 MB: Standard API handlers, moderate data processing
+- 1024 MB: Compute-intensive tasks, image processing
+- 3008+ MB: ML inference, large data processing
+
+CPU scaling: Lambda allocates CPU proportionally to memory. At 1,769 MB a function has the equivalent of one full vCPU. Functions below this threshold share a single vCPU. If your function is CPU-bound, the optimal memory setting is often 1,769 MB or higher.
+
+arm64 (Graviton) savings: arm64 is approximately 20% cheaper per GB-second than x86_64 and typically provides equal or faster performance. This is the single easiest cost optimization for most functions. Use x86_64 only when you depend on x86-only native binaries -- older Python C extension wheels (NumPy, Pandas pre-built for x86), Node.js native addons compiled for x86, or vendor-provided Lambda layers that ship only x86 binaries. Most pure-Python, pure-Node.js, and Java/Go/.NET workloads run on arm64 without changes.
+
+### AWS Lambda Power Tuning
+
+[Lambda Power Tuning](https://github.com/alexcasalboni/aws-lambda-power-tuning) is an open-source Step Functions state machine that automates memory/cost optimization. It invokes your function at multiple memory settings, measures duration and cost, and recommends the optimal configuration.
+
+How it works:
+
+1. Deploy the state machine into your AWS account (one-time setup)
+2. Execute it with your function ARN and the memory values to test
+3. It invokes your function N times at each memory setting, collects metrics
+4. Returns the optimal memory size plus a visualization URL showing the cost/performance curve
+
+Deploy via SAR (simplest):
+
+```bash
+aws serverlessrepo create-cloud-formation-change-set \
+  --application-id arn:aws:serverlessrepo:us-east-1:451282441545:applications/aws-lambda-power-tuning \
+  --stack-name lambda-power-tuning \
+  --capabilities CAPABILITY_IAM
+```
+
+Or deploy via SAM CLI:
+
+```bash
+sam init --location https://github.com/alexcasalboni/aws-lambda-power-tuning
+sam deploy --guided
+```
+
+Run the state machine:
+
+```json
+{
+  "lambdaARN": "arn:aws:lambda:us-east-1:123456789012:function:my-function",
+  "powerValues": [128, 256, 512, 1024, 1769, 3008],
+  "num": 50,
+  "payload": {}
+}
+```
+
+| Parameter     | Description                                                |
+| ------------- | ---------------------------------------------------------- |
+| `lambdaARN`   | ARN of the function to tune                                |
+| `powerValues` | Memory sizes (MB) to test -- include 1769 (1 vCPU boundary) |
+| `num`         | Invocations per memory setting (50-100 for stable results) |
+| `payload`     | Event payload to pass to each invocation                   |
+
+Output: The state machine returns the cheapest and fastest configurations with exact cost-per-invocation at each memory level. It also generates a visualization URL (data encoded client-side, nothing sent to external servers) showing the cost/performance tradeoff curve.
+
+When to use:
+
+- Before launching a new function to production -- right-size from the start
+- When `get_metrics` shows memory utilization is consistently very low or very high
+- After significant code changes that affect compute profile
+- Periodically (quarterly) for long-running production functions
+
+## Cold Start Optimization
+
+Cold starts affect latency on the first invocation after idle time or scaling events.
+
+Checklist:
+
+- [ ] Initialize SDK clients and database connections outside the handler function
+- [ ] Use `lru_cache` or module-level variables for configuration that doesn't change
+- [ ] Minimize deployment package size (exclude dev dependencies, use layers for shared code)
+- [ ] Choose a fast-starting runtime (Python, Node.js) for latency-sensitive paths
+- [ ] Consider `arm64` architecture for faster cold starts
+- [ ] Use provisioned concurrency only for consistently latency-sensitive endpoints
+
+When to use provisioned concurrency:
+
+- API endpoints with strict latency SLAs
+- Functions called synchronously where cold starts are user-visible
+- Not recommended for asynchronous or batch processing workloads
+
+## Lambda SnapStart
+
+SnapStart reduces cold start latency by taking a snapshot of the initialized execution environment, then resuming from that snapshot on subsequent invocations. This provides sub-second startup performance with minimal code changes.
+
+Supported runtimes: Java 11+, Python 3.12+, .NET 8+
+Not supported with: provisioned concurrency, EFS, ephemeral storage > 512 MB, container images
+
+Enable in SAM template:
+
+```yaml
+MyFunction:
+  Type: AWS::Serverless::Function
+  Properties:
+    Runtime: python3.12
+    SnapStart:
+      ApplyOn: PublishedVersions
+```
+
+SnapStart only works on published versions, not `$LATEST`. Always use an alias pointing to a published version.
+
+Critical -- handle uniqueness correctly:
+
+```python
+# WRONG: unique value captured in snapshot, reused across invocations
+import uuid
+CORRELATION_ID = str(uuid.uuid4())
+
+# CORRECT: generate unique values inside the handler
+def handler(event, context):
+    correlation_id = str(uuid.uuid4())
+```
+
+Re-establish connections on restore: Use `lambda_runtime_api_prepare_to_invoke.py` (Python) runtime hooks to reconnect databases or refresh credentials after snapshot restoration -- connection state is not guaranteed.
+
+When to use SnapStart vs provisioned concurrency:
+
+| Scenario                                   | Recommendation          |
+| ------------------------------------------ | ----------------------- |
+| Tolerate ~100-200 ms restore time          | SnapStart               |
+| Require < 10 ms latency                    | Provisioned concurrency |
+| Java/Python/.NET with heavy initialization | SnapStart               |
+| Infrequently invoked functions             | Neither                 |
+
+Pricing: Free for Java. Python and .NET incur a caching charge (minimum 3 hours) plus a restoration charge.
+
+## Lambda Managed Instances
+
+Lambda Managed Instances run your function on dedicated EC2 instances from your own account, while AWS still manages OS patching, load balancing, and auto-scaling. Unlike regular Lambda, each instance handles multiple concurrent requests, so your code must be thread-safe.
+
+When to use:
+
+- Consistent high-throughput workloads (hundreds to thousands of requests per second)
+- Workloads that benefit from warm connection pools shared across concurrent requests
+- Scenarios where cold starts must be eliminated at lower cost than provisioned concurrency
+
+When NOT to use:
+
+- Bursty or unpredictable traffic -- instances take tens of seconds to launch (vs. seconds for regular Lambda)
+- Low-volume applications
+- Any code that is not thread-safe (module-level mutable state, non-reentrant libraries)
+
+Cost model: EC2 instance cost + 15% premium + $0.20 per million requests. Compatible with existing EC2 Savings Plans. GPU instances are not supported.
+
+Configure via AWS CLI (SAM template support may vary -- check latest CloudFormation docs):
+
+```bash
+aws lambda create-function \
+  --function-name my-function \
+  --runtime python3.12 \
+  --handler app.handler \
+  --role arn:aws:iam::123456789012:role/my-role \
+  --code S3Bucket=my-bucket,S3Key=my-code.zip \
+  --compute-config '{"Mode": "ManagedInstances"}'
+```
+
+Thread safety requirement: Because multiple requests execute concurrently in the same environment, any module-level state must be read-only after initialization. Use connection pools designed for concurrent access (e.g., psycopg3 AsyncConnectionPool, SQLAlchemy async pools).
+
+## Cost Optimization
+
+### Decision Framework
+
+| Scenario                 | Recommendation                                             |
+| ------------------------ | ---------------------------------------------------------- |
+| Unpredictable traffic    | On-demand billing, no provisioned concurrency              |
+| Steady baseline + spikes | Provisioned concurrency for baseline, on-demand for spikes |
+| Batch processing         | Maximize batch size, optimize memory for cost              |
+| Infrequently called      | Minimize memory, accept cold starts                        |
+
+### Key Cost Levers
+
+- Memory: Lower memory is cheaper per-ms, but if it makes duration longer, net cost may increase
+- Timeout: Set to actual max expected duration + buffer, not the maximum 900s
+- Reserved concurrency: Caps maximum concurrent executions to prevent runaway costs
+- Storage: Use S3 lifecycle policies to transition objects to cheaper tiers
+- Logs: Set CloudWatch log retention to the minimum needed (7-30 days for dev, longer for prod/compliance)
+
+## API Gateway Optimization
+
+- Enable caching for read-heavy GET endpoints (0.5 GB cache is the minimum size)
+- Use request validation at the gateway level to reject bad requests before invoking Lambda
+- Use HTTP APIs (v2) instead of REST APIs when you don't need REST API-specific features (cheaper, lower latency)
+
+## Response Streaming
+
+Response streaming sends data to the client incrementally rather than buffering the complete response. This dramatically reduces time-to-first-byte (TTFB) for workloads where output is generated progressively.
+
+### When to Use Streaming
+
+| Scenario                               | Benefit                                                       |
+| -------------------------------------- | ------------------------------------------------------------- |
+| LLM/Bedrock responses                  | Users see tokens appear in real time instead of waiting       |
+| Responses > 6 MB                       | Streaming bypasses the 6 MB sync payload limit (up to 200 MB) |
+| Long-running operations (up to 15 min) | Keeps the HTTP connection alive and sends progress            |
+| Large file/dataset delivery            | Stream directly without S3 pre-signed URL workarounds         |
+
+### Lambda Side -- `streamifyResponse`
+
+Wrap your handler with `awslambda.streamifyResponse()` (Node.js runtime). Use `HttpResponseStream.from()` to attach HTTP metadata before writing to the stream.
+
+```typescript
+const streamingHandler = async (event: any, responseStream: NodeJS.WritableStream) => {
+  const httpStream = awslambda.HttpResponseStream.from(responseStream, {
+    statusCode: 200,
+    headers: { 'Content-Type': 'text/event-stream', 'Cache-Control': 'no-cache' },
+  });
+
+  // Write tokens in Server-Sent Events format
+  for await (const chunk of someStream) {
+    httpStream.write(`data: ${JSON.stringify({ token: chunk })}\n\n`);
+  }
+  httpStream.write('data: [DONE]\n\n');
+  httpStream.end();
+};
+
+export const handler = awslambda.streamifyResponse(streamingHandler);
+```
+
+Runtime support: Node.js only for `streamifyResponse`. Python and other runtimes can stream via Lambda Function URLs using a different mechanism.
+
+### API Gateway REST API -- Enable Streaming
+
+API Gateway REST API response streaming requires two changes in your OpenAPI definition:
+
+1. Use the `/response-streaming-invocations` Lambda ARN path (not `/invocations`)
+2. Set `responseTransferMode: STREAM` on the integration
+
+```yaml
+# openapi.yaml
+x-amazon-apigateway-integration:
+  type: AWS_PROXY
+  httpMethod: POST
+  uri:
+    Fn::Sub: "arn:aws:apigateway:${AWS::Region}:lambda:path/2021-11-15/functions/${MyFunction.Arn}/response-streaming-invocations"
+  responseTransferMode: STREAM
+  passthroughBehavior: when_no_match
+```
+
+Compare to the standard (non-streaming) path:
+
+```yaml
+# Standard (buffered) integration
+uri:
+  Fn::Sub: "arn:aws:apigateway:${AWS::Region}:lambda:path/2015-03-31/functions/${MyFunction.Arn}/invocations"
+```
+
+This feature is available on all endpoint types -- regional, private, and edge-optimized.
+
+### Lambda Function URLs -- Enable Streaming
+
+Function URLs also support streaming without API Gateway:
+
+```yaml
+MyFunction:
+  Type: AWS::Serverless::Function
+  Properties:
+    FunctionUrlConfig:
+      AuthType: AWS_IAM
+      InvokeMode: RESPONSE_STREAM   # default is BUFFERED
+```
+
+### Server-Sent Events (SSE) Pattern
+
+For LLM and AI streaming, use SSE format -- it's natively supported by browsers and easy to consume:
+
+```text
+data: {"token":"Hello"}\n\n
+data: {"token":" world"}\n\n
+data: [DONE]\n\n
+```
+
+Client-side consumption (JavaScript):
+
+```javascript
+const es = new EventSource('/streaming');
+es.onmessage = (e) => {
+  if (e.data === '[DONE]') { es.close(); return; }
+  appendToken(JSON.parse(e.data).token);
+};
+```
+
+### Key Limits
+
+| Resource                               | Limit      |
+| -------------------------------------- | ---------- |
+| Max streamed response size             | 200 MB     |
+| Standard (buffered) sync response      | 6 MB       |
+| Max integration timeout with streaming | 15 minutes |
+
+## DynamoDB Optimization
+
+- Use single-table design with composite keys (PK/SK) for efficient access patterns
+- Use `Query` instead of `Scan` wherever possible
+- Project only needed attributes to reduce read capacity usage
+- Use ON_DEMAND billing for unpredictable workloads, PROVISIONED with auto-scaling for steady workloads
+- Use GSIs with KEYS_ONLY projection when you only need to look up primary keys
+
+## Event Source Mapping Tuning
+
+Use `esm_optimize` to get source-specific recommendations. General guidelines:
+
+| Source           | Key Tuning Parameters                                                            |
+| ---------------- | -------------------------------------------------------------------------------- |
+| DynamoDB Streams | `BatchSize` (1-10000), `ParallelizationFactor` (1-10)                            |
+| Kinesis          | `BatchSize` (1-10000), `ParallelizationFactor` (1-10), `TumblingWindowInSeconds` |
+| SQS              | `BatchSize` (1-10000), `MaximumConcurrency`, `MaximumBatchingWindowInSeconds`    |
+| Kafka/MSK        | `BatchSize` (1-10000), `MaximumBatchingWindowInSeconds`                          |
+
+## Monitoring
+
+For Lambda metrics, event source metrics, EventBridge metrics, alarm configuration, and dashboard setup, see [observability.md](observability.md). Use `get_metrics` to retrieve current values.
+
+## AWS Lambda Powertools
+
+For Powertools installation, core utilities reference, deep dives (Feature Flags, Parameters, Parser, Environment Variable Validation, Streaming), and structured logging guidance, see [powertools.md](powertools.md).

--- a/plugins/aws-serverless/skills/aws-serverless-lambda/references/orchestration-and-workflows.md
+++ b/plugins/aws-serverless/skills/aws-serverless-lambda/references/orchestration-and-workflows.md
@@ -1,0 +1,40 @@
+# Orchestration and Workflows Guide
+
+## Choosing an Orchestration Approach
+
+| Approach                     | Best For                                                                                                                                                                                      | Runtime                                                                                                                                                                                                                                                                                                              |
+| ---------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Lambda durable functions | Multi-step business logic and AI/ML pipelines expressed as sequential code, with checkpointing and human-in-the-loop -- see the [aws-serverless-durable-functions skill](../../aws-serverless-durable-functions/) | Python: Python 3.11+ (Currently only Lambda runtime environments 3.13+ come with the Durable Execution SDK pre-installed. 3.11 is the min supported Python version by the Durable SDK itself, however, you could use OCI to bring your own container image with your own Python runtime + Durable SDK.), Node.js 22+ |
+| Step Functions Standard  | Cross-service orchestration, long-running auditable workflows, non-idempotent operations                                                                                                      | Any (JSON/YAML ASL definition)                                                                                                                                                                                                                                                                                       |
+| Step Functions Express   | High-volume, short-lived event processing, idempotent operations (100k+ exec/sec)                                                                                                             | Any                                                                                                                                                                                                                                                                                                                  |
+| EventBridge + Lambda     | Loosely coupled event-driven choreography with no central coordinator -- see [event-driven-architecture.md](event-driven-architecture.md)                                                      | Any                                                                                                                                                                                                                                                                                                                  |
+
+Key distinction: Lambda durable functions keep the workflow logic inside your Lambda code using standard language constructs. Step Functions define the workflow as a separate graph-based state machine that calls Lambda (and 9,000+ API actions across 200+ AWS services). Use durable functions when the workflow is tightly coupled to business logic written in Python or Node.js. Use Step Functions when you need visual design, cross-service coordination, or native service integrations without Lambda as an intermediary.
+
+---
+
+## Lambda durable functions
+
+Lambda Durable Functions enable resilient multi-step applications that execute for up to one year, with automatic checkpointing, replay, and suspension -- without consuming compute charges during wait periods.
+
+### Durable functions vs Step Functions
+
+|                          | Durable functions                                        | Step Functions                                                        |
+| ------------------------ | -------------------------------------------------------- | --------------------------------------------------------------------- |
+| Programming model    | Sequential code with `context.step()`                    | Graph-based state machine (ASL JSON/YAML)                             |
+| Runtimes             | Python 3.13+, Node.js 22+                                | Any (runtime-agnostic)                                                |
+| Workflow definition  | Inside your Lambda function code                         | Separate `.asl.json` file                                             |
+| AWS integrations     | Via SDK calls inside steps                               | 9,000+ native API actions (no Lambda needed)                          |
+| Execution visibility | CloudWatch Logs + `get-durable-execution-history`        | Step Functions console, execution history API                         |
+| Max duration         | Up to 1 year                                             | Standard: 1 year, Express: 5 minutes                                  |
+| Execution semantics  | At-least-once with checkpointing                         | Standard: exactly-once, Express: at-least-once                        |
+| Billing              | Active compute time only (free during waits)             | Per state transition (Standard) or per execution + duration (Express) |
+| Best for             | Business logic workflows, AI pipelines, code-first teams | Cross-service orchestration, visual workflows, polyglot teams         |
+
+For comprehensive durable functions guidance -- including the SDK, programming model, replay rules, testing, error handling, and deployment patterns -- see the [aws-serverless-durable-functions skill](../../aws-serverless-durable-functions/) in this plugin.
+
+---
+
+## AWS Step Functions
+
+For comprehensive Step Functions guidance -- Standard vs Express workflows, ASL definitions, JSONata, SDK integrations, Distributed Map, testing, and best practices -- see [step-functions.md](step-functions.md).

--- a/plugins/aws-serverless/skills/aws-serverless-lambda/references/powertools.md
+++ b/plugins/aws-serverless/skills/aws-serverless-lambda/references/powertools.md
@@ -1,0 +1,237 @@
+# AWS Lambda Powertools
+
+Lambda Powertools is the recommended library for implementing observability and reliability patterns with minimal boilerplate. It is available for Python, TypeScript, Java, and .NET.
+
+Install:
+
+| Runtime    | Command                                                                                                     |
+| ---------- | ----------------------------------------------------------------------------------------------------------- |
+| Python     | `pip install aws-lambda-powertools`                                                                         |
+| TypeScript | `npm i @aws-lambda-powertools/logger @aws-lambda-powertools/tracer @aws-lambda-powertools/metrics`          |
+| Java       | Add `software.amazon.lambda:powertools-tracing`, `powertools-logging`, `powertools-metrics` to Maven/Gradle |
+| .NET       | `dotnet add package AWS.Lambda.Powertools.Logging` (plus `.Tracing`, `.Metrics`)                            |
+
+SAM init templates:
+
+- Python: `sam init --app-template hello-world-powertools-python`
+- TypeScript: `sam init --app-template hello-world-powertools-typescript`
+
+Core utilities:
+
+| Utility                       | What it does                                                                                                   |
+| ----------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| Logger                    | Structured JSON logging with Lambda context automatically injected                                             |
+| Tracer                    | X-Ray tracing with decorators; traces handler + downstream calls                                               |
+| Metrics                   | Custom CloudWatch metrics via Embedded Metric Format (EMF) -- async, no API call overhead                       |
+| Idempotency               | Prevent duplicate execution using DynamoDB as idempotency store                                                |
+| Batch                     | Partial batch failure handling for SQS, Kinesis, DynamoDB Streams                                              |
+| Parameters                | Cached retrieval from SSM Parameter Store, Secrets Manager, AppConfig                                          |
+| Parser                    | Event validation with typed models -- Python uses Pydantic, TypeScript uses Zod                                 |
+| Feature Flags             | Rule-based feature toggles backed by AppConfig                                                                 |
+| Event Handler             | Route REST/HTTP API, GraphQL, and Bedrock Agent events with decorators (Python, TS, Java, .NET)                |
+| Kafka Consumer            | Deserialize Kafka events (Avro, Protobuf, JSON Schema) for MSK and self-managed Kafka (Python, TS, Java, .NET) |
+| Data Masking              | Redact or encrypt sensitive fields for compliance (Python, TS)                                                 |
+| Event Source Data Classes | Typed data classes for all Lambda event sources (Python)                                                       |
+
+Use Embedded Metric Format (EMF) for custom metrics -- zero latency overhead and no extra API cost. See [observability.md](observability.md) for setup and code examples.
+
+Parameters caching reduces cold start impact from secrets retrieval. The Parameters utility caches values for a configurable TTL (default 5 seconds), avoiding an API call on every invocation.
+
+Key environment variables:
+
+| Variable                        | Purpose                                                  |
+| ------------------------------- | -------------------------------------------------------- |
+| `POWERTOOLS_PARAMETERS_MAX_AGE` | Cache TTL in seconds for Parameters utility (default: 5) |
+
+For observability environment variables (`POWERTOOLS_SERVICE_NAME`, `POWERTOOLS_LOG_LEVEL`, `POWERTOOLS_METRICS_NAMESPACE`, `POWERTOOLS_DEV`), see [observability.md](observability.md).
+
+Parser validation: Python uses Pydantic models; TypeScript uses Zod schemas. Both provide compile-time type safety and runtime validation for Lambda event payloads.
+
+## Structured Logging
+
+For structured logging best practices, Logger setup (Python and TypeScript), log level strategy, and Logs Insights queries, see [observability.md](observability.md).
+
+## Deep Dives
+
+### Feature Flags
+
+Use Feature Flags for runtime configuration changes without redeployment -- percentage rollouts, user-targeted flags, and kill switches. The backend is AWS AppConfig, which supports deployment strategies (linear, canary, all-at-once) with automatic rollback.
+
+Python:
+
+```python
+from aws_lambda_powertools.utilities.feature_flags import AppConfigStore, FeatureFlags
+
+app_config = AppConfigStore(environment="prod", application="my-app", name="features")
+feature_flags = FeatureFlags(store=app_config)
+
+def handler(event, context):
+    # Boolean flag with default
+    dark_mode = feature_flags.evaluate(name="dark_mode", default=False)
+
+    # Rules-based flag (percentage rollout, user targeting)
+    new_checkout = feature_flags.evaluate(
+        name="new_checkout",
+        context={"username": event["requestContext"]["authorizer"]["claims"]["sub"]},
+        default=False,
+    )
+```
+
+TypeScript:
+
+```typescript
+import { AppConfigProvider } from '@aws-lambda-powertools/parameters/appconfig';
+import { FeatureFlags } from '@aws-lambda-powertools/parameters/feature-flags';
+
+const provider = new AppConfigProvider({
+  environment: 'prod',
+  application: 'my-app',
+  name: 'features',
+});
+const featureFlags = new FeatureFlags({ provider });
+
+export const handler = async (event: any) => {
+  const darkMode = await featureFlags.evaluate('dark_mode', false);
+  const newCheckout = await featureFlags.evaluate('new_checkout', false, {
+    username: event.requestContext.authorizer.claims.sub,
+  });
+};
+```
+
+### Parameters
+
+The Parameters utility provides cached retrieval from SSM Parameter Store, Secrets Manager, and AppConfig with a configurable TTL.
+
+Default TTL: 5 seconds. Override globally with the `POWERTOOLS_PARAMETERS_MAX_AGE` environment variable (in seconds) or per-call with `max_age`.
+
+Python:
+
+```python
+from aws_lambda_powertools.utilities.parameters import get_parameter, get_secret
+
+# Cached for 300 seconds
+db_host = get_parameter("/my-app/prod/db-host", max_age=300)
+
+# Secrets Manager -- decrypted and cached
+db_password = get_secret("my-app/prod/db-password", max_age=300)
+```
+
+TypeScript:
+
+```typescript
+import { getParameter } from '@aws-lambda-powertools/parameters/ssm';
+import { getSecret } from '@aws-lambda-powertools/parameters/secrets';
+
+const dbHost = await getParameter('/my-app/prod/db-host', { maxAge: 300 });
+const dbPassword = await getSecret('my-app/prod/db-password', { maxAge: 300 });
+```
+
+### Parser (Input Validation)
+
+Validate event payloads at the system boundary using typed schemas. Catches malformed input before your business logic runs.
+
+Python (Pydantic):
+
+```python
+from pydantic import BaseModel, field_validator
+from aws_lambda_powertools.utilities.parser import event_parser
+from aws_lambda_powertools.utilities.parser.envelopes import ApiGatewayEnvelope
+
+class OrderRequest(BaseModel):
+    order_id: str
+    amount: float
+    currency: str = "USD"
+
+    @field_validator("amount")
+    def amount_must_be_positive(cls, v):
+        if v <= 0:
+            raise ValueError("amount must be positive")
+        return v
+
+@event_parser(model=OrderRequest, envelope=ApiGatewayEnvelope)
+def handler(event: OrderRequest, context):
+    # event is already validated and typed
+    return {"statusCode": 200, "body": f"Order {event.order_id}: {event.amount} {event.currency}"}
+```
+
+TypeScript (Zod):
+
+```typescript
+import { z } from 'zod';
+import { APIGatewayProxyEvent, APIGatewayProxyResult, Context } from 'aws-lambda';
+
+const OrderRequest = z.object({
+  orderId: z.string(),
+  amount: z.number().positive(),
+  currency: z.string().default('USD'),
+});
+
+type OrderRequest = z.infer<typeof OrderRequest>;
+
+export const handler = async (event: APIGatewayProxyEvent): Promise<APIGatewayProxyResult> => {
+  const parsed = OrderRequest.safeParse(JSON.parse(event.body ?? '{}'));
+  if (!parsed.success) {
+    return { statusCode: 400, body: JSON.stringify({ errors: parsed.error.issues }) };
+  }
+  const order = parsed.data;
+  return { statusCode: 200, body: JSON.stringify({ orderId: order.orderId }) };
+};
+```
+
+### Environment Variable Validation
+
+Validate required environment variables at module load time (outside the handler) so misconfigured functions fail immediately on cold start rather than producing cryptic errors mid-invocation.
+
+Python (Pydantic):
+
+```python
+import os
+from pydantic import BaseModel
+
+class Config(BaseModel):
+    table_name: str
+    event_bus_arn: str
+    log_level: str = "INFO"
+
+# Validated once at module load -- fails fast if TABLE_NAME or EVENT_BUS_ARN is missing
+config = Config(
+    table_name=os.environ["TABLE_NAME"],
+    event_bus_arn=os.environ["EVENT_BUS_ARN"],
+    log_level=os.environ.get("LOG_LEVEL", "INFO"),
+)
+```
+
+TypeScript (Zod):
+
+```typescript
+import { z } from 'zod';
+
+const Config = z.object({
+  TABLE_NAME: z.string(),
+  EVENT_BUS_ARN: z.string(),
+  LOG_LEVEL: z.string().default('INFO'),
+});
+
+// Validated once at module load
+const config = Config.parse(process.env);
+```
+
+This pattern catches missing or malformed configuration at deploy time (via smoke tests) or immediately on first invocation, rather than on the specific code path that uses the variable.
+
+### Streaming (Python)
+
+For processing S3 objects larger than available Lambda memory, use the Powertools Streaming utility. It provides a stream-like interface that reads data in chunks without loading the entire object into memory.
+
+```python
+from aws_lambda_powertools.utilities.streaming import S3Object
+
+def handler(event, context):
+    bucket = event["Records"][0]["s3"]["bucket"]["name"]
+    key = event["Records"][0]["s3"]["object"]["key"]
+
+    s3_object = S3Object(bucket=bucket, key=key)
+    for line in s3_object:
+        process_line(line)
+```
+
+This is particularly useful for CSV/JSON-lines processing, log analysis, and any workload where the input file exceeds the function's memory allocation.

--- a/plugins/aws-serverless/skills/aws-serverless-lambda/references/step-functions-testing.md
+++ b/plugins/aws-serverless/skills/aws-serverless-lambda/references/step-functions-testing.md
@@ -1,0 +1,286 @@
+# AWS Step Functions Testing
+
+## TestState API
+
+TestState API enables unit and integration testing of Step Functions without deployment. Key capabilities:
+
+- Mock service integrations -- Test without invoking real services
+- Advanced states -- Map, Parallel, Activity, `.sync`, `.waitForTaskToken` (require mocks)
+- Control execution -- Simulate retries, Map iterations, error scenarios
+- Chain tests -- Use output->input to test execution paths
+- Optional IAM -- When mocking, `roleArn` optional
+
+```bash
+aws stepfunctions test-state \
+  --definition '{"Type":"Task","Resource":"arn:aws:states:::lambda:invoke","Arguments":{...},"End":true}' \
+  --input '{"data":"value"}' \
+  --mock '{"result":"{\"StatusCode\":200,\"Payload\":{\"body\":\"success\"}}"}' \
+  --inspection-level DEBUG
+```
+
+## Inspection Levels
+
+| Level     | Returns                                                                         | Use Case            |
+| --------- | ------------------------------------------------------------------------------- | ------------------- |
+| INFO  | `output`, `status`, `nextState`                                                 | Quick validation    |
+| DEBUG | + `afterInputPath`, `afterParameters`, `afterResultSelector`, `afterResultPath` | Data flow debugging |
+| TRACE | + HTTP `request`/`response` (use `--reveal-secrets` for auth)                   | HTTP Task debugging |
+
+## Critical: Service-Specific Mock Structure
+
+Warning: Mocks MUST match AWS service API response schema exactly -- field names (case-sensitive), types, required fields.
+
+### Finding Mock Structure
+
+1. Identify service from `Resource` ARN: `arn:aws:states:::lambda:invoke` -> Lambda `Invoke` API
+2. Consult AWS SDK docs for that API's Response Syntax
+3. Structure mock to match
+
+### Common Service Mocks
+
+| Service         | API              | Mock Structure                          | Example                                                                       |
+| --------------- | ---------------- | --------------------------------------- | ----------------------------------------------------------------------------- |
+| Lambda          | `Invoke`         | `{StatusCode, Payload, FunctionError?}` | `'{"result":"{\"StatusCode\":200,\"Payload\":{\"body\":\"ok\"}}\"}'`          |
+| DynamoDB        | `PutItem`        | `{Attributes?}`                         | `'{"result":"{\"Attributes\":{\"id\":{\"S\":\"123\"}}}"}'`                    |
+| DynamoDB        | `GetItem`        | `{Item?}`                               | `'{"result":"{\"Item\":{\"id\":{\"S\":\"123\"}}}"}'`                          |
+| SNS             | `Publish`        | `{MessageId}`                           | `'{"result":"{\"MessageId\":\"abc-123\"}"}'`                                  |
+| SQS             | `SendMessage`    | `{MessageId, MD5OfMessageBody}`         | `'{"result":"{\"MessageId\":\"xyz\",\"MD5OfMessageBody\":\"...\"}"}'`         |
+| EventBridge     | `PutEvents`      | `{FailedEntryCount, Entries[]}`         | `'{"result":"{\"FailedEntryCount\":0,\"Entries\":[{\"EventId\":\"123\"}]}"}'` |
+| S3              | `PutObject`      | `{ETag, VersionId?}`                    | `'{"result":"{\"ETag\":\"\\\"abc123\\\"\"}"}'`                                |
+| Step Functions  | `StartExecution` | `{ExecutionArn, StartDate}`             | `'{"result":"{\"ExecutionArn\":\"arn:...\",\"StartDate\":\"...\"}"}'`         |
+| Secrets Manager | `GetSecretValue` | `{ARN, Name, SecretString?}`            | `'{"result":"{\"Name\":\"MySecret\",\"SecretString\":\"...\"}"}'`             |
+
+For `.sync` patterns: Mock the polling API (e.g., `startExecution.sync:2` -> mock `DescribeExecution`, NOT `StartExecution`)
+
+### Mock Syntax
+
+Success: `--mock '{"result":"<service API response JSON>"}'`\
+Error: `--mock '{"errorOutput":{"error":"ErrorCode","cause":"description"}}'`\
+Validation: `--mock '{"fieldValidationMode":"STRICT|PRESENT|NONE","result":"..."}'`
+
+Validation modes:
+
+- `STRICT` (default): All required fields, correct types -- use in CI/CD
+- `PRESENT`: Only validate fields present -- flexible testing
+- `NONE`: No validation -- quick prototyping only
+
+## Testing Map States
+
+Tests Map's input/output processing, not iterations inside. Mock = entire Map output.
+
+```bash
+aws stepfunctions test-state \
+  --definition '{
+    "Type":"Map",
+    "ItemsPath":"$.items",
+    "ItemSelector":{"value.$":"$$.Map.Item.Value"},
+    "ItemProcessor":{"ProcessorConfig":{"Mode":"INLINE"},...},
+    "End":true
+  }' \
+  --input '{"items":[1,2,3]}' \
+  --mock '{"result":"[10,20,30]"}' \
+  --inspection-level DEBUG
+```
+
+DEBUG returns: `afterItemsPath`, `afterItemSelector`, `afterItemBatcher`, `toleratedFailureCount`, `maxConcurrency`
+
+Distributed Map: Provide data in input (as if read from S3)\
+Failure threshold testing: Use `--state-configuration '{"mapIterationFailureCount":N}'`\
+Testing state within Map: `--state-name` auto-populates `$$.Map.Item.Index`, `$$.Map.Item.Value`
+
+## Testing Parallel States
+
+Mock = JSON array, one element per branch (in definition order):
+
+```bash
+--mock '{"result":"[{\"branch1\":\"result1\"},{\"branch2\":\"result2\"}]"}'
+```
+
+## Testing Error Handling
+
+### Retry Logic
+
+```bash
+--state-configuration '{"retrierRetryCount":1}' \
+--mock '{"errorOutput":{"error":"Lambda.ServiceException","cause":"..."}}' \
+--inspection-level DEBUG
+```
+
+Response includes: `status:"RETRIABLE"`, `retryBackoffIntervalSeconds`, `retryIndex`
+
+### Catch Handlers
+
+```bash
+--mock '{"errorOutput":{"error":"Lambda.TooManyRequestsException","cause":"..."}}' \
+--inspection-level DEBUG
+```
+
+Response includes: `status:"CAUGHT_ERROR"`, `nextState`, `catchIndex`, error in `output` via `ResultPath`
+
+### Error Propagation in Map/Parallel
+
+```bash
+--state-name "ChildState" \
+--state-configuration '{"errorCausedByState":"ChildState"}' \
+--mock '{"errorOutput":{"error":"States.TaskFailed","cause":"..."}}'
+```
+
+## Testing .sync and .waitForTaskToken
+
+Required: Must provide mock (validation exception otherwise)
+
+### .sync Patterns
+
+Mock the polling API, not initial call:
+
+```bash
+# startExecution.sync:2 -> mock DescribeExecution
+--mock '{"result":"{\"Status\":\"SUCCEEDED\",\"Output\":\"{...}\"}"}'
+```
+
+Common patterns: `startExecution.sync:2`->`DescribeExecution`, `batch:submitJob.sync`->`DescribeJobs`, `glue:startJobRun.sync`->`GetJobRun`
+
+### .waitForTaskToken
+
+```bash
+--context '{"Task":{"Token":"test-token-123"}}' \
+--mock '{"result":"{\"StatusCode\":200,\"Payload\":{\"status\":\"approved\"}}"}'
+```
+
+## Activity States
+
+Require mock:
+
+```bash
+--definition '{"Type":"Task","Resource":"arn:aws:states:...:activity:MyActivity",...}' \
+--mock '{"result":"{\"result\":\"completed\"}"}'
+```
+
+## Chaining Tests (Integration Testing)
+
+```bash
+RESULT_1=$(aws stepfunctions test-state --state-name "State1" ... | jq -r '.output')
+NEXT_1=$(... | jq -r '.nextState')
+RESULT_2=$(aws stepfunctions test-state --state-name "$NEXT_1" --input "$RESULT_1" ...)
+```
+
+Validates: data transformations, state transitions, end-to-end paths
+
+## Context Fields
+
+Test states referencing execution context:
+
+```bash
+--context '{
+  "Execution":{"Id":"arn:...","Name":"test-123","StartTime":"2024-01-01T10:00:00.000Z"},
+  "State":{"Name":"ProcessData","EnteredTime":"2024-01-01T10:00:05.000Z"},
+  "Task":{"Token":"test-token-abc123"}
+}'
+```
+
+## HTTP Tasks (TRACE)
+
+```bash
+--resource "arn:aws:states:::http:invoke" \
+--inspection-level TRACE \
+--reveal-secrets  # Requires states:RevealSecrets permission
+```
+
+Only use `--reveal-secrets` after explicit approval. Do not paste revealed secrets, authorization headers, request bodies, response bodies, or other sensitive data into chat, files, logs, or MCP calls.
+
+Returns: `inspectionData.request` (method, URL, headers, body), `inspectionData.response` (status, headers, body)
+
+## Troubleshooting
+
+| Error                   | Fix                                            |
+| ----------------------- | ---------------------------------------------- |
+| Invalid field type      | Check AWS SDK docs for correct types           |
+| Required field missing  | Add field OR use `fieldValidationMode:PRESENT` |
+| .sync validation failed | Mock polling API, not initial call             |
+
+Debug workflow:
+
+1. Start `fieldValidationMode:NONE` for logic testing
+2. Switch to `PRESENT` for partial validation
+3. Use `STRICT` in CI/CD
+
+## Test Automation Pattern
+
+```bash
+#!/bin/bash
+test_state() {
+  local state_name=$1
+  local input=$2
+  local mock=$3
+
+  aws stepfunctions test-state \
+    --definition "$(cat statemachine.asl.json)" \
+    --state-name "$state_name" \
+    --input "$input" \
+    --mock "$mock" \
+    --inspection-level DEBUG
+}
+
+# Test chain
+RESULT=$(test_state "State1" '{"id":"123"}' '{"result":"..."}' | jq -r '.output')
+test_state "State2" "$RESULT" '{"result":"..."}'
+```
+
+## Best Practices
+
+1. Always verify mock structure against AWS SDK docs for the specific service
+2. For .sync, mock polling API (DescribeX/GetX), not initial call
+3. Use STRICT validation in CI/CD to catch mismatches early
+4. Test all error paths with appropriate error codes
+5. Chain tests to validate multi-state execution paths
+6. Start with NONE->PRESENT->STRICT when developing mocks
+7. Use DEBUG for data flow, TRACE for HTTP debugging
+8. Mock external dependencies to isolate state machine logic
+9. Test Map failure thresholds with `mapIterationFailureCount`
+10. Never commit `--reveal-secrets` output to version control
+
+## Quick Reference
+
+```bash
+# Basic test
+aws stepfunctions test-state --definition '{...}' --input '{...}' --mock '{...}'
+
+# Test specific state in state machine
+aws stepfunctions test-state --definition "$(cat sm.json)" --state-name "MyState" --input '{...}' --mock '{...}'
+
+# Test retry (2nd attempt)
+--state-configuration '{"retrierRetryCount":1}' --mock '{"errorOutput":{...}}'
+
+# Test Map failure threshold
+--state-configuration '{"mapIterationFailureCount":5}' --mock '{"errorOutput":{...}}'
+
+# Test with context
+--context '{"Execution":{"Id":"..."}, "Task":{"Token":"..."}}'
+
+# HTTP Task with secrets
+--inspection-level TRACE --reveal-secrets
+
+# Use only after explicit approval; do not paste revealed auth data into chat,
+# files, logs, or MCP calls.
+
+# Mock validation modes
+--mock '{"fieldValidationMode":"STRICT|PRESENT|NONE","result":"..."}'
+```
+
+## Step Functions Local (Docker)
+
+Run a local emulator for integration testing. Note it is unsupported and does not have full feature parity with the cloud service:
+
+```bash
+docker run -p 8083:8083 amazon/aws-stepfunctions-local
+
+# Run alongside sam local start-lambda for Lambda-integrated tests
+sam local start-lambda &
+docker run -p 8083:8083 \
+  -e LAMBDA_ENDPOINT=http://host.docker.internal:3001 \
+  amazon/aws-stepfunctions-local
+```
+
+Then use the AWS CLI with `--endpoint-url http://localhost:8083` to create and execute state machines locally.
+
+For most use cases, the TestState API (above) is preferred -- it tests against real AWS service behavior without requiring Docker or a local emulator.

--- a/plugins/aws-serverless/skills/aws-serverless-lambda/references/step-functions.md
+++ b/plugins/aws-serverless/skills/aws-serverless-lambda/references/step-functions.md
@@ -1,0 +1,286 @@
+# AWS Step Functions
+
+Step Functions provides visual workflow orchestration with native integrations to 9,000+ API actions across 200+ AWS services. Define workflows as state machines in Amazon States Language (ASL).
+
+## Standard vs Express Workflows
+
+|                                   | Standard                             | Express                                     |
+| --------------------------------- | ------------------------------------ | ------------------------------------------- |
+| Max duration                  | 1 year                               | 5 minutes                                   |
+| Execution semantics           | Exactly-once                         | At-least-once (async) / At-most-once (sync) |
+| Execution history             | Retained 90 days, queryable via API  | CloudWatch Logs only                        |
+| Max throughput                | 2,000 exec/sec                       | 100,000 exec/sec                            |
+| Pricing model                 | Per state transition                 | Per execution count + duration              |
+| `.sync` / `.waitForTaskToken` | Supported                            | Not supported                               |
+| Best for                      | Auditable, non-idempotent operations | High-volume, idempotent event processing    |
+
+Choose Standard for: payment processing, order fulfillment, compliance workflows, anything that must never execute twice.
+
+Choose Express for: IoT data ingestion, streaming transformations, mobile backends, high-throughput short-lived processing.
+
+## Key State Types
+
+| State              | Purpose                                                                              |
+| ------------------ | ------------------------------------------------------------------------------------ |
+| `Task`             | Execute work -- invoke Lambda, call any AWS service via SDK integration               |
+| `Choice`           | Branch based on input data conditions (no `Next` required on branches)               |
+| `Parallel`         | Execute multiple branches concurrently; waits for all branches to complete           |
+| `Map`              | Iterate over an array; use Distributed Map mode for up to 10M items from S3/DynamoDB |
+| `Wait`             | Pause for a fixed duration or until a specific timestamp                             |
+| `Pass`             | Pass input to output, optionally injecting or transforming data                      |
+| `Succeed` / `Fail` | End execution successfully or with an error and cause                                |
+
+## SAM Template
+
+```yaml
+Resources:
+  MyWorkflow:
+    Type: AWS::Serverless::StateMachine
+    Properties:
+      DefinitionUri: statemachine/my_workflow.asl.json
+      Type: STANDARD                          # or EXPRESS
+      DefinitionSubstitutions:
+        ProcessFunctionArn: !GetAtt ProcessFunction.Arn
+        ResultsTable: !Ref ResultsTable
+      Policies:
+        - LambdaInvokePolicy:
+            FunctionName: !Ref ProcessFunction
+        - DynamoDBWritePolicy:
+            TableName: !Ref ResultsTable
+      Tracing:
+        Enabled: true
+      Logging:
+        Destinations:
+          - CloudWatchLogsLogGroup:
+              LogGroupArn: !GetAtt WorkflowLogGroup.Arn
+        IncludeExecutionData: true
+        Level: ERROR                          # Use ALL for debugging, ERROR in production
+
+  WorkflowLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      RetentionInDays: 30
+```
+
+## State Machine Definition (ASL)
+
+Use `DefinitionSubstitutions` to inject ARNs -- never hardcode them:
+
+```json
+{
+  "Comment": "Order processing workflow",
+  "QueryLanguage": "JSONata",
+  "StartAt": "ProcessOrder",
+  "States": {
+    "ProcessOrder": {
+      "Type": "Task",
+      "Resource": "${ProcessFunctionArn}",
+      "Retry": [
+        {
+          "ErrorEquals": [
+            "Lambda.ServiceException",
+            "Lambda.AWSLambdaException",
+            "Lambda.TooManyRequestsException"
+          ],
+          "IntervalSeconds": 2,
+          "MaxAttempts": 3,
+          "BackoffRate": 2
+        }
+      ],
+      "Catch": [{ "ErrorEquals": ["States.ALL"], "Next": "HandleError" }],
+      "Next": "SaveResult"
+    },
+    "SaveResult": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::dynamodb:putItem",
+      "Arguments": {
+        "TableName": "${ResultsTable}",
+        "Item": {
+          "id": { "S": "{% $states.input.orderId %}" },
+          "status": { "S": "completed" }
+        }
+      },
+      "End": true
+    },
+    "HandleError": {
+      "Type": "Fail",
+      "Error": "OrderProcessingFailed"
+    }
+  }
+}
+```
+
+## JSONata -- Recommended Query Language
+
+JSONata is the modern, preferred way to reference and transform data in ASL. It replaces the five JSONPath I/O fields (`InputPath`, `Parameters`, `ResultSelector`, `ResultPath`, `OutputPath`) with just two: `Arguments` (inputs) and `Output` (result shape).
+
+Enable at the top level to apply to all states:
+
+```json
+{ "QueryLanguage": "JSONata", "StartAt": "...", "States": {...} }
+```
+
+Or per-state to migrate incrementally:
+
+```json
+{ "Type": "Task", "QueryLanguage": "JSONata", ... }
+```
+
+Expression syntax -- wrap expressions in `{% %}`:
+
+```json
+"Arguments": {
+  "userId": "{% $states.input.user.id %}",
+  "greeting": "{% 'Hello, ' & $states.input.user.name %}",
+  "total": "{% $sum($states.input.items.price) %}"
+}
+```
+
+Built-in Step Functions JSONata functions:
+
+- `$uuid()` -- generate a v4 UUID
+- `$parse(str)` -- deserialize a JSON string to an object
+- `$partition(array, size)` -- split array into chunks
+- `$range(start, end, step)` -- generate a number array
+- `$hash(value, algorithm)` -- compute MD5/SHA-256/etc. hash
+
+JSONPath is still supported and is the default if `QueryLanguage` is omitted -- existing state machines do not need to be migrated.
+
+## Integration Patterns
+
+| Pattern               | ARN suffix          | Behaviour                                                             |
+| --------------------- | ------------------- | --------------------------------------------------------------------- |
+| Request Response  | _(none)_            | Call service, proceed after HTTP 200                                  |
+| Run a Job         | `.sync`             | Call service, wait for job completion                                 |
+| Wait for Callback | `.waitForTaskToken` | Pass `$$.Task.Token`, pause until `SendTaskSuccess`/`SendTaskFailure` |
+
+Wait for Callback is the human-in-the-loop pattern: pass the task token to an external system (email, Slack, ticketing), call `sfn:SendTaskSuccess` with the token when approved.
+
+## SDK Integrations -- Avoid Lambda for Simple AWS Calls
+
+Step Functions can call any AWS service API directly without a Lambda intermediary. This saves both cost and latency for simple operations:
+
+```json
+"SaveToDynamoDB": {
+  "Type": "Task",
+  "Resource": "arn:aws:states:::dynamodb:putItem",
+  "Arguments": {
+    "TableName": "my-table",
+    "Item": { "id": { "S": "{% $states.input.id %}" } }
+  },
+  "End": true
+}
+```
+
+```json
+"PublishEvent": {
+  "Type": "Task",
+  "Resource": "arn:aws:states:::events:putEvents",
+  "Arguments": {
+    "Entries": [{
+      "EventBusName": "my-bus",
+      "Source": "my.service",
+      "DetailType": "OrderPlaced",
+      "Detail": "{% $states.input %}"
+    }]
+  },
+  "End": true
+}
+```
+
+Avoiding Lambda intermediaries for simple DynamoDB reads/writes, SNS publishes, SQS sends, and EventBridge puts eliminates invocation latency and cost.
+
+## Distributed Map -- Large-Scale Processing
+
+`Map` state with `Mode: DISTRIBUTED` processes up to 10 million items from S3, DynamoDB, or inline arrays, with each item running as an independent child workflow:
+
+```json
+"ProcessFiles": {
+  "Type": "Map",
+  "ItemProcessor": {
+    "ProcessorConfig": { "Mode": "DISTRIBUTED", "ExecutionType": "EXPRESS" },
+    "StartAt": "ProcessSingleFile",
+    "States": { "ProcessSingleFile": { "Type": "Task", "Resource": "${ProcessFunctionArn}", "End": true } }
+  },
+  "MaxConcurrency": 100,
+  "ItemReader": {
+    "Resource": "arn:aws:states:::s3:listObjectsV2",
+    "Parameters": { "Bucket.$": "$.bucket", "Prefix.$": "$.prefix" }
+  },
+  "End": true
+}
+```
+
+## Testing
+
+For testing Step Functions workflows, see [step-functions-testing.md](step-functions-testing.md) -- covers TestState API (mocking, inspection levels, retry simulation, chained tests) and Step Functions Local (Docker).
+
+## Anti-Polling Pattern
+
+The typical polling loop -- `Wait -> Check Status -> Choice -> loop` -- is an expensive anti-pattern in Standard workflows because every state transition is billed. Replace it with the callback + event-driven approach:
+
+1. Lambda starts the long-running task and receives a task token (`$$.Task.Token`)
+2. Store the task token alongside the job ID in DynamoDB
+3. Use `.waitForTaskToken` to pause the state machine at zero cost
+4. When the job completes, an EventBridge rule triggers a Lambda that looks up the token and calls `sfn:SendTaskSuccess`
+
+```json
+"StartJob": {
+  "Type": "Task",
+  "Resource": "arn:aws:states:::lambda:invoke.waitForTaskToken",
+  "Arguments": {
+    "FunctionName": "${StartJobFunctionArn}",
+    "Payload": {
+      "taskToken": "{% $$.Task.Token %}",
+      "input": "{% $states.input %}"
+    }
+  },
+  "HeartbeatSeconds": 3600,
+  "Next": "ProcessResult"
+}
+```
+
+For third-party APIs that don't emit events, pass a callback URL to the external service so it can POST back to your endpoint when done, which then calls `SendTaskSuccess`.
+
+Lambda durable functions alternative: `context.wait_for_callback()` / `context.waitForCallback()` implements the same pattern without manual token management.
+
+## Fan-Out / Fan-In
+
+| Scale                             | Recommended approach                                                        |
+| --------------------------------- | --------------------------------------------------------------------------- |
+| Up to 40 items                    | Step Functions `Map` state (Inline mode)                                    |
+| Up to 10 million items            | Step Functions `Map` state (Distributed mode, child Express workflows)      |
+| Millions of items, cost-sensitive | Custom: S3 -> Lambda fan-out -> SQS workers -> DynamoDB tracking -> aggregation |
+
+For most teams, Step Functions Distributed Map is the right trade-off between cost and operational simplicity. A custom S3+SQS+DynamoDB solution is meaningfully cheaper at very high item counts but carries significant implementation overhead.
+
+## Timeout Handling
+
+Always set both `TimeoutSeconds` and `HeartbeatSeconds` on Task states. Without them, a hung downstream call can hold the execution open indefinitely:
+
+```json
+"CallExternalAPI": {
+  "Type": "Task",
+  "Resource": "${FunctionArn}",
+  "TimeoutSeconds": 300,
+  "HeartbeatSeconds": 60,
+  "Retry": [...]
+}
+```
+
+- `TimeoutSeconds` -- maximum total time for the state (including retries)
+- `HeartbeatSeconds` -- maximum time between heartbeat signals; fails faster when a worker disappears silently
+
+Handling Express workflow timeouts: Express workflows do not publish `TIMED_OUT` events to EventBridge. Wrap Express workflows inside a parent Standard workflow -- the Standard workflow can catch the timeout and trigger remediation.
+
+## Best Practices
+
+- Always add `Retry` on Task states -- Lambda returns transient errors (`Lambda.ServiceException`, `Lambda.AWSLambdaException`, `Lambda.TooManyRequestsException`) under load; without retry, these fail the execution
+- Use `Catch` for error routing -- route failures to a dedicated error-handling state rather than letting the execution fail silently
+- Use `DefinitionSubstitutions` -- never hardcode ARNs or table names in `.asl.json` files
+- Use JSONata for new workflows -- it produces simpler, more readable definitions than JSONPath
+- Use SDK integrations directly -- call DynamoDB, SNS, SQS, EventBridge, etc. without a Lambda wrapper for simple operations
+- Enable X-Ray tracing (`Tracing.Enabled: true`) for end-to-end visibility across Step Functions and Lambda spans
+- Set logging to `Level: ERROR` in production and `Level: ALL` when debugging; `IncludeExecutionData: true` is required to see input/output in logs
+- Standard workflows: prefer for non-idempotent operations -- exactly-once semantics prevent accidental double-charges or duplicate records
+- Express workflows: ensure downstream operations are idempotent -- at-least-once delivery means tasks may run more than once

--- a/plugins/aws-serverless/skills/aws-serverless-lambda/references/troubleshooting.md
+++ b/plugins/aws-serverless/skills/aws-serverless-lambda/references/troubleshooting.md
@@ -1,0 +1,247 @@
+# Troubleshooting Guide
+
+## Symptom-Based Diagnosis
+
+### High Latency
+
+Possible causes (check in order):
+
+1. Cold start -- check if latency is only on first invocations after idle
+2. Under-provisioned memory -- more memory = more CPU
+3. Slow external calls -- database, HTTP APIs, other AWS services
+4. Large deployment package -- increases cold start time
+
+Diagnosis steps:
+
+- Use `get_metrics` to check duration (average vs p99) and memory utilization
+- Enable X-Ray tracing to identify which segment is slow
+- Check if function is in a VPC (adds ENI setup time on cold start)
+
+Resolution:
+
+- For cold starts: initialize SDK clients outside handler, reduce package size, consider provisioned concurrency
+- For slow external calls: use connection reuse, add VPC endpoints, increase timeout
+- For CPU-bound work: increase memory allocation
+
+### Function Errors
+
+Possible causes:
+
+1. Unhandled exceptions in application code
+2. Timeout exceeded
+3. Out of memory (OOM)
+4. Permission denied on AWS API calls
+
+Diagnosis steps:
+
+- Use `sam_logs` to retrieve recent CloudWatch logs for the function
+- Look for `Task timed out`, `Runtime.ExitError`, or `AccessDeniedException` messages
+- Check the error rate trend with `get_metrics`
+
+Resolution by error type:
+
+| Error Message                    | Cause                        | Fix                                                     |
+| -------------------------------- | ---------------------------- | ------------------------------------------------------- |
+| `Task timed out after X seconds` | Execution exceeded timeout   | Increase timeout, increase memory, optimize code        |
+| `Runtime.ExitError`              | OOM or process crash         | Increase memory, check for memory leaks                 |
+| `AccessDeniedException`          | Missing IAM permission       | Add the required action to the function's IAM role      |
+| `ResourceNotFoundException`      | Wrong resource ARN or region | Verify the resource exists in the correct region        |
+| `TooManyRequestsException`       | Concurrency limit reached    | Increase reserved concurrency or request limit increase |
+
+### Async Invocations and Throttling
+
+Common misconception: Async Lambda invocations (`InvocationType: Event`) are subject to throttling like sync invocations.
+
+Reality: Async invocations are always accepted -- Lambda's Event Invoke Frontend queues the request without checking concurrency limits. The invocation call itself never returns a throttle error. Throttling is only checked later when the internal poller attempts to run the function synchronously. If throttled at that point, the event is returned to the internal queue and retried for up to 6 hours.
+
+Practical implications:
+
+- You do not need SNS or EventBridge as a throttle-protection buffer in front of async Lambda invocations -- direct Lambda-to-Lambda async calls are safe
+- If you need guaranteed delivery with a DLQ, configure one on the function directly
+- Async invocations with reserved concurrency set to 0 will still be accepted but will fail during processing -- they will retry and eventually go to the DLQ or on-failure destination
+
+### Throttling and Concurrency Limits
+
+Symptoms: `TooManyRequestsException`, 429 errors from API Gateway, `Throttles` metric rising
+
+Key concurrency facts:
+
+- Default account limit: 1,000 concurrent executions per region (shared across all functions)
+- Concurrency != requests per second: Concurrency = avg_RPS x avg_duration_seconds
+- Burst limit: Lambda can scale by 1,000 new concurrent executions per 10 seconds (on-demand)
+
+Diagnosis:
+
+1. Check `ConcurrentExecutions` and `Throttles` metrics in CloudWatch with `get_metrics`
+2. Check if a single function is consuming all available concurrency
+3. Run `aws lambda get-account-settings` to see your account limit vs reserved allocations
+
+Resolution:
+
+- Set reserved concurrency on high-priority functions to guarantee capacity
+- Set reserved concurrency on lower-priority functions to cap their usage
+- Request a concurrency quota increase via AWS Service Quotas if the account limit is the bottleneck
+- Use SQS as a buffer in front of Lambda to absorb traffic spikes without throttling
+
+### Deployment Failures
+
+Common errors and solutions:
+
+| Error                                 | Cause                                        | Solution                                                                             |
+| ------------------------------------- | -------------------------------------------- | ------------------------------------------------------------------------------------ |
+| `Build Failed`                        | Missing dependencies or incompatible runtime | Run `sam_build` with `use_container: true`, verify `requirements.txt`/`package.json` |
+| `CREATE_FAILED` on IAM role           | Missing `CAPABILITY_IAM`                     | Add `capabilities = "CAPABILITY_IAM"` to samconfig.toml                              |
+| `ROLLBACK_COMPLETE`                   | Resource creation failed                     | Check CloudFormation events for the specific resource failure                        |
+| `No changes to deploy`                | No diff from last deploy                     | Verify `sam_build` ran, check correct samconfig profile                              |
+| `Stack is in ROLLBACK_COMPLETE state` | Previous deploy failed                       | Delete the stack with `aws cloudformation delete-stack`, then redeploy               |
+
+## API Gateway Issues
+
+### CORS Errors
+
+Symptoms: Browser blocking requests, `Access-Control-Allow-Origin` errors
+
+Checklist:
+
+- Verify CORS is configured on the API Gateway (AllowOrigin, AllowMethods, AllowHeaders)
+- Check that OPTIONS method returns correct headers
+- Ensure AllowOrigin matches the frontend domain (not `*` in production)
+- Verify Lambda response includes CORS headers if using proxy integration
+
+### 5xx Errors
+
+Symptoms: API returning 500/502/503 errors
+
+Diagnosis:
+
+- 502 Bad Gateway: Lambda returned invalid response format. Check that response includes `statusCode` and `body`.
+- 503 Service Unavailable: Lambda throttled. Check concurrency limits.
+- 500 Internal Server Error: Check Lambda logs for unhandled exceptions.
+
+## Event Source Mapping Issues
+
+### When to Use Which Tool
+
+| Symptom                            | Tool to Use                      |
+| ---------------------------------- | -------------------------------- |
+| Need to set up a new ESM           | `esm_guidance`                   |
+| ESM exists but performance is poor | `esm_optimize`                   |
+| Kafka/MSK connection failing       | `esm_kafka_troubleshoot`         |
+| Need IAM policy for ESM            | `secure_esm_*` (source-specific) |
+
+### DynamoDB Streams -- High Iterator Age
+
+Symptoms: `IteratorAge` metric increasing in CloudWatch
+
+Diagnosis steps:
+
+1. Check `ParallelizationFactor` -- default is 1, maximum is 10
+2. Check function duration -- slow processing causes backlog
+3. Check for poison records causing repeated retries
+4. Check concurrency -- throttling prevents scaling
+
+Resolution:
+
+- Increase `ParallelizationFactor` and `BatchSize`
+- Enable `BisectBatchOnFunctionError` to isolate bad records
+- Set `MaximumRetryAttempts` to limit retries on persistent failures
+- Use `esm_optimize` for specific tuning recommendations
+
+### Kinesis -- Shard Throttling
+
+Symptoms: `ReadProvisionedThroughputExceeded` errors
+
+Resolution:
+
+- Check if multiple consumers share the same shard (each shard supports 2 MB/s reads)
+- Use enhanced fan-out for multiple consumers
+- Consider switching to ON_DEMAND stream mode for automatic scaling
+- Increase shard count for PROVISIONED mode
+
+### SQS -- Messages Going to DLQ
+
+Symptoms: Messages accumulating in dead-letter queue
+
+Diagnosis:
+
+- Check that `VisibilityTimeout` on the queue is >= Lambda function timeout
+- Check for partial batch failures: enable `ReportBatchItemFailures` in `FunctionResponseTypes`
+- Check `maxReceiveCount` in the redrive policy (too low causes premature DLQ routing)
+
+### Kafka/MSK -- Connection Failures
+
+Symptoms: ESM stays in `Creating` or `Failed` state
+
+Use `esm_kafka_troubleshoot` with the error message. Common causes:
+
+- Lambda not in same VPC as MSK cluster
+- Security group missing inbound rule on ports 9092/9094
+- IAM authentication not configured correctly
+- SASL/SCRAM secret not in the correct format
+
+## VPC and Networking
+
+### Lambda Cannot Reach AWS Services
+
+Symptoms: Timeouts when calling DynamoDB, S3, SQS from VPC-attached Lambda
+
+Cause: Lambda in VPC private subnets cannot reach AWS service endpoints without a path.
+
+Resolution options (choose one):
+
+- Add VPC gateway endpoints for DynamoDB and S3 (free, recommended)
+- Add VPC interface endpoints for other services (per-hour + per-GB cost)
+- Add NAT Gateway in public subnet (higher cost, required for internet access)
+- Use IPv6 + Egress-Only Internet Gateway for internet access -- Lambda now supports IPv6, so if your VPC has IPv6 CIDR blocks and an Egress-Only Internet Gateway, Lambda functions can reach the internet without a NAT Gateway, eliminating NAT Gateway costs entirely
+
+### ENI Exhaustion
+
+Symptoms: Lambda functions fail to start, `ENILimitReached` errors
+
+Resolution:
+
+- Use multiple subnets across AZs (each /24 subnet provides ~250 IPs)
+- Set reserved concurrency to cap the maximum ENI usage
+- Lambda uses Hyperplane ENIs which are shared, but high concurrency can still exhaust IPs
+
+## Lambda SnapStart Issues
+
+SnapStart issues are specific to Java 11+, Python 3.12+, and .NET 8+ functions with `SnapStart: ApplyOn: PublishedVersions`.
+
+### Stale unique values
+
+Symptom: All invocations share the same UUID, timestamp, or random value
+
+Cause: Value was generated during initialization (before snapshot), so all restored environments use the same value.
+
+Fix: Move any call to `uuid.uuid4()`, `random`, `time.time()`, or similar into the handler function body, not at module level.
+
+### Stale database connection after restore
+
+Symptom: Database errors on the first call after a period of inactivity
+
+Cause: The connection object was captured in the snapshot but the actual TCP connection is no longer valid after resume.
+
+Fix: Validate the connection before use, or use a `lambda_runtime_api_prepare_to_invoke` hook to re-establish it after restoration.
+
+### SnapStart not activating
+
+Symptom: Cold starts still slow despite SnapStart enabled
+
+Check:
+
+- SnapStart only applies to published versions and aliases pointing to them, not `$LATEST`
+- The function is not using provisioned concurrency, EFS, or ephemeral storage > 512 MB
+- The runtime is Java 11+, Python 3.12+, or .NET 8+
+
+## Debugging Workflow
+
+When a function is failing and the cause is unclear, follow this sequence:
+
+1. Check logs: Use `sam_logs` to get recent log output
+2. Check metrics: Use `get_metrics` to identify error rate, duration, and throttle trends
+3. Check configuration: Verify timeout, memory, VPC, and IAM settings in the SAM template
+4. Test locally: Use `sam_local_invoke` with the failing event payload to reproduce
+5. Test deployed function: Use `sam remote invoke` with the failing event to test directly in AWS -- bypasses local environment differences
+6. Trace calls: Enable X-Ray tracing to identify which downstream call is failing
+7. Check dependencies: Verify external services (databases, APIs) are reachable and healthy

--- a/plugins/aws-serverless/skills/aws-serverless-lambda/references/web-app-deployment.md
+++ b/plugins/aws-serverless/skills/aws-serverless-lambda/references/web-app-deployment.md
@@ -1,0 +1,260 @@
+# Web Application Deployment Guide
+
+## Overview
+
+Deploy web applications to AWS Serverless using the `deploy_webapp` tool and Lambda Web Adapter. This covers backend APIs, static frontends, and full-stack applications -- from endpoint selection through custom domains and frontend updates.
+
+## Deployment Types
+
+Choose the deployment type based on your application:
+
+| Type          | Use Case                    | What Gets Created                      |
+| ------------- | --------------------------- | -------------------------------------- |
+| backend   | API services, microservices | Lambda + API Gateway                   |
+| frontend  | Static sites, SPAs          | S3 + CloudFront                        |
+| fullstack | Complete web apps           | Lambda + API Gateway + S3 + CloudFront |
+
+## API Endpoint Options
+
+| Option                        | Best For                                                            | Notes                                                           |
+| ----------------------------- | ------------------------------------------------------------------- | --------------------------------------------------------------- |
+| HTTP API (API Gateway v2) | Most REST/HTTP APIs                                                 | 70% cheaper than REST API, lower latency                        |
+| REST API (API Gateway v1) | APIs needing WAF, caching, usage plans, request transforms          | More features, higher cost                                      |
+| Lambda Function URL       | Simple HTTPS endpoints, webhooks, single-function APIs              | No API Gateway; free (pay only for Lambda). Supports streaming. |
+| Application Load Balancer | High-traffic APIs with mixed Lambda/container targets, existing ALB | Fixed hourly cost; efficient at high request volumes            |
+
+### Lambda Function URLs
+
+The simplest option for a single Lambda function that needs an HTTPS endpoint:
+
+```yaml
+MyFunction:
+  Type: AWS::Serverless::Function
+  Properties:
+    FunctionUrlConfig:
+      AuthType: AWS_IAM   # or NONE for public endpoints
+      Cors:
+        AllowOrigins:
+          - "https://myapp.example.com"
+```
+
+Use `AuthType: NONE` only for public webhook receivers or assets where you handle auth in the function. For internal services, use `AWS_IAM` and sign requests with SigV4.
+
+Prefer Function URLs over API Gateway when:
+
+- Serving payloads larger than 10 MB (API Gateway's response limit)
+- Handling requests longer than 29 seconds (API Gateway's integration timeout)
+- Building a Lambdalith where per-endpoint metrics are managed in-code
+- Internal service-to-service calls authenticated with AWS_IAM
+
+Prefer API Gateway when:
+
+- You need per-endpoint CloudWatch metrics without custom instrumentation
+- You require Cognito authorizers, usage plans, API keys, or request validation
+- You are exposing WebSocket APIs
+- You want WAF integration at the API level
+
+### CORS
+
+Configure CORS on the API Gateway for browser-based frontend access:
+
+- Set `AllowOrigin` to your frontend domain in production (avoid `*`)
+- Include necessary headers: `Content-Type`, `Authorization`, `X-Api-Key`
+- Set appropriate `MaxAge` for preflight caching
+
+### Custom Domains
+
+Use the `configure_domain` tool to set up custom domains with:
+
+- ACM certificate (must be in us-east-1 for CloudFront)
+- Route 53 DNS record
+- API Gateway base path mapping
+
+## Lambda Web Adapter
+
+Lambda Web Adapter allows standard web frameworks to run on Lambda without code changes. The `deploy_webapp` tool automatically configures it.
+
+How it works:
+
+- Adds the Lambda Web Adapter layer to your function
+- Sets `AWS_LAMBDA_EXEC_WRAPPER` to `/opt/bootstrap`
+- Configures the `PORT` environment variable for your application
+- Your framework listens on that port as it would normally
+
+Custom startup: For applications needing pre-start steps (migrations, config loading), provide a startup script that runs setup commands before `exec`-ing your application.
+
+Supported backend frameworks: Express.js, FastAPI, Flask, Spring Boot, ASP.NET Core, Gin
+
+Supported frontend frameworks: React, Vue.js, Angular, Next.js, Svelte
+
+## Project Structure
+
+### Backend-Only
+
+```text
+my-backend/
++-- src/
+|   +-- app.js          # Express application
+|   +-- routes/         # API routes
+|   +-- middleware/     # Custom middleware
++-- package.json
++-- Dockerfile          # Optional
+```
+
+### Frontend-Only
+
+```text
+my-frontend/
++-- dist/               # Built assets
+|   +-- index.html
+|   +-- assets/
++-- package.json
+```
+
+### Full-Stack
+
+```text
+my-fullstack-app/
++-- frontend/
+|   +-- dist/           # Built frontend
+|   +-- package.json
++-- backend/
+|   +-- src/
+|   +-- package.json
++-- deployment-config.json
+```
+
+## Frontend Updates
+
+Use `update_webapp_frontend` to push new frontend assets to S3 and optionally invalidate the CloudFront cache. For zero-downtime updates, use content-hashed filenames so old and new assets can coexist.
+
+## Database Integration
+
+### RDS with Lambda
+
+- Place Lambda in VPC with private subnets for RDS access
+- Use VPC endpoints to avoid NAT Gateway costs for AWS service calls
+- Set connection pool max to 1 per Lambda instance -- but note that Lambda Managed Instances handle multiple concurrent requests, so use a proper connection pool there
+- Store connection strings in Secrets Manager
+
+For DynamoDB optimization (billing, key design, query patterns), see [optimization.md](optimization.md).
+
+## Environment Management
+
+Use `samconfig.toml` environment-specific sections for multi-environment deployments. See [sam-project-setup.md](../../aws-serverless-deployment/references/sam-project-setup.md) for configuration details.
+
+Store environment-specific secrets in Secrets Manager or SSM Parameter Store, referenced by environment name.
+
+## Authentication & Authorization
+
+### Choosing an Auth Approach
+
+| Approach                                    | Best For                                | API Type             |
+| ------------------------------------------- | --------------------------------------- | -------------------- |
+| Cognito User Pools + JWT authorizer     | User sign-up/sign-in for your own app   | HTTP API (v2)        |
+| Cognito User Pools + Cognito authorizer | Same, with built-in token validation    | REST API (v1)        |
+| Lambda authorizer (token-based)         | Custom auth logic, third-party IdPs     | Both                 |
+| Lambda authorizer (request-based)       | Multi-source auth (headers, query, IP)  | Both                 |
+| IAM authorization                       | Service-to-service, internal APIs       | Both + Function URLs |
+| API keys + usage plans                  | Rate limiting third-party API consumers | REST API (v1) only   |
+
+### Cognito User Pools vs Identity Pools
+
+- User Pools = authentication (who are you?). Handles sign-up, sign-in, MFA, and issues JWT tokens. This is what most web APIs need.
+- Identity Pools = authorization (what AWS resources can you access?). Exchanges tokens (from User Pools, Google, Facebook) for temporary AWS credentials. Use this when clients need direct AWS access (S3 upload from browser, IoT).
+
+Most API backends only need User Pools + a JWT or Cognito authorizer on API Gateway.
+
+### JWT Authorizer (HTTP API)
+
+The simplest and cheapest option for HTTP APIs backed by Cognito:
+
+```yaml
+MyCognitoUserPool:
+  Type: AWS::Cognito::UserPool
+
+MyCognitoUserPoolClient:
+  Type: AWS::Cognito::UserPoolClient
+  Properties:
+    UserPoolId: !Ref MyCognitoUserPool
+    ExplicitAuthFlows:
+      - ALLOW_USER_SRP_AUTH
+      - ALLOW_REFRESH_TOKEN_AUTH
+
+MyApi:
+  Type: AWS::Serverless::HttpApi
+  Properties:
+    Auth:
+      DefaultAuthorizer: MyCognitoAuth
+      Authorizers:
+        MyCognitoAuth:
+          AuthorizationScopes:
+            - email
+          IdentitySource: $request.header.Authorization
+          JwtConfiguration:
+            issuer: !Sub "https://cognito-idp.${AWS::Region}.amazonaws.com/${MyCognitoUserPool}"
+            audience:
+              - !Ref MyCognitoUserPoolClient
+```
+
+JWT authorizers validate the token signature and claims at the API Gateway level -- no Lambda invocation needed for auth. This is free (no extra cost beyond HTTP API pricing).
+
+### Lambda Authorizer
+
+Use Lambda authorizers when you need custom auth logic: validating tokens from a third-party IdP, checking database-backed permissions, or combining multiple auth signals.
+
+Token-based authorizers receive only the `Authorization` header. Request-based authorizers receive the full request (headers, query string, path, IP) -- use these when auth depends on more than just a bearer token.
+
+```yaml
+MyApi:
+  Type: AWS::Serverless::Api
+  Properties:
+    Auth:
+      DefaultAuthorizer: MyLambdaAuth
+      Authorizers:
+        MyLambdaAuth:
+          FunctionArn: !GetAtt AuthFunction.Arn
+          FunctionPayloadType: TOKEN
+          Identity:
+            Header: Authorization
+            ReauthorizeEvery: 300  # Cache auth result for 5 minutes
+```
+
+Set `ReauthorizeEvery` > 0 to cache authorization results and avoid invoking the authorizer Lambda on every request. A value of 300 (5 minutes) is a reasonable default.
+
+### API Keys and Usage Plans
+
+API keys are for tracking and throttling third-party API consumers -- they are not an authentication mechanism. Always combine API keys with a proper authorizer.
+
+```yaml
+MyApi:
+  Type: AWS::Serverless::Api
+  Properties:
+    Auth:
+      ApiKeyRequired: true
+      UsagePlan:
+        CreateUsagePlan: PER_API
+        Throttle:
+          BurstLimit: 100
+          RateLimit: 50
+        Quota:
+          Limit: 10000
+          Period: MONTH
+```
+
+API keys and usage plans are REST API (v1) only. HTTP APIs do not support them.
+
+### Auth Best Practices
+
+- [ ] Use JWT authorizers with HTTP API for most web applications -- cheapest, lowest latency
+- [ ] Cache Lambda authorizer results (`ReauthorizeEvery` > 0) to avoid per-request invocations
+- [ ] Never use API keys as the sole authentication mechanism -- they are for usage tracking, not identity
+- [ ] Use IAM authorization (SigV4) for service-to-service calls, not shared API keys
+- [ ] Store JWT client IDs and secrets in SSM Parameter Store, not in template literals
+
+## Performance
+
+- Caching: Use CloudFront caching for static assets. Disable caching for API paths.
+- Response streaming: For LLM/AI responses, large payloads (> 6 MB), or long-running operations, use Lambda response streaming to reduce TTFB. See [optimization.md](optimization.md) for configuration.
+
+For cold start optimization, memory right-sizing, and connection pooling, see [optimization.md](optimization.md).

--- a/plugins/aws-serverless/skills/aws-serverless-managed-instances/SKILL.md
+++ b/plugins/aws-serverless/skills/aws-serverless-managed-instances/SKILL.md
@@ -1,34 +1,218 @@
 ---
 name: aws-serverless-managed-instances
-description: Evaluate and migrate predictable Lambda workloads to AWS Lambda Managed Instances, including concurrency, cost, capacity providers, thread safety, and rollout planning.
+description: >
+  Evaluate, configure, and migrate workloads to AWS Lambda Managed Instances (LMI).
+  Triggers on: Lambda Managed Instances, LMI, capacity provider, multi-concurrency Lambda,
+  dedicated instance Lambda, EC2-backed Lambda, cold start elimination, Graviton Lambda,
+  instance type for Lambda, Lambda cost optimization with Reserved Instances or Savings Plans.
+  Also trigger when users describe high-volume predictable workloads seeking cost savings,
+  or compare Lambda vs EC2 for steady-state traffic. For standard Lambda without LMI,
+  use the aws-serverless-lambda skill instead.
+argument-hint: "[describe your workload or what you need help with]"
+metadata:
+  tags: lambda, lmi, managed-instances, ec2, capacity-provider, multi-concurrency, cost-optimization
 ---
 
-# AWS Serverless Managed Instances
+# AWS Lambda Managed Instances (LMI)
 
-Use this skill when the user mentions Lambda Managed Instances, LMI, dedicated instance Lambda, capacity providers, predictable high-volume workloads, cold start reduction, multi-concurrency Lambda, Graviton migration, or Lambda versus EC2 cost tradeoffs.
+Run Lambda functions on current-generation EC2 instances in your account while AWS manages provisioning, patching, scaling, routing, and load balancing. Combines Lambda's developer experience with EC2's pricing and hardware options.
 
-## Workflow
+For standard Lambda development, see [aws-serverless-lambda skill](../aws-serverless-lambda/). For SAM/CDK deployment, see [aws-serverless-deployment skill](../aws-serverless-deployment/).
 
-1. Confirm whether LMI is available for the user's target region, account, runtime, and workload requirements.
-2. Gather workload profile: average and peak concurrency, request duration, memory, CPU intensity, I/O behavior, traffic predictability, latency goals, current Lambda cost, and availability targets.
-3. Compare standard Lambda, provisioned concurrency, SnapStart where applicable, ECS or EC2, and LMI. Do not assume LMI is cheaper.
-4. Identify thread-safety and concurrency risks before recommending migration:
-   - Shared globals
-   - Mutable caches
-   - Connection pools
-   - Hardcoded `/tmp` paths
-   - Non-thread-safe libraries
-   - Per-invocation credentials or context leakage
-5. Recommend a gradual rollout through versions and weighted aliases. Start in non-production and compare metrics before full cutover.
-6. Define alarms for throttles, CPU, memory, errors, latency, queue age, and cost anomalies.
-7. Include rollback steps and a decommission plan only after metrics prove the migration is stable.
+## When to Load Reference Files
 
-## MCP Use
+- Cost comparison, pricing analysis, Lambda vs LMI cost, Savings Plans, or Reserved Instances -> see [references/cost-comparison.md](references/cost-comparison.md)
+- Instance types, memory sizing, vCPU ratios, scaling tuning, or capacity provider config -> see [references/configuration-guide.md](references/configuration-guide.md)
+- Thread safety, concurrency model, code review checklist, Powertools compatibility, or multi-concurrency readiness -> see [references/thread-safety.md](references/thread-safety.md)
+- Before/after code examples, runtime-specific migration (Node.js, Python, Java, .NET), or connection pooling -> see [references/migration-patterns.md](references/migration-patterns.md)
+- IAM roles, VPC setup, CLI commands, SAM template, or CDK example -> see [references/infrastructure-setup.md](references/infrastructure-setup.md) and [scripts/setup-lmi.sh](scripts/setup-lmi.sh). The script creates AWS resources and publishes a version; only run it after explicit approval, account/region review, and cost discussion.
+- Errors, throttling, debugging, or stuck deployments -> see [references/troubleshooting.md](references/troubleshooting.md)
 
-Use `aws-serverless-mcp` for Lambda guidance and generated templates only after narrowing the request. Avoid sending full production code or logs. Use sanitized metrics and approved identifiers.
+## Quick Decision: Is LMI Right for This Workload?
 
-## Safety
+| Signal         | LMI is a strong fit                                                                     | Standard Lambda is better                              |
+| -------------- | --------------------------------------------------------------------------------------- | ------------------------------------------------------ |
+| Traffic        | Steady, predictable, 50M+ req/mo                                                        | Bursty, unpredictable, long idle                       |
+| Cost           | Duration-heavy spend at scale                                                           | Low or sporadic invocations                            |
+| Cold starts    | Unacceptable (LMI eliminates for provisioned capacity; scale-out may have brief delays) | Tolerable or mitigated by SnapStart                    |
+| Compute        | Latest CPUs, specific families, high network bandwidth                                  | Standard Lambda memory/CPU sufficient                  |
+| Isolation      | Dedicated EC2 instances in your account, full VPC control                               | Shared Firecracker micro-VMs acceptable                |
+| Scale-to-zero  | Not needed (execution environments always running)                                      | Required (pay nothing when idle)                       |
+| Code readiness | Thread-safe (Node.js/Java/.NET) or any Python code                                      | Non-thread-safe Node.js/Java/.NET, expensive to change |
 
-Ask before creating capacity providers, changing function configuration, publishing versions, shifting aliases, changing VPC settings, changing IAM roles, reading production metrics or logs, or making cost-bearing changes.
+## Instructions
 
-Do not recommend minimum capacity without an explicit cost ceiling and availability goal. Explain the tradeoff between warm capacity, multi-AZ resilience, and idle cost.
+### Step 1: Assess the Workload
+
+Gather these signals before recommending:
+
+1. Traffic pattern: Steady vs bursty? Requests per second?
+2. Current costs: Monthly Lambda spend? Existing Savings Plans?
+3. Runtime: Node.js, Java, .NET, or Python?
+4. Memory/CPU: How much memory? CPU-bound or I/O-bound?
+5. Execution duration: Average and P99?
+6. Concurrency readiness: Thread safety (Node.js/Java/.NET)? Shared `/tmp` paths? Per-invocation DB connections?
+7. VPC: Already in a VPC? Private resource access needed?
+
+### Step 2: Build the Cost Comparison
+
+REQUIRED: Present a cost comparison before recommending LMI. Compare at minimum:
+
+| Scenario         | When it wins                |
+| ---------------- | --------------------------- |
+| Lambda on-demand | Low volume, bursty traffic  |
+| LMI on-demand    | High volume, steady traffic |
+
+Rule of thumb: LMI becomes cost-competitive when your Lambda spend exceeds ~$1,000/month with steady traffic.
+
+For discount analysis (Savings Plans, Reserved Instances), refer users to the [AWS Pricing Calculator](https://calculator.aws/) and [references/cost-comparison.md](references/cost-comparison.md) for formulas and worked examples. Discount recommendations require workload-specific forecasting beyond this skill's scope.
+
+### Step 3: Configure the Deployment
+
+Instance families (~450 types): C-series (compute, .xlarge+), M-series (general, .large+), R-series (memory, .large+). ARM (Graviton) for best price-performance.
+
+Memory-to-vCPU ratios: 2:1 (compute), 4:1 (general, default), 8:1 (memory). Min 2 GB, max 32 GB.
+
+Multi-concurrency defaults/vCPU: Node.js 64, Java 32, .NET 32, Python 16.
+
+Scaling: MinExecutionEnvironments (default 3), MaxVCpuCount (default 400), TargetResourceUtilization.
+
+See [references/configuration-guide.md](references/configuration-guide.md) for decision trees and detailed tuning.
+
+### Step 4: Migrate the Code
+
+Review code for concurrency safety. LMI runs multiple invocations concurrently per execution environment, but the model differs by runtime:
+
+- Python: Process-based isolation -- globals are NOT shared. No thread-safety changes needed. Focus on `/tmp` conflicts and memory sizing (per-process x concurrency).
+- Node.js: Worker threads -- globals shared within a worker. Requires async safety. Callback handlers not supported on Node.js 22.
+- Java/.NET: OS threads/Tasks -- handler shared across threads. Requires full thread safety.
+
+Common issues (all runtimes): shared `/tmp` paths, per-invocation DB connections.
+Thread-safety issues (Node.js/Java/.NET only): mutable globals, non-thread-safe libs.
+
+See [references/thread-safety.md](references/thread-safety.md) for the review checklist and [references/migration-patterns.md](references/migration-patterns.md) for runtime-specific before/after code.
+
+### Step 5: Set Up Infrastructure
+
+1. Create two IAM roles: execution role (for the function) and operator role (for capacity provider EC2 management)
+2. Configure VPC with subnets across multiple AZs (recommended 3+ for resiliency)
+3. Create capacity provider with VPC config and scaling limits
+4. Create or update function with capacity provider attachment
+5. Publish a version (triggers instance provisioning)
+
+See [references/infrastructure-setup.md](references/infrastructure-setup.md) for CLI commands and SAM templates.
+
+### Step 6: Validate and Cut Over
+
+1. Deploy to a non-production environment first
+2. Monitor CloudWatch: CPU utilization, memory, concurrency, throttle rate
+3. Gradual traffic shift with weighted aliases (10% -> 50% -> 100%)
+4. Compare costs after 1-2 weeks of production data
+5. Decommission standard Lambda once stable
+
+## Best Practices
+
+### Configuration
+
+- Do: Start with 4:1 ratio and runtime default concurrency
+- Do: Use ARM (Graviton) unless x86 dependencies exist
+- Do: Let Lambda choose instance types unless specific hardware needed
+- Do: Set MaxVCpuCount to control cost ceiling
+- Don't: Set MinExecutionEnvironments below 3 in production (reduces multi-AZ coverage). Non-prod environments can use 1 as the minimum.
+- Don't: Over-restrict instance types (lowers availability)
+
+### Migration
+
+- Do: Start with I/O-heavy functions (benefit most from multi-concurrency; CPU-bound functions compete for same CPU)
+- Do: Review code for concurrency safety before attaching to capacity provider (thread safety for Node.js/Java/.NET; `/tmp` and memory for Python)
+- Do: Use weighted aliases for gradual traffic shift
+- Do: Include request IDs in all log statements
+- Do: Initialize DB pools and SDK clients outside the handler
+- Do: Estimate total `/tmp` usage under max concurrency
+- Don't: Write to hardcoded `/tmp` paths without request-unique naming
+- Don't: Skip cost comparison -- LMI is not always cheaper
+
+### Operations
+
+- Do: Set CloudWatch alarms on throttle rate > 1% and CPU > 80%
+- Don't: Manually terminate LMI EC2 instances (delete the capacity provider instead)
+- Don't: Forget to publish a version -- unpublished functions cannot run on LMI
+
+## Limits Quick Reference
+
+| Resource          | Limit                                     |
+| ----------------- | ----------------------------------------- |
+| Memory            | 2 GB min, 32 GB max                       |
+| Concurrency/vCPU  | 64 (Node.js), 32 (Java/.NET), 16 (Python) |
+| Instance lifespan | ~12 hours (auto-replaced by Lambda)       |
+| EE lifespan       | ~4 hours (auto-replaced by Lambda)        |
+| Runtimes          | Node.js, Java, .NET, Python               |
+| Instance families | C (.xlarge+), M (.large+), R (.large+)    |
+| Scaling           | Doubles within 5 min without throttles    |
+
+## Troubleshooting Quick Reference
+
+| Issue                      | Cause                             | Fix                                                                  |
+| -------------------------- | --------------------------------- | -------------------------------------------------------------------- |
+| 429 throttles              | Traffic exceeds scaling speed     | Increase MinExecutionEnvironments or lower TargetResourceUtilization |
+| Function stuck PENDING     | Provisioning instances            | Wait; check VPC/IAM config                                           |
+| Architecture mismatch      | Function != capacity provider arch | Align both to same architecture                                      |
+| Cannot terminate instances | Managed by capacity provider      | Delete capacity provider instead                                     |
+| Race conditions            | Code not thread-safe              | See [references/thread-safety.md](references/thread-safety.md)       |
+
+See [references/troubleshooting.md](references/troubleshooting.md) for detailed resolution steps.
+
+## Configuration
+
+### AWS CLI Setup
+
+REQUIRED: AWS credentials configured on the host machine.
+
+Verify access: Run `aws sts get-caller-identity`
+
+### Regional Availability
+
+Currently available: us-east-1, us-east-2, us-west-2, ap-northeast-1, eu-west-1. Expanding to all commercial regions soon.
+
+Check the [Lambda Managed Instances documentation](https://docs.aws.amazon.com/lambda/latest/dg/lambda-managed-instances.html) for the latest regional availability.
+
+## Language Selection
+
+Default: TypeScript
+
+Override: "use Python" -> Python, "use JavaScript" -> JavaScript. When not specified, ALWAYS use TypeScript.
+
+## IaC Framework Selection
+
+Default: CDK
+
+Override: "use SAM" -> SAM YAML, "use CloudFormation" -> CloudFormation YAML. When not specified, ALWAYS use CDK.
+
+## Error Scenarios
+
+### Serverless MCP Server Unavailable
+
+- Inform user: "AWS Serverless MCP not responding"
+- Ask: "Proceed without MCP support?"
+- DO NOT continue without user confirmation
+
+### Unsupported Runtime
+
+- State: "Lambda Managed Instances does not yet support [runtime]"
+- List supported runtimes
+- Suggest standard Lambda as alternative
+
+### Unsupported Region
+
+- State: "Lambda Managed Instances is not yet available in [region]"
+- List available regions
+
+## Resources
+
+- [Lambda Managed Instances Docs](https://docs.aws.amazon.com/lambda/latest/dg/lambda-managed-instances.html)
+- [Introducing LMI (AWS Blog)](https://aws.amazon.com/blogs/aws/introducing-aws-lambda-managed-instances-serverless-simplicity-with-ec2-flexibility/)
+- [Build High-Performance Apps with LMI](https://aws.amazon.com/blogs/compute/build-high-performance-apps-with-aws-lambda-managed-instances/)
+- [Migrating Functions to LMI (AWS Blog)](https://aws.amazon.com/blogs/compute/migrating-your-functions-to-aws-lambda-managed-instances/)
+- [LMI Pricing Calculator](https://aws-samples.github.io/sample-aws-lambda-managed-instances/)
+- [LMI Samples Repository](https://github.com/aws-samples/sample-aws-lambda-managed-instances)
+- [AWS Lambda Pricing](https://aws.amazon.com/lambda/pricing/)

--- a/plugins/aws-serverless/skills/aws-serverless-managed-instances/SKILL.md
+++ b/plugins/aws-serverless/skills/aws-serverless-managed-instances/SKILL.md
@@ -1,0 +1,34 @@
+---
+name: aws-serverless-managed-instances
+description: Evaluate and migrate predictable Lambda workloads to AWS Lambda Managed Instances, including concurrency, cost, capacity providers, thread safety, and rollout planning.
+---
+
+# AWS Serverless Managed Instances
+
+Use this skill when the user mentions Lambda Managed Instances, LMI, dedicated instance Lambda, capacity providers, predictable high-volume workloads, cold start reduction, multi-concurrency Lambda, Graviton migration, or Lambda versus EC2 cost tradeoffs.
+
+## Workflow
+
+1. Confirm whether LMI is available for the user's target region, account, runtime, and workload requirements.
+2. Gather workload profile: average and peak concurrency, request duration, memory, CPU intensity, I/O behavior, traffic predictability, latency goals, current Lambda cost, and availability targets.
+3. Compare standard Lambda, provisioned concurrency, SnapStart where applicable, ECS or EC2, and LMI. Do not assume LMI is cheaper.
+4. Identify thread-safety and concurrency risks before recommending migration:
+   - Shared globals
+   - Mutable caches
+   - Connection pools
+   - Hardcoded `/tmp` paths
+   - Non-thread-safe libraries
+   - Per-invocation credentials or context leakage
+5. Recommend a gradual rollout through versions and weighted aliases. Start in non-production and compare metrics before full cutover.
+6. Define alarms for throttles, CPU, memory, errors, latency, queue age, and cost anomalies.
+7. Include rollback steps and a decommission plan only after metrics prove the migration is stable.
+
+## MCP Use
+
+Use `aws-serverless-mcp` for Lambda guidance and generated templates only after narrowing the request. Avoid sending full production code or logs. Use sanitized metrics and approved identifiers.
+
+## Safety
+
+Ask before creating capacity providers, changing function configuration, publishing versions, shifting aliases, changing VPC settings, changing IAM roles, reading production metrics or logs, or making cost-bearing changes.
+
+Do not recommend minimum capacity without an explicit cost ceiling and availability goal. Explain the tradeoff between warm capacity, multi-AZ resilience, and idle cost.

--- a/plugins/aws-serverless/skills/aws-serverless-managed-instances/references/configuration-guide.md
+++ b/plugins/aws-serverless/skills/aws-serverless-managed-instances/references/configuration-guide.md
@@ -1,0 +1,69 @@
+# LMI Configuration Guide
+
+## Instance Type Decision Tree
+
+- CPU-intensive (encoding, ML, compression) -> C-series, 2:1 ratio, concurrency=1/vCPU
+- Memory-intensive (caching, large datasets) -> R-series, 8:1 ratio
+- Network-intensive (streaming, data transfer) -> Use AllowedInstanceTypes for n-suffix types, 4:1 ratio
+- General/balanced (web APIs, microservices) -> M-series, 4:1 ratio, default concurrency
+
+Architecture: ARM (Graviton, g-suffix) for price-performance. x86 (i=Intel, a=AMD) when dependencies require it.
+
+## Memory-to-vCPU Ratios
+
+| Ratio | Profile | When to use                | Memory examples       |
+| ----- | ------- | -------------------------- | --------------------- |
+| 2:1   | Compute | CPU-bound work             | 2GB/1vCPU, 4GB/2vCPU  |
+| 4:1   | General | Most workloads (default)   | 4GB/1vCPU, 8GB/2vCPU  |
+| 8:1   | Memory  | Caching, data, Python apps | 8GB/1vCPU, 16GB/2vCPU |
+
+Min: 2 GB / 1 vCPU. Max: 32 GB. Memory must align with ratio multiples.
+
+## Memory Sizing from Existing Lambda
+
+| Current Lambda | LMI memory    | Ratio      | Rationale                                    |
+| -------------- | ------------- | ---------- | -------------------------------------------- |
+| 128-512 MB     | 2048 MB       | 4:1        | LMI minimum; multi-concurrency shares memory |
+| 512 MB-1 GB    | 2048 MB       | 4:1        | Room for concurrent requests                 |
+| 1-2 GB         | 4096 MB       | 4:1        | Standard upgrade path                        |
+| 2-4 GB         | 4096-8192 MB  | 4:1 or 8:1 | Depends on memory vs CPU bottleneck          |
+| 4-10 GB        | 8192-16384 MB | 8:1        | Likely memory-heavy workload                 |
+
+## Concurrency Tuning
+
+| Runtime | Default/vCPU | I/O-bound        | CPU-bound  |
+| ------- | ------------ | ---------------- | ---------- |
+| Node.js | 64           | Keep or increase | 1 per vCPU |
+| Java    | 32           | Keep             | 1 per vCPU |
+| .NET    | 32           | Keep             | 1 per vCPU |
+| Python  | 16           | Keep             | 1 per vCPU |
+
+Total capacity = MinExecutionEnvironments x PerExecutionEnvironmentMaxConcurrency
+
+## Capacity Provider Scaling Controls
+
+| Control                   | Default       | Guidance                                              |
+| ------------------------- | ------------- | ----------------------------------------------------- |
+| MinExecutionEnvironments  | 3             | Min 1 (non-prod); 3+ recommended for prod AZ coverage |
+| MaxExecutionEnvironments  | --             | Set based on cost budget                              |
+| MaxVCpuCount              | 400           | Set to control cost ceiling; adjust by load           |
+| TargetResourceUtilization | ~50% headroom | Raise for cost savings (less burst tolerance)         |
+| AllowedInstanceTypes      | All           | Restrict only for specific hardware needs             |
+| ExcludedInstanceTypes     | None          | Exclude expensive types in dev/test                   |
+
+## Monitoring Thresholds
+
+- CPU > 80%: reduce concurrency or add vCPUs
+- CPU < 20%: increase concurrency for better utilization
+- Throttle rate (429s) > 1%: increase MinExecutionEnvironments or reduce utilization target
+- Memory > 90%: increase memory or reduce concurrency
+- ExecutionEnvironmentConcurrency near ExecutionEnvironmentConcurrencyLimit: saturation -- reduce concurrency or scale out
+
+## CloudWatch Metrics Dimensions
+
+LMI metrics are split across two CloudWatch dimensions:
+
+- Alias (live): Invocations, Errors, Throttles, Duration
+- Version ($LATEST or numbered): CPUUtilization, MemoryUtilization, ExecutionEnvironmentConcurrency, ExecutionEnvironmentCount
+
+Create a unified dashboard combining both views to monitor LMI performance effectively.

--- a/plugins/aws-serverless/skills/aws-serverless-managed-instances/references/cost-comparison.md
+++ b/plugins/aws-serverless/skills/aws-serverless-managed-instances/references/cost-comparison.md
@@ -1,0 +1,17 @@
+# Lambda vs LMI Cost Comparison
+
+Use the [LMI Pricing Calculator](https://aws-samples.github.io/sample-aws-lambda-managed-instances/) for accurate, up-to-date cost comparisons based on your specific workload parameters (region, instance type, request volume, duration).
+
+When building a cost comparison for a user, gather: region, runtime, requests/month, average duration, memory, and architecture (x86 vs ARM). Plug these into the calculator rather than relying on hardcoded estimates.
+
+## When LMI is NOT Cheaper
+
+- Lambda spend below ~$1,000/month (fixed minimum execution environment cost exceeds Lambda)
+- Very short functions (< 100ms duration)
+- Highly bursty, unpredictable traffic
+- Workloads needing scale-to-zero
+
+## Tools
+
+- [LMI Pricing Calculator](https://aws-samples.github.io/sample-aws-lambda-managed-instances/) -- interactive comparison tool
+- [AWS Pricing Calculator](https://calculator.aws/) -- general AWS cost estimation

--- a/plugins/aws-serverless/skills/aws-serverless-managed-instances/references/infrastructure-setup.md
+++ b/plugins/aws-serverless/skills/aws-serverless-managed-instances/references/infrastructure-setup.md
@@ -1,0 +1,234 @@
+# LMI Infrastructure Setup
+
+## IAM Roles (Two Required)
+
+### 1. Execution Role (for the function)
+
+Trust policy:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Principal": { "Service": "lambda.amazonaws.com" },
+    "Action": "sts:AssumeRole"
+  }]
+}
+```
+
+Minimum permissions:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "logs:CreateLogGroup",
+        "logs:CreateLogStream",
+        "logs:PutLogEvents"
+      ],
+      "Resource": "arn:aws:logs:*:*:log-group:/aws/lambda/*"
+    }
+  ]
+}
+```
+
+Add VPC permissions only if the function accesses VPC resources:
+
+```json
+{
+  "Effect": "Allow",
+  "Action": [
+    "ec2:CreateNetworkInterface",
+    "ec2:DescribeNetworkInterfaces",
+    "ec2:DeleteNetworkInterface"
+  ],
+  "Resource": "*"
+}
+```
+
+### 2. Operator Role (for capacity provider EC2 management)
+
+Trust policy:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Principal": { "Service": "lambda.amazonaws.com" },
+    "Action": "sts:AssumeRole"
+  }]
+}
+```
+
+Minimum permissions (scoped with conditions):
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": ["ec2:RunInstances", "ec2:CreateTags", "ec2:AttachNetworkInterface"],
+      "Resource": [
+        "arn:aws:ec2:*:*:instance/*",
+        "arn:aws:ec2:*:*:network-interface/*",
+        "arn:aws:ec2:*:*:volume/*"
+      ],
+      "Condition": {
+        "StringEquals": {
+          "ec2:ManagedResourceOperator": "scaler.lambda.amazonaws.com"
+        }
+      }
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "ec2:DescribeAvailabilityZones",
+        "ec2:DescribeCapacityReservations",
+        "ec2:DescribeInstances",
+        "ec2:DescribeInstanceStatus",
+        "ec2:DescribeInstanceTypeOfferings",
+        "ec2:DescribeInstanceTypes",
+        "ec2:DescribeSecurityGroups",
+        "ec2:DescribeSubnets"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": ["ec2:RunInstances", "ec2:CreateNetworkInterface"],
+      "Resource": [
+        "arn:aws:ec2:*:*:subnet/*",
+        "arn:aws:ec2:*:*:security-group/*"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": "ec2:RunInstances",
+      "Resource": "arn:aws:ec2:*:*:image/*",
+      "Condition": {
+        "StringEquals": { "ec2:Owner": "amazon" }
+      }
+    },
+    {
+      "Effect": "Allow",
+      "Action": "iam:PassRole",
+      "Resource": "<execution-role-arn>"
+    }
+  ]
+}
+```
+
+The `ec2:ManagedResourceOperator` condition ensures RunInstances/CreateTags only apply to Lambda-managed instances. First-time capacity provider creation also requires `iam:CreateServiceLinkedRole`.
+
+## VPC Requirements
+
+LMI runs functions on EC2 instances inside the VPC. These instances need VPC endpoints or NAT to reach AWS services.
+
+- Subnets across multiple AZs recommended (minimum 1 required; 3+ for multi-AZ resiliency)
+- Security groups: HTTPS egress (port 443) for AWS API calls; no ingress needed
+- VPC endpoints (if no NAT gateway) for AWS service access:
+
+| Endpoint              | Type      | Purpose               |
+| --------------------- | --------- | --------------------- |
+| S3                    | Gateway   | Object storage access |
+| DynamoDB              | Gateway   | Table access          |
+| SQS                   | Interface | Queue operations      |
+| CloudWatch Logs       | Interface | Log delivery          |
+| CloudWatch Monitoring | Interface | Metrics/EMF           |
+| X-Ray                 | Interface | Distributed tracing   |
+
+## CLI Workflow
+
+### Required Parameters
+
+| Parameter            | Description                                 |
+| -------------------- | ------------------------------------------- |
+| `SUBNET_IDS`         | Comma-separated subnet IDs across 3+ AZs    |
+| `SECURITY_GROUP_ID`  | Security group ID for the capacity provider |
+| `ACCOUNT_ID`         | AWS account ID                              |
+| `OPERATOR_ROLE_ARN`  | ARN of the operator role (see above)        |
+| `EXECUTION_ROLE_ARN` | ARN of the execution role (see above)       |
+| `FUNCTION_NAME`      | Name for the Lambda function                |
+| `CP_NAME`            | Name for the capacity provider              |
+| `ARCHITECTURE`       | `arm64` (Graviton) or `x86_64`              |
+
+### Automated Setup
+
+See [`scripts/setup-lmi.sh`](../scripts/setup-lmi.sh) -- set the environment variables above and run:
+
+```bash
+./scripts/setup-lmi.sh <function-name> <capacity-provider-name> <architecture>
+```
+
+### Manual Steps
+
+```bash
+# 1. Create capacity provider
+aws lambda create-capacity-provider \
+  --capacity-provider-name $CP_NAME \
+  --vpc-config "SubnetIds=[$SUBNET_IDS],SecurityGroupIds=[$SECURITY_GROUP_ID]" \
+  --permissions-config "CapacityProviderOperatorRoleArn=$OPERATOR_ROLE_ARN" \
+  --instance-requirements "Architectures=[$ARCHITECTURE]" \
+  --capacity-provider-scaling-config "MaxVCpuCount=30"
+
+# 2. Create function
+aws lambda create-function --function-name $FUNCTION_NAME --runtime python3.13 \
+  --handler app.handler --zip-file fileb://function.zip \
+  --role $EXECUTION_ROLE_ARN --architectures $ARCHITECTURE \
+  --memory-size 4096 \
+  --capacity-provider-config \
+    "LambdaManagedInstancesCapacityProviderConfig={CapacityProviderArn=arn:aws:lambda:$AWS_REGION:$ACCOUNT_ID:capacity-provider:$CP_NAME}"
+
+# 3. Publish version (triggers provisioning -- takes several minutes)
+aws lambda publish-version --function-name $FUNCTION_NAME
+
+# 4. Invoke (must use versioned ARN)
+aws lambda invoke --function-name $FUNCTION_NAME:1 --payload '{}' response.json
+```
+
+Architecture must match between function and capacity provider.
+
+## SAM Template
+
+```yaml
+Resources:
+  MyCP:
+    Type: AWS::Lambda::CapacityProvider
+    Properties:
+      CapacityProviderName: my-cp
+      VpcConfig:
+        SubnetIds: [!Ref Sub1, !Ref Sub2, !Ref Sub3]
+        SecurityGroupIds: [!Ref SG]
+      PermissionsConfig:
+        CapacityProviderOperatorRoleArn: !GetAtt OpRole.Arn
+      InstanceRequirements:
+        Architectures: [arm64]
+      CapacityProviderScalingConfig:
+        MaxVCpuCount: 30
+
+  MyFn:
+    Type: AWS::Serverless::Function
+    Properties:
+      Runtime: python3.13
+      Handler: app.handler
+      MemorySize: 4096
+      Architectures: [arm64]
+      CapacityProviderConfig:
+        LambdaManagedInstancesCapacityProviderConfig:
+          CapacityProviderArn: !GetAtt MyCP.Arn
+```
+
+## Cleanup
+
+```bash
+aws lambda delete-function --function-name my-fn
+aws lambda delete-capacity-provider --capacity-provider-name my-cp
+```
+
+Deleting the capacity provider destroys all associated EC2 instances.

--- a/plugins/aws-serverless/skills/aws-serverless-managed-instances/references/migration-patterns.md
+++ b/plugins/aws-serverless/skills/aws-serverless-managed-instances/references/migration-patterns.md
@@ -1,0 +1,143 @@
+# LMI Migration Patterns
+
+Before/after code examples for migrating to multi-concurrency.
+
+## Node.js
+
+### Global State
+
+```javascript
+// BEFORE (race condition)
+let requestCount = 0;
+exports.handler = async (event) => {
+  requestCount++;
+  return { count: requestCount };
+};
+
+// AFTER (request-isolated)
+const { AsyncLocalStorage } = require('node:async_hooks');
+const als = new AsyncLocalStorage();
+exports.handler = async (event) => {
+  return als.run({ id: event.requestContext?.requestId }, async () => {
+    return await processEvent(event);
+  });
+};
+```
+
+### File I/O
+
+```javascript
+// BEFORE (shared path)
+fs.writeFileSync('/tmp/output.json', JSON.stringify(data));
+
+// AFTER (request-unique path)
+const path = `/tmp/output-${event.requestContext?.requestId}.json`;
+try { fs.writeFileSync(path, JSON.stringify(data)); }
+finally { fs.unlinkSync(path); }
+```
+
+### Database
+
+```javascript
+// BEFORE (per-invocation connection)
+exports.handler = async (event) => {
+  const conn = await mysql.createConnection({/*...*/});
+  const [rows] = await conn.execute('SELECT ...');
+  await conn.end();
+};
+
+// AFTER (shared pool)
+const pool = mysql.createPool({ connectionLimit: 10, /*...*/ });
+exports.handler = async (event) => {
+  const [rows] = await pool.execute('SELECT ...');
+  return rows;
+};
+```
+
+## Python
+
+Python on LMI uses process-based isolation. Each concurrent invocation runs in its own process with independent memory. Global state is NOT shared, so no locking is needed. The main migration concerns are `/tmp` conflicts, memory sizing, and connection pooling.
+
+### Global State (No Changes Needed)
+
+```python
+# This is SAFE on LMI -- each process has its own copy of cache
+cache = {}
+def handler(event, context):
+    cache[event['key']] = compute(event)
+    return cache[event['key']]
+
+# Module-level clients are also safe (isolated per process)
+s3_client = boto3.client('s3')
+dynamodb = boto3.resource('dynamodb')
+```
+
+### File I/O (Change Required -- `/tmp` is shared across processes)
+
+```python
+# BEFORE (conflict -- all processes share /tmp)
+with open('/tmp/data.json', 'w') as f: json.dump(event, f)
+
+# AFTER (request-unique path)
+path = f'/tmp/data-{context.aws_request_id}.json'
+try:
+    with open(path, 'w') as f: json.dump(event, f)
+finally:
+    os.unlink(path)
+```
+
+### Database (Change Required -- each process needs pooled connections)
+
+```python
+# BEFORE (per-invocation connection -- exhausts limits at concurrency)
+def handler(event, context):
+    conn = psycopg2.connect(host='...')
+
+# AFTER (pool per process -- initialized at module level)
+from psycopg2 import pool
+db_pool = pool.SimpleConnectionPool(1, 3, host=os.environ['DB_HOST'])
+def handler(event, context):
+    conn = db_pool.getconn()
+    try: return query(conn, event)
+    finally: db_pool.putconn(conn)
+# Note: total connections = pool_size x concurrency (e.g., 3 x 16 = 48)
+```
+
+### Memory Sizing
+
+```python
+# A function using 200 MB per process with default concurrency of 16:
+# Total memory approximately 200 MB x 16 = 3.2 GB
+# Use 4:1 or 8:1 memory-to-vCPU ratio to accommodate
+# Monitor MemoryUtilization metric and adjust as needed
+```
+
+## Java
+
+### Global State
+
+```java
+// BEFORE (race condition)
+private static Map<String, String> cache = new HashMap<>();
+
+// AFTER (thread-safe)
+private static final ConcurrentHashMap<String, String> cache = new ConcurrentHashMap<>();
+// Use cache.computeIfAbsent(key, k -> compute(k));
+```
+
+### Database
+
+```java
+// BEFORE (per-invocation)
+Connection conn = DriverManager.getConnection("jdbc:...");
+
+// AFTER (HikariCP pool, static init)
+private static final HikariDataSource ds;
+static {
+    HikariConfig c = new HikariConfig();
+    c.setJdbcUrl(System.getenv("DB_URL"));
+    c.setMaximumPoolSize(10);
+    ds = new HikariDataSource(c);
+}
+// Use: try (Connection conn = ds.getConnection()) { ... }
+```

--- a/plugins/aws-serverless/skills/aws-serverless-managed-instances/references/thread-safety.md
+++ b/plugins/aws-serverless/skills/aws-serverless-managed-instances/references/thread-safety.md
@@ -1,0 +1,107 @@
+# Concurrency Safety for LMI
+
+LMI runs multiple invocations concurrently in the same execution environment. The concurrency model differs by runtime -- some require thread safety, others provide process isolation.
+
+## Code Review Checklist
+
+When reviewing a function for LMI readiness, check each item:
+
+- [ ] No shared `/tmp` paths (use request ID in filenames, clean up after -- shared across ALL runtimes)
+- [ ] Estimate total `/tmp` usage under max concurrency (concurrent requests x per-request file size)
+- [ ] Database connections use pools (initialized outside handler, not per-invocation)
+- [ ] SDK clients outside handler (module-level singletons are fine -- they are thread-safe)
+- [ ] Logging includes request ID (for tracing concurrent requests)
+- [ ] Node.js/Java/.NET only: No global/static mutable variables (use immutable or request-local state)
+- [ ] Node.js/Java/.NET only: Thread-safe libraries only (check DB drivers, HTTP clients, caching libs)
+- [ ] Node.js/Java/.NET only: No request state in global scope (use AsyncLocalStorage for Node.js, ThreadLocal for Java, AsyncLocal for .NET)
+- [ ] Node.js/Java/.NET only: No environment variable mutation during requests
+- [ ] Python only: Memory budget accounts for per-process multiplication (memory x concurrency)
+
+## Runtime-Specific Guidance
+
+### Python (Process-Based Isolation)
+
+Python uses multiple independent processes, each with its own interpreter and memory space. Global variables, module-level caches, and singleton objects are duplicated per process, not shared. If a function works on standard Lambda today, it works on LMI without code changes related to shared state.
+
+Key concerns:
+
+- Memory consumption: total footprint approximately per-process memory x concurrency. A 200 MB function with 16 concurrent processes can consume 3+ GB.
+- `/tmp` filesystem is shared across all processes -- use `context.aws_request_id` in filenames
+- Each process needs its own connection pool -- size pools per-process, not globally
+- Prefer 4:1 or 8:1 memory-to-vCPU ratio to accommodate memory multiplication
+- Monitor `MemoryUtilization` metric and adjust ratio if needed
+
+Safe patterns (no locking needed):
+
+- Module-level mutable globals (isolated per process)
+- Module-level SDK clients and caches
+- `os.environ` reads
+
+### Node.js (Worker Threads + Async/Await)
+
+Uses worker threads (configurable via `AWS_LAMBDA_NODEJS_WORKER_COUNT`) combined with async/await event loops. The handler and global state are shared across concurrent invocations within a worker thread.
+
+The `await` keyword yields control to the event loop, which may execute another invocation that overwrites shared state before the first resumes.
+
+Key concerns:
+
+- Use `AsyncLocalStorage` from `node:async_hooks` for request context
+- Keep mutable state within handler local scope
+- Initialize SDK clients and DB pools at module level (they are thread-safe)
+- Avoid module-level mutable state (`let count = 0` is a race condition)
+- Callback-based handlers are NOT supported on Node.js 22 -- use async handlers
+
+### Java (OS Threads)
+
+Uses OS-level threads. Lambda loads the handler class once and invokes `handleRequest` from multiple threads simultaneously (identical to a Java app server).
+
+Key concerns:
+
+- Use immutable objects and thread-safe collections (`ConcurrentHashMap`, `Collections.synchronizedList`)
+- Initialize SDK clients and connection pools in constructor or static block
+- Avoid mutable `static` fields
+- Use `ThreadLocal<T>` for request-specific state
+- Use HikariCP or similar for connection pooling (AWS SDK for Java 2.x clients are thread-safe)
+
+### .NET (Task-Based Concurrency)
+
+Uses a single process with .NET Tasks (same model as ASP.NET Core). The handler object is shared across all Tasks.
+
+Key concerns:
+
+- Use `AsyncLocal<T>` for request-scoped data
+- Inject scoped services via DI container
+- Initialize `HttpClient` and SDK clients as singletons
+- Use `ConcurrentDictionary<TKey, TValue>` and `SemaphoreSlim` for thread-safe access
+- Invocation timeouts are NOT enforced by the runtime -- use `ILambdaContext.RemainingTime` to detect approaching timeouts
+
+## Common Anti-Patterns
+
+| Anti-pattern                     | Affected Runtimes   | Risk                              | Fix                                           |
+| -------------------------------- | ------------------- | --------------------------------- | --------------------------------------------- |
+| New DB connection per invocation | All                 | Exhausts connection limits        | Module-level connection pool                  |
+| Hardcoded `/tmp` paths           | All                 | File conflicts across processes   | Use `aws_request_id` in path                  |
+| Logging without request ID       | All                 | Unreadable interleaved logs       | Include `aws_request_id`                      |
+| Mutable module-level state       | Node.js, Java, .NET | Race condition / state corruption | Request-local scope or concurrent collections |
+| Setting env vars during request  | Node.js, Java, .NET | Race condition                    | Pass state via parameters                     |
+| Assuming sequential execution    | Node.js, Java, .NET | State corruption                  | Each invocation must be self-contained        |
+| Ignoring memory multiplication   | Python              | OOM at high concurrency           | Account for per-process x concurrency         |
+
+## Powertools for AWS Lambda Compatibility
+
+Powertools handles multi-concurrency transparently (structured logging, tracing, metrics). No code changes needed.
+
+| Runtime    | Package                                | Minimum Version |
+| ---------- | -------------------------------------- | --------------- |
+| Python     | Powertools for AWS Lambda (Python)     | 3.23.0          |
+| TypeScript | Powertools for AWS Lambda (TypeScript) | 2.29.0          |
+| Java       | Powertools for AWS Lambda (Java)       | 2.8.0           |
+| .NET       | Powertools for AWS Lambda (.NET)       | 3.1.0           |
+
+AWS SDK and X-Ray minimum versions:
+
+| Runtime | AWS SDK minimum                     | X-Ray SDK minimum             |
+| ------- | ----------------------------------- | ----------------------------- |
+| Node.js | AWS SDK for JavaScript v3 (3.933.0) | 3.12.0                        |
+| Java    | AWS SDK for Java 2.0 (2.34.0)       | 2.20.0                        |
+| .NET    | AWSSDK.Core (4.0.0.32)              | AWSXRayRecorder.Core (2.16.0) |

--- a/plugins/aws-serverless/skills/aws-serverless-managed-instances/references/troubleshooting.md
+++ b/plugins/aws-serverless/skills/aws-serverless-managed-instances/references/troubleshooting.md
@@ -1,0 +1,42 @@
+# LMI Troubleshooting
+
+## Common Issues
+
+| Issue                          | Cause                                            | Resolution                                                                          |
+| ------------------------------ | ------------------------------------------------ | ----------------------------------------------------------------------------------- |
+| 429 throttles during scale-up  | Traffic doubled faster than 5-min scaling window | Increase MinExecutionEnvironments or lower TargetResourceUtilization                |
+| Function stuck in PENDING      | Capacity provider provisioning instances         | Wait several minutes; verify VPC subnets have IP capacity and IAM roles are correct |
+| Architecture mismatch error    | Function architecture != capacity provider        | Align both to arm64 or x86_64                                                       |
+| Cannot terminate EC2 instances | LMI instances managed by capacity provider       | Delete capacity provider to destroy instances; cannot use EC2 console               |
+| High CPU, low throughput       | Concurrency too high for CPU-bound work          | Reduce PerExecutionEnvironmentMaxConcurrency to 1/vCPU                              |
+| Race conditions in production  | Code not thread-safe for multi-concurrency       | Review with checklist in thread-safety.md                                           |
+| Function version not ACTIVE    | Fewer than 3 execution environments ready        | Wait for provisioning; check capacity provider status                               |
+| Unexpected 500 errors          | Unhandled concurrent access to shared state      | Add thread-safe patterns from migration-patterns.md                                 |
+| CloudWatch logs missing        | VPC egress not configured                        | Add NAT Gateway or CloudWatch Logs VPC endpoint                                     |
+| High costs despite low traffic | Minimum execution environments always running    | Evaluate if standard Lambda is more cost-effective                                  |
+
+## Debugging Steps
+
+### Function Not Starting
+
+1. Check capacity provider status: `aws lambda get-capacity-provider --capacity-provider-name <name>`
+2. Verify subnets span 3+ AZs with available IPs
+3. Confirm security group allows necessary egress
+4. Check operator role has required permissions (see infrastructure-setup.md for least-privilege policy)
+5. Look for `Operator` field in EC2 DescribeInstances or `aws:lambda:capacity-provider` tag
+
+### Performance Issues
+
+1. Check CloudWatch metrics (5-min intervals): CPU utilization, memory, concurrency/env
+2. If CPU > 80%: reduce concurrency or add vCPUs (increase memory with appropriate ratio)
+3. If throttles > 1%: increase MinExecutionEnvironments
+4. If CPU < 20%: increase concurrency -- resources are underutilized
+5. For Python: verify 4:1 or 8:1 ratio (GIL limits CPU parallelism)
+
+### Cost Issues
+
+1. Verify instance count matches actual need (not over-provisioned)
+2. Check if Savings Plans or RIs are applied to these instances
+3. Compare actual costs against the 4-column estimate from cost-comparison.md
+4. If traffic is lower than expected, consider reducing MaxVCpuCount
+5. For dev/test: use ExcludedInstanceTypes to avoid expensive instance families

--- a/plugins/aws-serverless/skills/aws-serverless-managed-instances/scripts/setup-lmi.sh
+++ b/plugins/aws-serverless/skills/aws-serverless-managed-instances/scripts/setup-lmi.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Setup script for AWS Lambda Managed Instances (LMI)
+# Usage: ./setup-lmi.sh <function-name> <capacity-provider-name> <architecture>
+#
+# Prerequisites:
+#   - AWS CLI configured with appropriate credentials
+#   - VPC subnets and security group created
+#   - IAM roles created (see references/infrastructure-setup.md)
+#
+# Environment variables (required):
+#   SUBNET_IDS       - Comma-separated subnet IDs (3+ AZs)
+#   SECURITY_GROUP_ID - Security group ID
+#   ACCOUNT_ID       - AWS account ID
+#   OPERATOR_ROLE_ARN - ARN of the LMI operator role
+#   EXECUTION_ROLE_ARN - ARN of the Lambda execution role
+#
+# Environment variables (optional):
+#   AWS_REGION       - AWS region (default: from AWS CLI config)
+#   MAX_VCPU_COUNT   - Max vCPU limit (default: 30)
+#   MEMORY_SIZE      - Function memory in MB (default: 4096)
+#   RUNTIME          - Lambda runtime (default: python3.13)
+#   HANDLER          - Function handler (default: app.handler)
+#   APPROVE_LMI_CREATE - Must be "yes"; confirms this script may create AWS resources and cost
+
+FUNCTION_NAME="${1:?Usage: $0 <function-name> <capacity-provider-name> <architecture>}"
+CP_NAME="${2:?Usage: $0 <function-name> <capacity-provider-name> <architecture>}"
+ARCHITECTURE="${3:-arm64}"
+
+: "${SUBNET_IDS:?Set SUBNET_IDS (comma-separated, 3+ AZs)}"
+: "${SECURITY_GROUP_ID:?Set SECURITY_GROUP_ID}"
+: "${ACCOUNT_ID:?Set ACCOUNT_ID}"
+: "${OPERATOR_ROLE_ARN:?Set OPERATOR_ROLE_ARN}"
+: "${EXECUTION_ROLE_ARN:?Set EXECUTION_ROLE_ARN}"
+: "${APPROVE_LMI_CREATE:?Set APPROVE_LMI_CREATE=yes after explicit approval to create AWS resources}"
+
+if [ "${APPROVE_LMI_CREATE}" != "yes" ]; then
+  echo "Refusing to create AWS resources without APPROVE_LMI_CREATE=yes" >&2
+  exit 1
+fi
+
+MAX_VCPU_COUNT="${MAX_VCPU_COUNT:-30}"
+MEMORY_SIZE="${MEMORY_SIZE:-4096}"
+RUNTIME="${RUNTIME:-python3.13}"
+HANDLER="${HANDLER:-app.handler}"
+REGION="${AWS_REGION:-$(aws configure get region)}"
+
+echo "==> Creating capacity provider: ${CP_NAME}"
+aws lambda create-capacity-provider \
+  --capacity-provider-name "${CP_NAME}" \
+  --vpc-config "SubnetIds=[${SUBNET_IDS}],SecurityGroupIds=[${SECURITY_GROUP_ID}]" \
+  --permissions-config "CapacityProviderOperatorRoleArn=${OPERATOR_ROLE_ARN}" \
+  --instance-requirements "Architectures=[${ARCHITECTURE}]" \
+  --capacity-provider-scaling-config "MaxVCpuCount=${MAX_VCPU_COUNT}"
+
+CP_ARN="arn:aws:lambda:${REGION}:${ACCOUNT_ID}:capacity-provider:${CP_NAME}"
+
+echo "==> Creating function: ${FUNCTION_NAME}"
+aws lambda create-function \
+  --function-name "${FUNCTION_NAME}" \
+  --runtime "${RUNTIME}" \
+  --handler "${HANDLER}" \
+  --zip-file fileb://function.zip \
+  --role "${EXECUTION_ROLE_ARN}" \
+  --architectures "${ARCHITECTURE}" \
+  --memory-size "${MEMORY_SIZE}" \
+  --capacity-provider-config \
+    "LambdaManagedInstancesCapacityProviderConfig={CapacityProviderArn=${CP_ARN}}"
+
+echo "==> Publishing version (triggers instance provisioning -- may take several minutes)"
+VERSION=$(aws lambda publish-version --function-name "${FUNCTION_NAME}" --query 'Version' --output text)
+
+echo "==> Done. Function version: ${VERSION}"
+echo "    Invoke with: aws lambda invoke --function-name ${FUNCTION_NAME}:${VERSION} --payload '{}' response.json"
+echo "    Monitor provisioning: aws lambda get-capacity-provider --capacity-provider-name ${CP_NAME}"


### PR DESCRIPTION
## AWS Serverless

Adds AWS Serverless workflow support for Cline across Lambda, API Gateway, SAM/CDK deployment, Lambda durable functions, and Lambda Managed Instances. The plugin combines a pinned local AWS Serverless MCP server with detailed workflow skills and bundled reference docs for designing, generating, reviewing, deploying, and operating serverless applications.

## Cline Primitives

- MCP: registers `aws-serverless-mcp` through `uvx` with the pinned `awslabs.aws-serverless-mcp-server@0.1.19` package and `--allow-write`, enabling serverless project helpers, SAM/CDK workflows, Lambda testing helpers, EventBridge schema workflows, web app deployment helpers, and serverless guidance.
- Skills: bundles five prefixed skills for Lambda application design/debugging, API Gateway architecture and operations, SAM/CDK deployment, Lambda durable functions, and Lambda Managed Instances evaluation/migration.
- Reference docs: includes detailed drill-down references for API Gateway security, service integrations, observability, limits, deployments, WebSocket APIs, SAM/CDK project setup, Lambda event sources, Step Functions, Powertools, optimization, durable-function replay/testing/error handling, and LMI configuration, migration, cost, and troubleshooting.
- Script: includes an optional LMI setup helper that creates capacity providers/functions only when explicitly run with an approval environment variable.
- Rule: adds safety guidance for AWS account access, file writes, deployments, log reads, secret reveal, IAM/DNS/certificate/custom-domain/network changes, resource deletion, sensitive-data access, and cost-bearing operations.

## Requirements

- `uvx` and Python 3.10+ are required for the MCP server.
- First MCP launch may download and execute the pinned server package through `uvx`.
- Live AWS workflows require AWS credentials and the relevant local tools for the task, such as AWS CLI, SAM CLI, CDK, Docker or a compatible container runtime, and language-specific build tools.
- AWS permissions depend on the requested workflow and may include Lambda, API Gateway, Step Functions, EventBridge, CloudFormation, IAM, S3, CloudFront, Route 53, ACM, CloudWatch, X-Ray, VPC, and related resources.
- The plugin does not enable sensitive-data MCP access, run automatic post-edit hooks, validate templates after every edit, deploy stacks, read logs, invoke functions, create resources, or install CLIs at install time.

## Trust Boundaries

The MCP server is write-capable because project generation, template creation, deployment helpers, EventBridge schema workflows, and web app deployment are core serverless workflows. Cline should still ask before using MCP tools or shell commands that create or edit files, deploy stacks, invoke functions, inspect Step Functions executions, read logs or traces, change IAM, DNS, certificates, custom domains, networking, EventBridge schemas, S3/CloudFront assets, invalidate caches, delete resources, reveal secrets, enable sensitive-data access, or incur cost.

Do not send AWS credentials, API keys, tokens, customer data, request or response bodies, log excerpts, private architecture details, or regulated data to MCP tools, generated files, shell history, or chat unless the user explicitly provides and approves that exact use.
