### PR TITLE
feat: add dataproc plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,9 @@ Each plugin lives in `plugins/<slug>`. The directory name is the install keyword
 | `background-terminal` | Long-running shell jobs with polling and cleanup tools. |
 | `branch-protector` | A hook that blocks protected branch pushes unless explicitly allowed. |
 | `bundled-skills-demo` | A package plugin that proves bundled skill discovery works. |
-| `custom-compaction` | Provider message compaction through a plugin message builder. |
 | `clickhouse-data-analyst` | ClickHouse data analyst skill with supporting analysis and ClickHouse sub-skills. |
+| `custom-compaction` | Provider message compaction through a plugin message builder. |
+| `dataproc` | Google Cloud Dataproc cluster and job workflow skill. |
 | `env-blocker` | A hook that blocks reads of secret `.env` files. |
 | `gitignore-read-files-guard` | A hook that blocks file access to `.gitignore` ignored paths. |
 | `goal` | Completion nudges for active goals with a slash command and completion tool. |

--- a/plugins/dataproc/LICENSE.dataproc
+++ b/plugins/dataproc/LICENSE.dataproc
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/plugins/dataproc/README.md
+++ b/plugins/dataproc/README.md
@@ -1,0 +1,23 @@
+# dataproc
+
+Dataproc workflow guidance for Cline.
+
+## Cline Primitives
+
+This package plugin installs the `dataproc` skill. The skill helps Cline inspect Google Cloud Dataproc clusters and jobs, troubleshoot Spark and Hadoop workloads, and plan safe cluster or job lifecycle changes.
+
+The plugin also bundles a small read-oriented helper script for Dataproc Toolbox calls: `list_clusters`, `get_cluster`, `list_jobs`, and `get_job`. The script is only run when the user asks Cline to inspect Dataproc state.
+
+## Requirements
+
+- A Google Cloud project with the Dataproc API enabled.
+- Application Default Credentials available to the Cline process.
+- `DATAPROC_PROJECT` and `DATAPROC_REGION` set in the environment.
+- Dataproc Viewer permissions for read-only inspection.
+- Network access for `npx @toolbox-sdk/server@1.1.0` when using the bundled helper script.
+
+The plugin does not register an MCP server, store credentials, or run Google Cloud commands during installation. Stronger permissions such as Dataproc Editor are only needed if the user explicitly asks Cline to execute lifecycle changes. Those commands should be previewed and explicitly approved before Cline runs them.
+
+## Attribution
+
+This plugin includes Dataproc helper script behavior derived from `gemini-cli-extensions/dataproc`, licensed under Apache-2.0. See `LICENSE.dataproc`.

--- a/plugins/dataproc/index.ts
+++ b/plugins/dataproc/index.ts
@@ -1,0 +1,10 @@
+import type { AgentPlugin } from "@cline/sdk"
+
+const plugin: AgentPlugin = {
+	name: "dataproc",
+	manifest: {
+		capabilities: ["skills"],
+	},
+}
+
+export default plugin

--- a/plugins/dataproc/package.json
+++ b/plugins/dataproc/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "dataproc",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Cline plugin that bundles a Google Cloud Dataproc workflow skill.",
+  "cline": {
+    "plugins": [
+      {
+        "paths": [
+          "./index.ts"
+        ],
+        "capabilities": [
+          "skills"
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/dataproc/skills/dataproc/SKILL.md
+++ b/plugins/dataproc/skills/dataproc/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: dataproc
+description: Use when the user asks Cline to inspect, troubleshoot, or plan changes for Google Cloud Dataproc clusters and jobs, including Spark or Hadoop workload status, cluster health, job failures, and safe Dataproc lifecycle planning.
+---
+
+# Dataproc
+
+Use this skill for Google Cloud Dataproc cluster and job workflows. Favor read-only inspection first, state assumptions clearly, and ask before running commands that create, update, delete, submit, cancel, or otherwise mutate cloud resources.
+
+## Requirements
+
+- Google Cloud Application Default Credentials must be available to the Cline process.
+- `DATAPROC_PROJECT` must identify the Google Cloud project.
+- `DATAPROC_REGION` must identify the Dataproc region.
+- The Dataproc API must be enabled.
+- Read-only inspection requires Dataproc Viewer or equivalent permissions. Lifecycle operations require stronger project permissions such as Dataproc Editor, but only when the user explicitly asks Cline to execute those changes.
+
+Never ask the user to paste credentials or tokens into chat. If authentication is missing, ask them to configure ADC or environment variables outside the conversation and rerun the task.
+
+## Helper Script
+
+This skill includes one helper script for read-oriented Dataproc Toolbox calls:
+
+```bash
+node <skill-dir>/scripts/dataproc-tool.cjs <tool-name> '<json-params>'
+```
+
+Available tool names:
+
+- `list_clusters`
+- `get_cluster`
+- `list_jobs`
+- `get_job`
+
+Examples:
+
+```bash
+node <skill-dir>/scripts/dataproc-tool.cjs list_clusters '{"pageSize":20}'
+node <skill-dir>/scripts/dataproc-tool.cjs list_jobs '{"filter":"status.state = ERROR","pageSize":20}'
+node <skill-dir>/scripts/dataproc-tool.cjs get_cluster '{"clusterName":"example-cluster"}'
+node <skill-dir>/scripts/dataproc-tool.cjs get_job '{"jobId":"example-job"}'
+```
+
+Resolve `<skill-dir>` to this skill directory before running the script. The script validates `DATAPROC_PROJECT` and `DATAPROC_REGION`, passes the current environment through to the Dataproc Toolbox command, and invokes `npx --yes @toolbox-sdk/server@1.1.0 --prebuilt dataproc`, so it may need network access the first time it runs.
+
+## Workflow
+
+1. Identify the target project, region, cluster, and job from the user's request. If project or region is missing and cannot be read from `DATAPROC_PROJECT` / `DATAPROC_REGION`, ask for it.
+2. Classify the request as read-only inspection, troubleshooting, planning, or mutation.
+3. For read-only inspection, use the helper script when it answers the question directly. Keep result sizes bounded with filters and page sizes.
+4. For troubleshooting, gather the smallest useful context first: cluster state, job state, driver output location, relevant labels, job type, and recent error messages.
+5. For lifecycle operations, produce the exact `gcloud dataproc ...` command or config change first, explain the impact, and wait for explicit approval before executing.
+6. Report findings with concrete resource names, project, region, state, and next action. Call out uncertainty when the available data does not prove the cause.
+
+## Safety Rules
+
+- Do not create, update, delete, stop, start, submit, cancel, or drain Dataproc resources without explicit user approval in the current conversation.
+- Prefer filters over broad unbounded list calls.
+- Do not print access tokens, credential file contents, or secret environment variables.
+- Treat production clusters as sensitive. If the target environment is unclear, ask before running a mutating command.
+- When using `gcloud`, include `--project` and `--region` explicitly whenever possible.
+
+## Common Tasks
+
+List clusters:
+
+```bash
+node <skill-dir>/scripts/dataproc-tool.cjs list_clusters '{"pageSize":20}'
+```
+
+Find failed jobs:
+
+```bash
+node <skill-dir>/scripts/dataproc-tool.cjs list_jobs '{"filter":"status.state = ERROR","pageSize":20}'
+```
+
+Inspect one cluster:
+
+```bash
+node <skill-dir>/scripts/dataproc-tool.cjs get_cluster '{"clusterName":"CLUSTER_NAME"}'
+```
+
+Inspect one job:
+
+```bash
+node <skill-dir>/scripts/dataproc-tool.cjs get_job '{"jobId":"JOB_ID"}'
+```
+
+Plan a job submission:
+
+```bash
+gcloud dataproc jobs submit pyspark JOB_FILE \
+  --project "$DATAPROC_PROJECT" \
+  --region "$DATAPROC_REGION" \
+  --cluster CLUSTER_NAME
+```
+
+Show this command to the user with the concrete values and wait for approval before running it.

--- a/plugins/dataproc/skills/dataproc/scripts/dataproc-tool.cjs
+++ b/plugins/dataproc/skills/dataproc/scripts/dataproc-tool.cjs
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+
+const { spawn } = require("node:child_process")
+const os = require("node:os")
+
+const tools = new Set(["list_clusters", "get_cluster", "list_jobs", "get_job"])
+
+function usage() {
+	console.error("Usage: node dataproc-tool.cjs <tool-name> '<json-params>'")
+	console.error("Tools: list_clusters, get_cluster, list_jobs, get_job")
+}
+
+const [toolName, params = "{}"] = process.argv.slice(2)
+
+if (!tools.has(toolName)) {
+	usage()
+	process.exit(2)
+}
+
+if (!process.env.DATAPROC_PROJECT || !process.env.DATAPROC_REGION) {
+	console.error("DATAPROC_PROJECT and DATAPROC_REGION must be set in the environment.")
+	process.exit(2)
+}
+
+try {
+	JSON.parse(params)
+} catch (error) {
+	console.error(`Invalid JSON params: ${error instanceof Error ? error.message : String(error)}`)
+	process.exit(2)
+}
+
+const command = os.platform() === "win32" ? "npx.cmd" : "npx"
+const args = [
+	"--yes",
+	"@toolbox-sdk/server@1.1.0",
+	"--log-level",
+	"error",
+	"--prebuilt",
+	"dataproc",
+	"invoke",
+	toolName,
+	"--user-agent-metadata",
+	"cline-plugin-dataproc",
+	params,
+]
+
+const child = spawn(command, args, {
+	shell: os.platform() === "win32",
+	stdio: "inherit",
+	env: process.env,
+})
+
+child.on("close", (code) => {
+	process.exit(code ?? 1)
+})
+
+child.on("error", (error) => {
+	console.error(`Error executing Dataproc Toolbox helper: ${error instanceof Error ? error.message : String(error)}`)
+	process.exit(1)
+})


### PR DESCRIPTION
## Dataproc

Adds a Google Cloud Dataproc plugin for cluster and job workflows. It helps Cline inspect Dataproc state, troubleshoot Spark and Hadoop workload issues, and plan safe cluster or job lifecycle changes.

## Cline Primitives

This is a package plugin with a bundled `dataproc` skill. The skill gives Cline a read-first workflow for identifying the target project, region, cluster, and job; gathering bounded Dataproc context; diagnosing cluster/job status; and previewing lifecycle commands before any mutating action.

The plugin also includes a small read-oriented helper script for Dataproc Toolbox calls: `list_clusters`, `get_cluster`, `list_jobs`, and `get_job`. The helper is only run when the user asks Cline to inspect Dataproc state.

## Requirements

Users need a Google Cloud project with the Dataproc API enabled, Application Default Credentials available to the Cline process, and `DATAPROC_PROJECT` / `DATAPROC_REGION` set in the environment. Read-only inspection expects Dataproc Viewer or equivalent permissions. Stronger permissions such as Dataproc Editor are only needed if the user explicitly asks Cline to execute lifecycle changes.

The plugin does not register an MCP server, store credentials, or run Google Cloud commands during installation. The helper invokes `npx @toolbox-sdk/server@1.1.0` when used, so it may need network access the first time it runs.
