### PR TITLE
feat: add csharp lsp plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Each plugin lives in `plugins/<slug>`. The directory name is the install keyword
 | `branch-protector` | A hook that blocks protected branch pushes unless explicitly allowed. |
 | `bundled-skills-demo` | A package plugin that proves bundled skill discovery works. |
 | `custom-compaction` | Provider message compaction through a plugin message builder. |
+| `csharp-lsp` | C# build diagnostics through the local .NET SDK. |
 | `clickhouse-data-analyst` | ClickHouse data analyst skill with supporting analysis and ClickHouse sub-skills. |
 | `env-blocker` | A hook that blocks reads of secret `.env` files. |
 | `gitignore-read-files-guard` | A hook that blocks file access to `.gitignore` ignored paths. |

--- a/plugins/csharp-lsp/README.md
+++ b/plugins/csharp-lsp/README.md
@@ -1,0 +1,39 @@
+# csharp-lsp
+
+Adds local C# build diagnostics for Cline.
+
+## What It Does
+
+Registers `csharp_build_diagnostics`. The tool runs `dotnet build` against a workspace solution or project and returns compiler diagnostics. It defaults to `--no-restore` so invoking the tool does not implicitly fetch packages from the network.
+
+This is a Cline-native adaptation of C# language-server support. Cline does not yet expose a generic persistent LSP plugin primitive, so this plugin provides the most useful low-surprise diagnostic workflow through the .NET SDK.
+
+## Install
+
+```bash
+cline plugin install csharp-lsp
+```
+
+For local development from this repository:
+
+```bash
+cline plugin install ./plugins/csharp-lsp --cwd .
+```
+
+## Example Usage
+
+After installation, ask Cline:
+
+```text
+Run C# diagnostics for this solution and summarize the compiler errors.
+```
+
+## Requirements
+
+- A C# workspace with a `.sln`, `.slnx`, or `.csproj` file.
+- .NET SDK 6.0 or later on PATH.
+- Restored packages when using the default `--no-restore` behavior.
+
+## Security Notes
+
+The tool executes `dotnet build` inside the workspace. It does not modify source files, but normal .NET builds can write `bin/` and `obj/` outputs and execute build targets defined by the project. Use normal workspace trust rules before enabling it on untrusted projects.

--- a/plugins/csharp-lsp/index.ts
+++ b/plugins/csharp-lsp/index.ts
@@ -1,0 +1,223 @@
+import { execFile } from "node:child_process"
+import { readdirSync, realpathSync, statSync } from "node:fs"
+import { extname, isAbsolute, relative, resolve } from "node:path"
+import { promisify } from "node:util"
+import { type AgentPlugin, createTool } from "@cline/core"
+
+const execFileAsync = promisify(execFile)
+const TARGET_EXTENSIONS = new Set([".sln", ".slnx", ".csproj"])
+
+type CsharpBuildDiagnosticsInput = {
+	target?: string
+	configuration?: string
+	noRestore?: boolean
+	verbosity?: "quiet" | "minimal" | "normal"
+}
+
+function isInsideWorkspace(workspaceRoot: string, path: string): boolean {
+	try {
+		const workspaceRealPath = realpathSync(workspaceRoot)
+		const targetRealPath = realpathSync(path)
+		const rel = relative(workspaceRealPath, targetRealPath)
+		return rel === "" || (!rel.startsWith("..") && !isAbsolute(rel))
+	} catch {
+		return false
+	}
+}
+
+function isFile(path: string): boolean {
+	try {
+		return statSync(path).isFile()
+	} catch {
+		return false
+	}
+}
+
+function trimOutput(value: string): string {
+	const maxLength = 80_000
+	if (value.length <= maxLength) return value
+	return `${value.slice(0, maxLength)}\n[output truncated]`
+}
+
+function findDefaultTarget(workspaceRoot: string): string | undefined {
+	const entries = readdirSync(workspaceRoot)
+	const candidates = entries
+		.map((entry) => resolve(workspaceRoot, entry))
+		.filter((entry) => isFile(entry) && TARGET_EXTENSIONS.has(extname(entry)))
+		.sort((a, b) => {
+			const aExt = extname(a)
+			const bExt = extname(b)
+			if (aExt === bExt) return a.localeCompare(b)
+			if (aExt === ".sln") return -1
+			if (bExt === ".sln") return 1
+			if (aExt === ".slnx") return -1
+			if (bExt === ".slnx") return 1
+			return a.localeCompare(b)
+		})
+	return candidates[0]
+}
+
+function resolveTarget(workspaceRoot: string, target: string | undefined) {
+	const targetPath = target
+		? resolve(workspaceRoot, target)
+		: findDefaultTarget(workspaceRoot)
+	if (!targetPath) {
+		return {
+			ok: false as const,
+			error:
+				"target is required when the workspace root does not contain a .sln, .slnx, or .csproj file",
+		}
+	}
+	if (!isFile(targetPath)) {
+		return { ok: false as const, target: targetPath, error: "target does not exist" }
+	}
+	if (!isInsideWorkspace(workspaceRoot, targetPath)) {
+		return {
+			ok: false as const,
+			target: targetPath,
+			error: "target must be inside the workspace",
+		}
+	}
+	const extension = extname(targetPath)
+	if (!TARGET_EXTENSIONS.has(extension)) {
+		return {
+			ok: false as const,
+			target: targetPath,
+			error: "target must be a .sln, .slnx, or .csproj file",
+		}
+	}
+	return { ok: true as const, target: targetPath }
+}
+
+function createCsharpBuildDiagnosticsTool(workspaceRoot: string) {
+	return createTool({
+		name: "csharp_build_diagnostics",
+		description:
+			"Run local .NET build diagnostics for a C# solution or project inside the workspace. Uses dotnet build and returns compiler diagnostics. This may write normal build outputs such as bin/ and obj/.",
+		inputSchema: {
+			type: "object",
+			properties: {
+				target: {
+					type: "string",
+					description:
+						"Optional workspace-relative path to a .sln, .slnx, or .csproj file. Defaults to a solution or project in the workspace root.",
+				},
+				configuration: {
+					type: "string",
+					description: "Optional build configuration such as Debug or Release.",
+				},
+				noRestore: {
+					type: "boolean",
+					description:
+						"Whether to pass --no-restore. Defaults to true to avoid implicit package restore and network access.",
+				},
+				verbosity: {
+					type: "string",
+					enum: ["quiet", "minimal", "normal"],
+					description: "dotnet build verbosity. Defaults to minimal.",
+				},
+			},
+			additionalProperties: false,
+		},
+		timeoutMs: 120_000,
+		retryable: false,
+		async execute(input: unknown) {
+			if (!input || typeof input !== "object") {
+				return { ok: false, error: "input must be an object" }
+			}
+
+			const options = input as CsharpBuildDiagnosticsInput
+			if (options.target !== undefined && typeof options.target !== "string") {
+				return { ok: false, error: "target must be a string" }
+			}
+			if (
+				options.configuration !== undefined &&
+				typeof options.configuration !== "string"
+			) {
+				return { ok: false, error: "configuration must be a string" }
+			}
+			if (options.noRestore !== undefined && typeof options.noRestore !== "boolean") {
+				return { ok: false, error: "noRestore must be a boolean" }
+			}
+
+			const verbosity = options.verbosity ?? "minimal"
+			if (!["quiet", "minimal", "normal"].includes(verbosity)) {
+				return { ok: false, error: "verbosity must be quiet, minimal, or normal" }
+			}
+
+			const resolved = resolveTarget(workspaceRoot, options.target)
+			if (!resolved.ok) return resolved
+
+			const args = ["build", resolved.target, "--nologo", "--verbosity", verbosity]
+			if (options.noRestore !== false) args.push("--no-restore")
+			if (options.configuration?.trim()) {
+				args.push("--configuration", options.configuration.trim())
+			}
+
+			try {
+				const result = await execFileAsync("dotnet", args, {
+					cwd: workspaceRoot,
+					timeout: 120_000,
+					maxBuffer: 16 * 1024 * 1024,
+				})
+				return {
+					ok: true,
+					target: resolved.target,
+					command: "dotnet",
+					args,
+					stdout: trimOutput(result.stdout),
+					stderr: trimOutput(result.stderr),
+				}
+			} catch (error) {
+				if (error && typeof error === "object") {
+					const maybe = error as {
+						code?: unknown
+						killed?: unknown
+						signal?: unknown
+						stdout?: unknown
+						stderr?: unknown
+						message?: unknown
+					}
+					return {
+						ok: false,
+						target: resolved.target,
+						command: "dotnet",
+						args,
+						exitCode: maybe.code,
+						killed: maybe.killed,
+						signal: maybe.signal,
+						stdout:
+							typeof maybe.stdout === "string" ? trimOutput(maybe.stdout) : "",
+						stderr:
+							typeof maybe.stderr === "string" ? trimOutput(maybe.stderr) : "",
+						error:
+							typeof maybe.message === "string"
+								? maybe.message
+								: "dotnet build failed",
+					}
+				}
+				return {
+					ok: false,
+					target: resolved.target,
+					command: "dotnet",
+					args,
+					error: String(error),
+				}
+			}
+		},
+	})
+}
+
+const plugin: AgentPlugin = {
+	name: "csharp-lsp",
+	manifest: {
+		capabilities: ["tools"],
+	},
+
+	setup(api, ctx) {
+		const workspaceRoot = resolve(ctx.workspaceInfo?.rootPath ?? process.cwd())
+		api.registerTool(createCsharpBuildDiagnosticsTool(workspaceRoot))
+	},
+}
+
+export default plugin


### PR DESCRIPTION
## csharp-lsp

Adds a C# diagnostics plugin for Cline users working in .NET projects. Since Cline does not currently expose a generic persistent LSP primitive, this adapts C# language-server support into a practical local diagnostic tool rather than pretending to run a long-lived language server.

The plugin is intentionally narrow: it gives Cline a way to ask the local .NET SDK for compiler diagnostics on a solution or project, while keeping network and mutation surprises explicit.

## Cline Primitives

- Tool: registers `csharp_build_diagnostics`, which runs `dotnet build` against a workspace `.sln`, `.slnx`, or `.csproj` and returns structured stdout, stderr, exit status, and error metadata.
- Workspace guardrails: targets must resolve inside the workspace, including realpath checks for symlinks.
- Network guardrail: the tool defaults to `--no-restore` so it does not implicitly fetch NuGet packages. Users can opt out by setting `noRestore: false` when restore behavior is desired.

## Requirements

Users need a C# workspace with a solution or project file and .NET SDK 6.0 or later on PATH. With the default `--no-restore` behavior, packages should already be restored.

## Trust Boundaries

The tool executes `dotnet build` in the workspace. It does not modify source files, but normal .NET builds can write `bin/` and `obj/` outputs and execute build targets defined by the project. It should be used only in workspaces the user trusts, and Cline should not run it just to prove the plugin exists.
