### PR TITLE
feat: add clangd-lsp plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Each plugin lives in `plugins/<slug>`. The directory name is the install keyword
 | `background-terminal` | Long-running shell jobs with polling and cleanup tools. |
 | `branch-protector` | A hook that blocks protected branch pushes unless explicitly allowed. |
 | `bundled-skills-demo` | A package plugin that proves bundled skill discovery works. |
+| `clangd-lsp` | C/C++ diagnostics through the local clangd language server. |
 | `custom-compaction` | Provider message compaction through a plugin message builder. |
 | `clickhouse-data-analyst` | ClickHouse data analyst skill with supporting analysis and ClickHouse sub-skills. |
 | `env-blocker` | A hook that blocks reads of secret `.env` files. |

--- a/plugins/clangd-lsp/README.md
+++ b/plugins/clangd-lsp/README.md
@@ -1,0 +1,39 @@
+# clangd-lsp
+
+Adds C/C++ diagnostics through the local clangd language server.
+
+## What It Does
+
+Registers `clangd_check(file, compileCommandsDir?)`. The tool runs `clangd --check=<file>` against a C/C++ source or header file in the current workspace and returns clangd's diagnostic output without modifying files.
+
+This is a Cline-native tool wrapper, not a persistent editor-style LSP session. It is useful when Cline needs compiler-aware C/C++ feedback before editing or explaining code.
+
+## Install
+
+```bash
+cline plugin install clangd-lsp
+```
+
+For local development from this repository:
+
+```bash
+cline plugin install ./plugins/clangd-lsp --cwd .
+```
+
+## Example Usage
+
+After installation, ask Cline:
+
+```text
+Run clangd diagnostics for src/parser.cpp and explain the highest-priority issues.
+```
+
+## Requirements
+
+- `clangd` available on `PATH`.
+- A C or C++ workspace.
+- `compile_commands.json` when the project needs custom include paths, defines, or compiler flags.
+
+## Security Notes
+
+The tool runs the local `clangd` executable on a user-selected workspace file and reads project files through clangd, including compile flags from the selected compile database when provided. It does not edit files or invoke a shell. Use normal workspace trust rules before enabling it on untrusted projects.

--- a/plugins/clangd-lsp/index.ts
+++ b/plugins/clangd-lsp/index.ts
@@ -1,0 +1,211 @@
+import { execFile } from "node:child_process"
+import { existsSync, statSync } from "node:fs"
+import { dirname, isAbsolute, relative, resolve } from "node:path"
+import { promisify } from "node:util"
+import { type AgentPlugin, createTool } from "@cline/sdk"
+
+const execFileAsync = promisify(execFile)
+
+const CPP_EXTENSIONS = new Set([
+	".c",
+	".cc",
+	".cpp",
+	".cxx",
+	".c++",
+	".h",
+	".hh",
+	".hpp",
+	".hxx",
+	".h++",
+	".ipp",
+	".inl",
+	".tpp",
+	".txx",
+])
+
+type ClangdCheckInput = {
+	file: string
+	compileCommandsDir?: string
+}
+
+function getExtension(path: string): string {
+	const index = path.lastIndexOf(".")
+	return index >= 0 ? path.slice(index).toLowerCase() : ""
+}
+
+function isDirectory(path: string): boolean {
+	try {
+		return statSync(path).isDirectory()
+	} catch {
+		return false
+	}
+}
+
+function trimOutput(value: string): string {
+	const maxLength = 60_000
+	if (value.length <= maxLength) {
+		return value
+	}
+	return `${value.slice(0, maxLength)}\n[output truncated]`
+}
+
+function isInsideWorkspace(workspaceRoot: string, path: string): boolean {
+	const rel = relative(workspaceRoot, path)
+	return rel === "" || (!rel.startsWith("..") && !isAbsolute(rel))
+}
+
+function resolveWorkspacePath(workspaceRoot: string, userPath: string): string {
+	return resolve(workspaceRoot, userPath)
+}
+
+function createClangdCheckTool(workspaceRoot: string) {
+	return createTool({
+		name: "clangd_check",
+		description:
+			"Run local clangd diagnostics for a C/C++ source or header file inside the workspace. Uses clangd --check and never modifies files.",
+		inputSchema: {
+			type: "object",
+			properties: {
+				file: {
+					type: "string",
+					description: "Workspace-relative path to a C/C++ file.",
+				},
+				compileCommandsDir: {
+					type: "string",
+					description:
+						"Optional workspace-relative directory containing compile_commands.json. Defaults to the file's directory and parent discovery by clangd.",
+				},
+			},
+			required: ["file"],
+			additionalProperties: false,
+		},
+		timeoutMs: 45_000,
+		retryable: false,
+		async execute(input: unknown) {
+			if (!input || typeof input !== "object") {
+				return { ok: false, error: "input must be an object" }
+			}
+
+			const { file, compileCommandsDir } = input as ClangdCheckInput
+			if (!file || typeof file !== "string") {
+				return { ok: false, error: "file is required" }
+			}
+			if (
+				compileCommandsDir !== undefined &&
+				typeof compileCommandsDir !== "string"
+			) {
+				return { ok: false, error: "compileCommandsDir must be a string" }
+			}
+
+			const filePath = resolveWorkspacePath(workspaceRoot, file)
+			if (!isInsideWorkspace(workspaceRoot, filePath)) {
+				return {
+					ok: false,
+					file: filePath,
+					workspaceRoot,
+					error: "file must be inside the workspace",
+				}
+			}
+			if (!existsSync(filePath) || !statSync(filePath).isFile()) {
+				return { ok: false, file: filePath, error: "file does not exist" }
+			}
+
+			const extension = getExtension(filePath)
+			if (!CPP_EXTENSIONS.has(extension)) {
+				return {
+					ok: false,
+					file: filePath,
+					error: `unsupported C/C++ file extension: ${extension || "(none)"}`,
+				}
+			}
+
+			const args = [`--check=${filePath}`]
+			if (compileCommandsDir) {
+				const compileDir = resolveWorkspacePath(workspaceRoot, compileCommandsDir)
+				if (!isInsideWorkspace(workspaceRoot, compileDir)) {
+					return {
+						ok: false,
+						file: filePath,
+						compileCommandsDir: compileDir,
+						workspaceRoot,
+						error: "compileCommandsDir must be inside the workspace",
+					}
+				}
+				if (!isDirectory(compileDir)) {
+					return {
+						ok: false,
+						file: filePath,
+						compileCommandsDir: compileDir,
+						error: "compileCommandsDir must be an existing directory",
+					}
+				}
+				args.push(`--compile-commands-dir=${compileDir}`)
+			}
+
+			try {
+				const result = await execFileAsync("clangd", args, {
+					cwd: dirname(filePath),
+					timeout: 45_000,
+					maxBuffer: 1024 * 1024,
+				})
+				return {
+					ok: true,
+					file: filePath,
+					command: "clangd",
+					args,
+					stdout: trimOutput(result.stdout),
+					stderr: trimOutput(result.stderr),
+				}
+			} catch (error) {
+				if (error && typeof error === "object") {
+					const maybe = error as {
+						code?: unknown
+						killed?: unknown
+						signal?: unknown
+						stdout?: unknown
+						stderr?: unknown
+						message?: unknown
+					}
+					return {
+						ok: false,
+						file: filePath,
+						command: "clangd",
+						args,
+						exitCode: maybe.code,
+						killed: maybe.killed,
+						signal: maybe.signal,
+						stdout:
+							typeof maybe.stdout === "string" ? trimOutput(maybe.stdout) : "",
+						stderr:
+							typeof maybe.stderr === "string" ? trimOutput(maybe.stderr) : "",
+						error:
+							typeof maybe.message === "string"
+								? maybe.message
+								: "clangd check failed",
+					}
+				}
+				return {
+					ok: false,
+					file: filePath,
+					command: "clangd",
+					args,
+					error: String(error),
+				}
+			}
+		},
+	})
+}
+
+const plugin: AgentPlugin = {
+	name: "clangd-lsp",
+	manifest: {
+		capabilities: ["tools"],
+	},
+
+	setup(api, ctx) {
+		const workspaceRoot = resolve(ctx.workspaceInfo?.rootPath ?? process.cwd())
+		api.registerTool(createClangdCheckTool(workspaceRoot))
+	},
+}
+
+export default plugin


### PR DESCRIPTION
## clangd-lsp

Adds a C/C++ diagnostics plugin built around the local `clangd` language server. The plugin gives Cline a focused way to ask clangd for compiler-aware feedback on a workspace file before editing, explaining, or debugging C/C++ code.

This is intentionally a one-shot diagnostics surface rather than a persistent editor-style language server session. Cline does not currently expose a generic LSP primitive, so the useful user-facing shape is a small tool that runs `clangd --check=<file>` and returns the diagnostic output.

## Cline Primitives

This plugin registers one tool:

- `clangd_check(file, compileCommandsDir?)` runs local `clangd --check` for a C/C++ source or header file inside the current workspace and returns stdout/stderr, exit status, and error details as structured data.

The tool is workspace-bounded, rejects unsupported file extensions before invoking clangd, and returns structured errors for missing files, malformed input, missing `clangd`, timeouts, and clangd failures.

## Requirements

- `clangd` must be installed and available on `PATH`.
- The target project should be a C or C++ workspace.
- Projects that need custom include paths, defines, or compiler flags should provide a `compile_commands.json`; callers can pass `compileCommandsDir` when clangd should use a specific compile database directory.

## Trust Boundaries

The plugin runs the local `clangd` executable against files in the active workspace. It does not edit files and does not invoke a shell, but clangd can read project files and compile database flags while analyzing the selected file. Users should apply normal workspace trust rules before enabling it on untrusted projects.
