### PR TITLE
feat: add clickhouse best practices plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,9 @@ Each plugin lives in `plugins/<slug>`. The directory name is the install keyword
 | `background-terminal` | Long-running shell jobs with polling and cleanup tools. |
 | `branch-protector` | A hook that blocks protected branch pushes unless explicitly allowed. |
 | `bundled-skills-demo` | A package plugin that proves bundled skill discovery works. |
-| `custom-compaction` | Provider message compaction through a plugin message builder. |
+| `clickhouse-best-practices` | ClickHouse and chDB schema, query, architecture, and client troubleshooting skills. |
 | `clickhouse-data-analyst` | ClickHouse data analyst skill with supporting analysis and ClickHouse sub-skills. |
+| `custom-compaction` | Provider message compaction through a plugin message builder. |
 | `env-blocker` | A hook that blocks reads of secret `.env` files. |
 | `gitignore-read-files-guard` | A hook that blocks file access to `.gitignore` ignored paths. |
 | `goal` | Completion nudges for active goals with a slash command and completion tool. |

--- a/plugins/clickhouse-best-practices/LICENSE.clickhouse-agent-skills
+++ b/plugins/clickhouse-best-practices/LICENSE.clickhouse-agent-skills
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/plugins/clickhouse-best-practices/NOTICE.clickhouse-agent-skills
+++ b/plugins/clickhouse-best-practices/NOTICE.clickhouse-agent-skills
@@ -1,0 +1,36 @@
+ClickHouse Best Practices for Cline
+
+This plugin includes adapted guidance from the ClickHouse Agent Skills
+project:
+
+- https://github.com/ClickHouse/agent-skills
+
+The adapted skills retain the original licensing noted in their frontmatter:
+
+- clickhouse-best-practices: Apache-2.0
+- clickhouse-architecture-advisor: Apache-2.0
+- chdb-sql: Apache-2.0
+- chdb-datastore: Apache-2.0
+- clickhouse-js-node-troubleshooting: MIT
+
+MIT notice for clickhouse-js-node-troubleshooting:
+
+Copyright (c) ClickHouse Inc
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/plugins/clickhouse-best-practices/README.md
+++ b/plugins/clickhouse-best-practices/README.md
@@ -1,0 +1,49 @@
+# clickhouse-best-practices
+
+Adds an offline ClickHouse skill pack for schema design, query review, architecture decisions, Node.js client troubleshooting, and local chDB analytics.
+
+## What It Does
+
+Bundles five guidance-only skills and does not register an MCP server:
+
+- `clickhouse-best-practices` reviews schemas, queries, ingestion plans, materialized views, and safe analytical workflow.
+- `clickhouse-architecture-advisor` maps workload requirements to ClickHouse architecture choices.
+- `clickhouse-js-node-troubleshooting` diagnoses common `@clickhouse/client` connection, TLS, proxy, insert, streaming, and timeout issues.
+- `chdb-sql` helps write embedded ClickHouse SQL over local files, object storage, and remote analytical sources from Python.
+- `chdb-datastore` helps replace pandas-style workflows with chDB DataStore patterns for faster local and cross-source analysis.
+
+## Install
+
+```bash
+cline plugin install clickhouse-best-practices
+```
+
+For local development from this repository:
+
+```bash
+cline plugin install ./plugins/clickhouse-best-practices --cwd .
+```
+
+## Example Usage
+
+After installation, ask Cline:
+
+```text
+Use ClickHouse best practices to review this table schema and ingestion plan.
+```
+
+Or:
+
+```text
+Help me troubleshoot this @clickhouse/client socket hang up error.
+```
+
+## Requirements
+
+- No API keys or external services are required to load the skills.
+- chDB guidance assumes a Python project where installing and importing `chdb` is appropriate.
+- Node.js client guidance assumes the project uses `@clickhouse/client` in a Node runtime.
+
+## Trust Boundaries
+
+These skills are guidance only; they do not register MCP servers or execute code. Use the separate `clickhouse` plugin when the user wants ClickHouse Cloud MCP access. Treat database schemas, query results, logs, connection strings, cloud URLs, and local file samples as sensitive project data. Ask before suggesting broad data exports, production-impacting queries, package installs, or service changes.

--- a/plugins/clickhouse-best-practices/index.ts
+++ b/plugins/clickhouse-best-practices/index.ts
@@ -1,0 +1,10 @@
+import type { AgentPlugin } from "@cline/sdk"
+
+const plugin: AgentPlugin = {
+	name: "clickhouse-best-practices",
+	manifest: {
+		capabilities: ["skills"],
+	},
+}
+
+export default plugin

--- a/plugins/clickhouse-best-practices/package.json
+++ b/plugins/clickhouse-best-practices/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "clickhouse-best-practices",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Offline Cline skill pack for ClickHouse and chDB best practices.",
+  "cline": {
+    "plugins": [
+      {
+        "paths": [
+          "./index.ts"
+        ],
+        "capabilities": [
+          "skills"
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/clickhouse-best-practices/skills/chdb-datastore/SKILL.md
+++ b/plugins/clickhouse-best-practices/skills/chdb-datastore/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: chdb-datastore
+description: Use chDB DataStore for pandas-style local and cross-source analytics. Use when speeding up pandas-like workflows, filtering or joining DataFrames, reading parquet/CSV/JSON/Arrow, or joining data from MySQL, PostgreSQL, S3, MongoDB, ClickHouse Cloud, Iceberg, or Delta Lake.
+license: Apache-2.0
+metadata:
+  author: chdb-io
+  adapted_from: ClickHouse Agent Skills
+---
+
+# chDB DataStore
+
+Help users use chDB DataStore as a pandas-compatible analytical layer backed by ClickHouse.
+
+## When To Use
+
+- The user has pandas-style code that is slow or memory-heavy.
+- The user wants DataFrame-like filtering, grouping, aggregation, or joins.
+- The user wants to query parquet, CSV, JSON, Arrow, object storage, or remote databases as DataFrames.
+- The user wants cross-source joins without building a full pipeline first.
+
+Use `chdb-sql` instead when the user primarily wants raw SQL examples or ClickHouse table functions.
+
+## Safety
+
+- Treat file paths, bucket URLs, connection details, schemas, sample rows, and query outputs as sensitive.
+- Do not ask users to paste passwords, tokens, or full connection strings.
+- Ask before suggesting installation, scanning large private datasets, or joining/exporting data across systems.
+
+## Migration Guidance
+
+- Identify the current pandas bottleneck: file read, group-by, join, memory pressure, or repeated transformations.
+- Keep the first rewrite small and behavior-preserving.
+- Push filters, projections, and joins into chDB rather than materializing full intermediate DataFrames.
+- Validate row counts, null handling, numeric precision, timestamps, and ordering assumptions.
+- For cross-source joins, clarify which system owns the data and whether local materialization is acceptable.
+- Preserve readable pandas-like code where performance is already adequate.
+
+## Response Shape
+
+```md
+Use DataStore when:
+- [why this workload fits]
+
+Minimal rewrite:
+- Provide a compact, redacted Python snippet.
+
+Validation:
+- [checks against the old pandas result]
+
+Caveats:
+- [memory, credentials, source access, or semantics]
+```

--- a/plugins/clickhouse-best-practices/skills/chdb-sql/SKILL.md
+++ b/plugins/clickhouse-best-practices/skills/chdb-sql/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: chdb-sql
+description: Use embedded ClickHouse SQL from Python with chDB. Use when querying parquet, CSV, JSON, local files, URLs, S3, MySQL, PostgreSQL, MongoDB, Iceberg, Delta Lake, or ClickHouse sources without running a separate server.
+license: Apache-2.0
+metadata:
+  author: chdb-io
+  adapted_from: ClickHouse Agent Skills
+---
+
+# chDB SQL
+
+Help users use chDB as embedded ClickHouse SQL from Python for local files, object storage, and remote analytical sources.
+
+## When To Use
+
+- The user wants SQL over local parquet, CSV, JSON, Arrow, or log files.
+- The user wants quick analytical exploration without a separate ClickHouse server.
+- The user wants stateful multi-step local analysis with a Python process.
+- The user needs ClickHouse functions, table functions, or cross-source joins from Python.
+
+Do not use this skill for general ClickHouse server administration or pandas-style DataFrame API work; use `chdb-datastore` for DataFrame-like workflows.
+
+## Safety
+
+- Treat local file paths, URLs, object storage paths, credentials, and query outputs as sensitive.
+- Do not ask users to paste secrets. Prefer environment variables, local profiles, or existing project configuration.
+- Ask before suggesting installation, large scans, cross-source exports, or queries over private buckets and production databases.
+
+## Guidance
+
+- Start with a tiny query that proves the file or source is readable.
+- Use explicit file formats where inference may be ambiguous.
+- Use `Session` when the workflow needs temporary tables, repeated queries, or shared state.
+- Prefer parameterized queries for user-supplied values.
+- Keep memory limits and local disk constraints in mind for large files.
+- Push filters and projections into the SQL instead of loading full datasets into Python first.
+- For remote sources, clarify network access, credentials, and whether data movement is acceptable.
+
+## Response Shape
+
+```md
+Approach:
+- [chDB query/session pattern]
+
+Example:
+- Provide a compact, redacted Python snippet.
+
+Notes:
+- [format, performance, safety, or credential caveat]
+```
+
+Keep examples minimal and avoid fabricating schema details.

--- a/plugins/clickhouse-best-practices/skills/clickhouse-architecture-advisor/SKILL.md
+++ b/plugins/clickhouse-best-practices/skills/clickhouse-architecture-advisor/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: clickhouse-architecture-advisor
+description: Design ClickHouse architectures from workload requirements. Use when choosing ingestion strategies, time-series partitioning, real-time pre-aggregation, enrichment patterns, mutable-state handling, or production topology.
+license: Apache-2.0
+metadata:
+  author: ClickHouse Inc
+  adapted_from: ClickHouse Agent Skills
+---
+
+# ClickHouse Architecture Advisor
+
+Turn workload requirements into ClickHouse architecture recommendations. Prefer explicit tradeoffs over one-size-fits-all guidance.
+
+## Inputs To Gather
+
+- Data sources, formats, and expected ingest rate.
+- Latency targets for ingestion and queries.
+- Retention, backfill, replay, and deletion requirements.
+- Query shapes, filters, joins, aggregations, concurrency, and freshness needs.
+- Expected data volume, cardinality, and skew.
+- Operational constraints: cloud, self-managed, local development, compliance, budget, and team experience.
+
+## Decision Areas
+
+### Ingestion
+
+- Use direct batched inserts for simple application writes.
+- Use queues or streaming pipelines when durability, buffering, replay, or fan-out matters.
+- Use ClickPipes or managed connectors when the source is supported and operational simplicity is more important than custom control.
+- Use object storage landing zones for bulk historical loads and replayable pipelines.
+
+### Time Series
+
+- Use the sort key for common time-bounded filters plus high-value dimensions.
+- Keep partitions coarse enough to avoid too many parts.
+- Model retention with TTLs or partition drops where possible.
+- Separate hot and historical access patterns when they need different layouts.
+
+### Joins And Enrichment
+
+- Prefer denormalization when enrichment is stable and heavily queried.
+- Use dictionaries for fast key-value lookups.
+- Use materialized views for repeated derived tables.
+- Keep runtime joins for smaller dimensions, ad hoc exploration, or cases where freshness outweighs query cost.
+
+### Mutable Data
+
+- Avoid row-by-row updates as the default design.
+- Consider `ReplacingMergeTree`, `CollapsingMergeTree`, or versioned append patterns for late-arriving changes.
+- Make query-time deduplication costs explicit.
+- Define reconciliation and backfill strategy before production.
+
+### Pre-Aggregation
+
+- Use incremental materialized views for stable real-time rollups.
+- Use refreshable materialized views for complex joins or recomputation-heavy transformations.
+- Keep raw data when audits, reprocessing, or changing metrics definitions matter.
+
+## Output
+
+Return:
+
+```md
+Recommendation:
+- [architecture choice]
+
+Why:
+- [workload evidence]
+
+Tradeoffs:
+- [cost, latency, complexity, freshness]
+
+Next validation:
+- [small experiment, schema check, benchmark, or operational question]
+```
+
+Label unsupported assumptions clearly.

--- a/plugins/clickhouse-best-practices/skills/clickhouse-best-practices/SKILL.md
+++ b/plugins/clickhouse-best-practices/skills/clickhouse-best-practices/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: clickhouse-best-practices
+description: Review ClickHouse schemas, SQL, ingestion plans, materialized views, and performance choices. Use for CREATE TABLE design, ORDER BY keys, partitions, data types, joins, inserts, updates, deletes, slow queries, or ClickHouse-specific query review.
+license: Apache-2.0
+metadata:
+  author: ClickHouse Inc
+  adapted_from: ClickHouse Agent Skills
+---
+
+# ClickHouse Best Practices
+
+Use ClickHouse-specific judgment when reviewing database design or SQL. Columnar MergeTree behavior, sort keys, background merges, and analytical access patterns matter more than row-store intuition.
+
+## Safety
+
+- Do not ask users to paste passwords, OAuth tokens, API keys, private keys, or full connection strings.
+- Treat schemas, logs, query text, query results, object names, cloud URLs, and billing or service metadata as sensitive project data.
+- For exploratory SQL, prefer read-only SELECT queries with explicit `LIMIT`, narrow filters, and small time ranges.
+- Prefer metadata and schema checks before SQL. Do not treat `LIMIT` as a cost guard for broad aggregates, joins, or scans because ClickHouse may still need to read substantial data before limiting output.
+- Ask before recommending broad scans, expensive group-bys, export-like outputs, destructive DDL, mutations, or production configuration changes.
+
+## Schema Review
+
+- Choose `ORDER BY` before table creation; changing it later usually requires a table rebuild.
+- Put frequently filtered, lower-cardinality dimensions earlier in `ORDER BY`, then more granular columns.
+- Align the sort key with the highest-value query patterns, not every possible filter.
+- Prefer native types over storing everything as `String`.
+- Use the smallest numeric type that safely fits the domain.
+- Use `LowCardinality(String)` for repeated strings with bounded cardinality.
+- Avoid `Nullable` where a default value clearly represents missing data.
+- Keep partition cardinality bounded. Partition mostly for lifecycle management and data movement, not routine query speed.
+- Start without partitioning unless retention, backfills, or data-management requirements justify it.
+
+## Query Review
+
+- Filter on the `ORDER BY` prefix whenever possible.
+- Filter large tables before joins.
+- Use `ANY JOIN` when only one match is needed.
+- Consider dictionaries, denormalization, projections, or materialized views before adding frequent large joins.
+- Avoid null-heavy join keys and clarify semantics for missing values.
+- Use skipping indexes only for selective predicates not covered by the sort key; validate with real query patterns.
+- Use `EXPLAIN`, small bounded queries, or system tables to verify assumptions before recommending major changes.
+
+## Ingestion And Mutations
+
+- Batch inserts around 10,000 to 100,000 rows when practical.
+- Use async inserts for high-frequency small inserts.
+- Prefer native or efficient columnar formats for bulk loading.
+- Avoid frequent `ALTER TABLE UPDATE`; model update patterns with engines such as `ReplacingMergeTree` when appropriate.
+- Avoid frequent large deletes; prefer partition drops, retention policies, or lightweight deletes when appropriate.
+- Avoid routine `OPTIMIZE TABLE ... FINAL`; let background merges work unless there is a specific operational reason.
+
+## Materialized Views
+
+- Use incremental materialized views for real-time aggregations over append-heavy streams.
+- Use refreshable materialized views when the query depends on complex joins or full recomputation.
+- Match the target table key to the serving query pattern.
+- Document freshness expectations, backfill behavior, and failure recovery.
+
+## Response Shape
+
+For reviews, answer with:
+
+```md
+Rules checked:
+- [area] - [pass/fail/needs evidence]
+
+Findings:
+- [specific issue, why it matters in ClickHouse, concrete fix]
+
+Open questions:
+- [missing workload, schema, volume, retention, or query detail]
+```
+
+If evidence is missing, say what to inspect next instead of guessing.

--- a/plugins/clickhouse-best-practices/skills/clickhouse-js-node-troubleshooting/SKILL.md
+++ b/plugins/clickhouse-best-practices/skills/clickhouse-js-node-troubleshooting/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: clickhouse-js-node-troubleshooting
+description: Troubleshoot the ClickHouse Node.js client in Node runtimes. Use for @clickhouse/client connection drops, socket hang up errors, TLS or proxy issues, query parameters, inserts, streaming, compression, read-only users, and timeout behavior. Do not use for browser, Workers, Edge, or @clickhouse/client-web issues.
+license: MIT
+metadata:
+  author: ClickHouse Inc
+  adapted_from: ClickHouse Agent Skills
+---
+
+# ClickHouse Node.js Troubleshooting
+
+Diagnose `@clickhouse/client` issues from symptoms, configuration, error messages, and minimal code snippets. Protect secrets and prefer small, reversible checks.
+
+Use this skill only for Node.js runtimes. For browser, Workers, Edge, or `@clickhouse/client-web`, say that the runtime has different constraints and avoid applying Node transport assumptions.
+
+## Safety
+
+- Do not ask for full connection strings, passwords, tokens, certificates, or private keys.
+- Ask users to redact hosts, usernames, database names, query text, and payload samples when needed.
+- Do not suggest production-impacting changes without calling out blast radius and rollback.
+
+## Triage
+
+Collect:
+
+- Client package name and version.
+- Runtime: Node.js version, serverless/container/local environment, proxy or load balancer path.
+- Transport: HTTP or HTTPS, TLS settings, compression, keep-alive, request timeout.
+- Operation: select, insert, stream, ping, query parameters, session, or long-running query.
+- Exact error class and where it occurs.
+- Whether the same query works in `clickhouse-client` or another known-good path.
+
+## Common Patterns
+
+- `socket hang up` or `ECONNRESET`: check keep-alive reuse, proxy idle timeout, serverless execution limits, request body size, and long-running query timeout.
+- TLS failures: verify CA handling, hostname validation, corporate proxy behavior, and whether the endpoint requires HTTPS.
+- Proxy path issues: confirm that custom pathnames are preserved and not double-prefixed.
+- Insert failures: verify format, column order, JSONEachRow shape, required columns, compression, and payload size.
+- Streaming issues: consume streams fully, attach error handlers, avoid buffering huge responses, and close resources.
+- Query parameter issues: use client-supported parameter binding instead of string interpolation.
+- Read-only user errors: separate permission failures from SQL syntax and route writes through an allowed role.
+- Data type surprises: check DateTime64 precision, Decimal handling, UUID strings, arrays, maps, and nullable values.
+
+## Response Shape
+
+```md
+Likely cause:
+- [ranked hypothesis]
+
+Evidence:
+- [what in the error/config/code points there]
+
+Safe checks:
+- [small check that avoids exposing secrets]
+
+Fix:
+- [specific client/config/code change]
+
+Still needed:
+- [minimal missing detail]
+```


### PR DESCRIPTION
## clickhouse-best-practices

Adds an offline ClickHouse skill pack for Cline users who want ClickHouse guidance without installing a runtime integration. This is the standalone skills path: schema design, query review, architecture decisions, Node.js client troubleshooting, and local chDB analytics.

This is intentionally separate from the `clickhouse` plugin, which focuses on ClickHouse Cloud MCP access and OAuth setup.

## Cline Primitives

- `clickhouse-best-practices` skill reviews ClickHouse schemas, SQL, ingestion plans, materialized views, and performance choices with explicit safety guidance for costly scans, mutations, and sensitive data.
- `clickhouse-architecture-advisor` skill maps workload requirements to ClickHouse architecture choices across ingestion, time-series design, enrichment, mutable data, and pre-aggregation.
- `clickhouse-js-node-troubleshooting` skill diagnoses `@clickhouse/client` issues in Node runtimes, including connection drops, TLS/proxy issues, inserts, streams, query parameters, and timeouts.
- `chdb-sql` skill helps write embedded ClickHouse SQL from Python over local files, object storage, and remote analytical sources.
- `chdb-datastore` skill helps adapt pandas-style workflows to chDB DataStore patterns for faster local and cross-source analysis.

## Requirements

- No API keys or external services are required to load the skills.
- chDB guidance assumes a Python project where installing and importing `chdb` is appropriate.
- Node.js client troubleshooting assumes a Node runtime using `@clickhouse/client`; it is not intended for browser, Workers, Edge, or `@clickhouse/client-web` issues.

## Trust Boundaries

The plugin is guidance-only: it does not register MCP servers, install packages, or execute code.

Database schemas, query results, logs, connection strings, cloud URLs, local file paths, and data samples can all contain sensitive project data. The bundled skills tell Cline to avoid pasted secrets, prefer small bounded examples, ask before broad scans or data exports, and call out production-impacting changes before recommending them.
