### PR TITLE
feat: add azure cosmos db assistant plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Each plugin lives in `plugins/<slug>`. The directory name is the install keyword
 | --- | --- |
 | `agent-browser` | Web and Electron browser automation via the agent-browser CLI skill. |
 | `agents-squad` | Background subagents with presets, skills, and shared handoffs. |
+| `azure-cosmos-db-assistant` | Azure Cosmos DB best-practices skill and code review slash command. |
 | `background-terminal` | Long-running shell jobs with polling and cleanup tools. |
 | `branch-protector` | A hook that blocks protected branch pushes unless explicitly allowed. |
 | `bundled-skills-demo` | A package plugin that proves bundled skill discovery works. |

--- a/plugins/azure-cosmos-db-assistant/README.md
+++ b/plugins/azure-cosmos-db-assistant/README.md
@@ -1,0 +1,21 @@
+# azure-cosmos-db-assistant
+
+Azure Cosmos DB review guidance for data modeling, partition keys, query efficiency, SDK usage, indexing, throughput, global distribution, monitoring, design patterns, and vector search.
+
+## What It Adds
+
+- `cosmosdb-best-practices` skill for designing, writing, and reviewing Azure Cosmos DB applications.
+- `/cosmos-review` slash command that submits a focused review prompt for the current workspace or a path the user provides.
+
+This plugin does not register a live Cosmos DB MCP server. Live database operations require user-specific service deployment and short-lived authentication, so they should be configured explicitly through the user's normal Cline MCP settings when needed.
+
+## Requirements
+
+- No API keys, Azure account, or local binaries are required for best-practices review.
+- Live account inspection is optional and should be configured separately by the user if they have an Azure Cosmos DB MCP Toolkit deployment.
+
+## Trust Boundaries
+
+- Ask before querying a live Azure Cosmos DB account, sampling documents, running vector searches, changing throughput, changing indexes, or reading production diagnostics.
+- Do not print account keys, connection strings, JWT tokens, document samples, customer data, or full resource identifiers unless the user explicitly asks.
+- Prefer code and configuration review first. Treat live database information as optional context that requires explicit approval.

--- a/plugins/azure-cosmos-db-assistant/index.ts
+++ b/plugins/azure-cosmos-db-assistant/index.ts
@@ -1,0 +1,35 @@
+import type { AgentPlugin } from "@cline/sdk"
+
+function buildReviewPrompt(input: string): string {
+	const target = input.trim() || "the current workspace"
+	return [
+		`Review ${target} for Azure Cosmos DB best practices.`,
+		"Use the cosmosdb-best-practices skill.",
+		"Prioritize findings in this order: data model design, partition key choice, CosmosClient lifecycle, query efficiency, SDK retry/connection patterns, indexing, throughput, global distribution, monitoring, and vector search.",
+		"For each finding, include severity, evidence from the code, impact on RU cost, latency, or scalability, and a concrete fix.",
+		"Do not connect to a live Azure Cosmos DB account, sample documents, read production diagnostics, change throughput, change indexes, print secrets, or perform destructive actions unless the user explicitly approves that separately.",
+	].join("\n")
+}
+
+const plugin: AgentPlugin = {
+	name: "azure-cosmos-db-assistant",
+	manifest: {
+		capabilities: ["commands", "skills"],
+	},
+
+	setup(api) {
+		api.registerCommand({
+			name: "cosmos-review",
+			description: "Review code for Azure Cosmos DB best practices.",
+			handler(input) {
+				const submitPrompt = buildReviewPrompt(input)
+				return {
+					reply: "Starting an Azure Cosmos DB best-practices review.",
+					submitPrompt,
+				}
+			},
+		})
+	},
+}
+
+export default plugin

--- a/plugins/azure-cosmos-db-assistant/package.json
+++ b/plugins/azure-cosmos-db-assistant/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "azure-cosmos-db-assistant",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Cline plugin for Azure Cosmos DB review guidance and best practices.",
+  "cline": {
+    "plugins": [
+      {
+        "paths": [
+          "./index.ts"
+        ],
+        "capabilities": [
+          "commands",
+          "skills"
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/azure-cosmos-db-assistant/skills/cosmosdb-best-practices/SKILL.md
+++ b/plugins/azure-cosmos-db-assistant/skills/cosmosdb-best-practices/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: cosmosdb-best-practices
+description: Use this skill when designing, writing, reviewing, or refactoring Azure Cosmos DB applications, especially for data modeling, partition keys, queries, SDK usage, indexing, throughput, global distribution, monitoring, design patterns, and vector search.
+---
+
+# Azure Cosmos DB Best Practices
+
+Use this skill for Azure Cosmos DB NoSQL API guidance and code review.
+
+## Review Order
+
+1. Data model design: document shape, embed vs reference, item size, schema versioning, type discriminators, JSON serialization, relationship hydration.
+2. Partition key design: high cardinality, query alignment, hotspot avoidance, hierarchical partition keys, synthetic keys, partition key length, logical partition growth.
+3. SDK usage: singleton client lifecycle, async APIs, retry-after handling for 429 responses, direct mode for production, preferred and excluded regions, diagnostics, ETags, local emulator configuration.
+4. Query efficiency: avoid scans, minimize cross-partition queries, project only needed fields, parameterize queries, page with continuation tokens, align filters and ORDER BY with indexes.
+5. Indexing: exclude unused paths, add composite indexes for common ORDER BY patterns, configure spatial indexes only when needed, understand index type and consistency tradeoffs.
+6. Throughput and scaling: choose serverless, autoscale, or provisioned throughput based on workload shape; right-size RU/s; decide database vs container throughput deliberately.
+7. Global distribution: choose consistency level, read regions, multi-region writes, automatic failover, zone redundancy, and conflict resolution based on business requirements.
+8. Monitoring: track RU consumption, throttling, latency, diagnostics, Azure Monitor integration, and alert thresholds.
+9. Design patterns: Change Feed for materialized views, service-layer hydration for references, cached or count-based ranking patterns.
+10. Vector search: feature enablement, vector embedding policy, index type, `VectorDistance()` queries, normalized embeddings for cosine similarity, and repository patterns.
+
+## Code Review Output
+
+For each finding, include:
+
+1. Severity: Critical, High, Medium, or Low.
+2. Evidence: specific files, code, queries, or configuration.
+3. Impact: RU cost, latency, scalability, availability, correctness, or maintainability.
+4. Recommendation: a concrete fix with code or configuration when useful.
+5. Validation: how the user can verify the improvement safely.
+
+## Guardrails
+
+- Ask before connecting to a live Azure Cosmos DB account, querying data, sampling documents, reading production diagnostics, changing indexes, changing throughput, or running migrations.
+- Do not expose account keys, connection strings, JWT tokens, document samples, customer data, or full resource identifiers.
+- Prefer static code and configuration review before live inspection.
+- If live inspection is approved, start with read-only metadata and narrow queries.
+
+## Topic Checklist
+
+Use these checks when the user asks for broad review:
+
+- Data model keeps frequently read data together while avoiding unbounded arrays and item growth near the 2 MB item limit.
+- Partition key has high cardinality, avoids hot tenants or timestamps, and matches the most important query patterns.
+- CosmosClient is reused as a singleton and configured for production connection mode, retries, preferred regions, and diagnostics.
+- Queries are parameterized, scoped to partitions when possible, use projections, and avoid full container scans.
+- Indexing policy supports known filters and sort orders without indexing unused high-cardinality or large fields unnecessarily.
+- Throughput mode and RU/s match the workload's traffic pattern, environments, and cost expectations.
+- Global distribution choices match consistency, failover, write-region, and latency requirements.
+- Monitoring captures RU usage, 429s, latency percentiles, diagnostics, and relevant Azure Monitor alerts.
+- Vector search configuration matches embedding dimensions, distance metric, index type, and query pattern.


### PR DESCRIPTION
# azure-cosmos-db-assistant

Adds a focused Azure Cosmos DB assistant plugin for Cline users who want best-practices review without connecting to a live database by default.

The plugin is intentionally static-review first. It helps Cline reason about Cosmos DB application code, data models, partition keys, queries, SDK usage, indexing, throughput, global distribution, monitoring, design patterns, and vector search. It does not register a live MCP server or include setup flows that ask users to paste short-lived database auth into chat.

## Cline Primitives

- Skill: bundles `cosmosdb-best-practices`, a review-oriented skill for Azure Cosmos DB NoSQL API design and implementation guidance.
- Slash command: registers `/cosmos-review`, which submits a focused Cosmos DB review prompt for the current workspace or a path the user provides.

The command routes Cline into the bundled skill and asks for findings with severity, code evidence, RU/latency/scalability impact, concrete fixes, and safe validation steps.

## Requirements

- No API keys, Azure account, or local binaries are required for the default best-practices review flow.
- Live account inspection is optional and should be configured separately by the user if they have an Azure Cosmos DB MCP Toolkit deployment.

## Trust Boundaries

The plugin does not register MCP tools for live database operations. The skill and command require explicit approval before connecting to a live Azure Cosmos DB account, sampling documents, reading production diagnostics, changing throughput, changing indexes, running vector searches, handling secrets, or performing destructive actions.

The default workflow is code and configuration review first. Live database information is optional context, not something this plugin tries to set up or access automatically.
