### PR TITLE
feat: add exa plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Each plugin lives in `plugins/<slug>`. The directory name is the install keyword
 | `custom-compaction` | Provider message compaction through a plugin message builder. |
 | `clickhouse-data-analyst` | ClickHouse data analyst skill with supporting analysis and ClickHouse sub-skills. |
 | `env-blocker` | A hook that blocks reads of secret `.env` files. |
+| `exa` | Exa MCP search, advanced search, page extraction, and research workflow guidance. |
 | `gitignore-read-files-guard` | A hook that blocks file access to `.gitignore` ignored paths. |
 | `goal` | Completion nudges for active goals with a slash command and completion tool. |
 | `intercom-support-triage-slack` | Intercom conversation triage tools for support workflows. |

--- a/plugins/exa/LICENSE.exa-mcp-server
+++ b/plugins/exa/LICENSE.exa-mcp-server
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Exa Labs
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/plugins/exa/NOTICE.exa-mcp-server
+++ b/plugins/exa/NOTICE.exa-mcp-server
@@ -1,0 +1,9 @@
+This plugin includes adapted guidance from exa-mcp-server by Exa Labs,
+licensed under MIT.
+
+Source repository: https://github.com/exa-labs/exa-mcp-server
+Source plugin version: 3.3.9
+
+The Cline plugin registers Exa's remote MCP endpoint and bundles a compact
+Cline-native research skill. It does not vendor or start the local npm MCP
+server package.

--- a/plugins/exa/README.md
+++ b/plugins/exa/README.md
@@ -1,12 +1,12 @@
 # exa
 
-Adds Exa web search, advanced search, and page extraction to Cline through Exa's MCP server, plus a bundled research workflow skill.
+Adds Exa web search and page extraction to Cline through Exa's MCP server, plus a bundled research workflow skill.
 
 ## What It Does
 
-Registers an `exa` MCP server for web search, advanced web search, and fetching page content. Use it for current web research, source discovery, code and documentation lookup, competitive research, literature scans, company research, and targeted extraction from known URLs.
+Registers an `exa` MCP server for web search and fetching page content. Use it for current web research, source discovery, code and documentation lookup, competitive research, literature scans, company research, and targeted extraction from known URLs.
 
-The bundled `exa-research` skill helps Cline plan searches, avoid leaking private data in queries, filter sources, deduplicate results, and synthesize answers with clear source handling.
+The bundled `exa-research` skill helps Cline plan searches, avoid leaking private data in queries, filter sources, deduplicate results, and synthesize answers with clear source handling. A Cline rule reinforces the data-sharing boundary before private text, private URLs, customer data, or secrets are sent to Exa.
 
 ## Install
 
@@ -35,7 +35,7 @@ Research competitors to this company and return a table with product focus, targ
 ## Requirements
 
 - Exa account authentication for higher limits and authenticated features.
-- The MCP server may allow anonymous use with rate limits, but users should expect to authorize Exa or provide an Exa API key when the server requests it.
+- The MCP server may allow anonymous use with rate limits, but users should expect to authorize Exa through Cline's MCP auth flow if the server requests it.
 - Network access to Exa and the public web.
 
 ## Security Notes

--- a/plugins/exa/README.md
+++ b/plugins/exa/README.md
@@ -1,0 +1,47 @@
+# exa
+
+Adds Exa web search, advanced search, and page extraction to Cline through Exa's MCP server, plus a bundled research workflow skill.
+
+## What It Does
+
+Registers an `exa` MCP server for web search, advanced web search, and fetching page content. Use it for current web research, source discovery, code and documentation lookup, competitive research, literature scans, company research, and targeted extraction from known URLs.
+
+The bundled `exa-research` skill helps Cline plan searches, avoid leaking private data in queries, filter sources, deduplicate results, and synthesize answers with clear source handling.
+
+## Install
+
+```bash
+cline plugin install exa
+```
+
+For local development from this repository:
+
+```bash
+cline plugin install ./plugins/exa --cwd .
+```
+
+## Example Usage
+
+After installation, ask Cline:
+
+```text
+Use Exa to find current sources on TypeScript build tooling adoption, then summarize the most relevant findings.
+```
+
+```text
+Research competitors to this company and return a table with product focus, target users, funding status, and source URLs.
+```
+
+## Requirements
+
+- Exa account authentication for higher limits and authenticated features.
+- The MCP server may allow anonymous use with rate limits, but users should expect to authorize Exa or provide an Exa API key when the server requests it.
+- Network access to Exa and the public web.
+
+## Security Notes
+
+Search queries and fetched URLs are sent to Exa. Do not include private code, secrets, customer data, internal URLs, unreleased plans, or confidential text in queries unless the user explicitly accepts that data-sharing boundary.
+
+## Attribution
+
+The MCP endpoint and research patterns are adapted from Exa Labs' `exa-mcp-server`, licensed under MIT. See `LICENSE.exa-mcp-server` and `NOTICE.exa-mcp-server`.

--- a/plugins/exa/index.ts
+++ b/plugins/exa/index.ts
@@ -3,15 +3,25 @@ import type { AgentPlugin } from "@cline/sdk"
 const plugin: AgentPlugin = {
 	name: "exa",
 	manifest: {
-		capabilities: ["mcp", "skills"],
+		capabilities: ["mcp", "rules", "skills"],
 	},
 	setup(api) {
 		api.registerMcpServer({
 			name: "exa",
 			transport: {
 				type: "streamableHttp",
-				url: "https://mcp.exa.ai/mcp?client=cline-plugin&tools=web_search_exa,web_search_advanced_exa,web_fetch_exa",
+				url: "https://mcp.exa.ai/mcp?client=cline-plugin&tools=web_search_exa,web_fetch_exa",
 			},
+		})
+
+		api.registerRule({
+			id: "exa:data-sharing-boundary",
+			source: "exa",
+			content: [
+				"When using Exa MCP tools, remember that search queries and fetched URLs are sent to Exa.",
+				"Do not send private source code, secrets, internal URLs, customer data, tokenized links, unreleased plans, or confidential text to Exa unless the user explicitly accepts that data-sharing boundary.",
+				"Prefer public-safe search terms when the user's request can be answered without exposing private details.",
+			].join("\n"),
 		})
 	},
 }

--- a/plugins/exa/index.ts
+++ b/plugins/exa/index.ts
@@ -3,7 +3,7 @@ import type { AgentPlugin } from "@cline/sdk"
 const plugin: AgentPlugin = {
 	name: "exa",
 	manifest: {
-		capabilities: ["mcp", "rules", "skills"],
+		capabilities: ["mcp", "skills"],
 	},
 	setup(api) {
 		api.registerMcpServer({
@@ -12,16 +12,6 @@ const plugin: AgentPlugin = {
 				type: "streamableHttp",
 				url: "https://mcp.exa.ai/mcp?client=cline-plugin&tools=web_search_exa,web_fetch_exa",
 			},
-		})
-
-		api.registerRule({
-			id: "exa:data-sharing-boundary",
-			source: "exa",
-			content: [
-				"When using Exa MCP tools, remember that search queries and fetched URLs are sent to Exa.",
-				"Do not send private source code, secrets, internal URLs, customer data, tokenized links, unreleased plans, or confidential text to Exa unless the user explicitly accepts that data-sharing boundary.",
-				"Prefer public-safe search terms when the user's request can be answered without exposing private details.",
-			].join("\n"),
 		})
 	},
 }

--- a/plugins/exa/index.ts
+++ b/plugins/exa/index.ts
@@ -1,0 +1,19 @@
+import type { AgentPlugin } from "@cline/sdk"
+
+const plugin: AgentPlugin = {
+	name: "exa",
+	manifest: {
+		capabilities: ["mcp", "skills"],
+	},
+	setup(api) {
+		api.registerMcpServer({
+			name: "exa",
+			transport: {
+				type: "streamableHttp",
+				url: "https://mcp.exa.ai/mcp?client=cline-plugin&tools=web_search_exa,web_search_advanced_exa,web_fetch_exa",
+			},
+		})
+	},
+}
+
+export default plugin

--- a/plugins/exa/package.json
+++ b/plugins/exa/package.json
@@ -12,6 +12,7 @@
         ],
         "capabilities": [
           "mcp",
+          "rules",
           "skills"
         ]
       }

--- a/plugins/exa/package.json
+++ b/plugins/exa/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "exa",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Cline plugin that registers the Exa MCP server and bundles an Exa research skill.",
+  "cline": {
+    "plugins": [
+      {
+        "paths": [
+          "./index.ts"
+        ],
+        "capabilities": [
+          "mcp",
+          "skills"
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/exa/package.json
+++ b/plugins/exa/package.json
@@ -12,7 +12,6 @@
         ],
         "capabilities": [
           "mcp",
-          "rules",
           "skills"
         ]
       }

--- a/plugins/exa/skills/exa-research/SKILL.md
+++ b/plugins/exa/skills/exa-research/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: exa-research
+description: Use Exa MCP search and fetch tools for current web research, source discovery, competitive research, literature scans, company research, code or docs lookup, and multi-source synthesis.
+---
+
+# Exa Research
+
+Use this skill when the user asks for current web research, source discovery, deep dives, competitive analysis, literature reviews, code or documentation lookup, company research, people discovery, or extraction from known URLs.
+
+## Privacy Gate
+
+Before searching or fetching a URL, decide whether the query, URL, or requested page contains private code, secrets, customer data, internal hostnames, tokenized links, unreleased business plans, or confidential text. If it does, ask the user before sending it to Exa. When possible, rewrite private details into public-safe search terms.
+
+Do not paste API keys, tokens, cookies, full private stack traces, proprietary source files, private URLs, or signed download links into search queries or fetch requests.
+
+## Auth and Rate Limits
+
+If Exa returns an auth or rate-limit error, surface that directly. Ask the user to authorize Exa through Cline's MCP auth flow or provide an Exa API key using the server's supported setup path. Do not silently fall back to generic search when the user explicitly asked for Exa.
+
+## Search Planning
+
+Classify the request before searching:
+
+- Simple lookup: one or two targeted searches, then fetch the best source if needed.
+- Current status or news: search with exact dates or date ranges derived from today's date.
+- Comparison or best-of: define evaluation criteria before searching.
+- Company or market research: search by company name, category terms, customer segment, funding, competitors, and product pages.
+- Literature or technical research: include official docs, papers, release notes, standards, and reputable engineering writeups.
+- Exhaustive or deep research: split into independent search angles and merge results carefully.
+
+For ambiguous depth, ask whether the user wants a quick pass or a deeper sweep.
+
+## Source Handling
+
+- Prefer primary sources: official docs, product pages, standards, papers, changelogs, filings, or direct company material.
+- Use reputable secondary sources for interpretation, market context, or independent confirmation.
+- Deduplicate by URL and entity.
+- Fetch pages when snippets are insufficient or when a claim needs verification.
+- Track dates for news, product changes, releases, and pricing.
+- Avoid relying on SEO copies of the same content.
+
+## Query Patterns
+
+Start specific, then broaden:
+
+- Exact entity plus task: `Acme product documentation API rate limits`.
+- Category plus constraint: `open source vector database hybrid search benchmark 2026`.
+- Source-targeted: `site:docs.example.com authentication redirect uri`.
+- Recent updates: include exact date ranges when the user asks for recent or latest information.
+- Alternatives: combine product names with `competitors`, `alternatives`, `versus`, `pricing`, or `case study`.
+
+If results are weak, change the angle instead of only swapping synonyms.
+
+## Answer Shape
+
+For research answers, include:
+
+- Direct answer or recommendation.
+- Key evidence with source URLs or cited source names.
+- Important caveats, freshness limits, and contradictions.
+- A short next-step list when more verification would materially improve confidence.
+
+For tables, define columns before searching and keep empty fields explicit rather than guessing.

--- a/plugins/exa/skills/exa-research/SKILL.md
+++ b/plugins/exa/skills/exa-research/SKILL.md
@@ -1,63 +1,211 @@
 ---
 name: exa-research
-description: Use Exa MCP search and fetch tools for current web research, source discovery, competitive research, literature scans, company research, code or docs lookup, and multi-source synthesis.
+description: "Deep research powered by Exa. Use for lead generation, literature reviews, deep dives, competitive analysis, or any query where one search falls short, including phrases like 'research this', 'find everything about', 'find me all', or 'deep dive on'."
 ---
 
-# Exa Research
+# Exa Research Orchestrator
 
-Use this skill when the user asks for current web research, source discovery, deep dives, competitive analysis, literature reviews, code or documentation lookup, company research, people discovery, or extraction from known URLs.
+You are the orchestrator. Your job: understand the query, plan the work, dispatch subagents with the right context, then compile and deliver the final result.
 
-## Privacy Gate
+## Prerequisites: Auth
 
-Before searching or fetching a URL, decide whether the query, URL, or requested page contains private code, secrets, customer data, internal hostnames, tokenized links, unreleased business plans, or confidential text. If it does, ask the user before sending it to Exa. When possible, rewrite private details into public-safe search terms.
+Server: `https://mcp.exa.ai/mcp`.
+
+1. OAuth (recommended) -- when Cline prompts for MCP auth, sign in to Exa through the browser flow.
+2. Anonymous -- works without setup but rate-limited.
+
+On auth / rate-limit errors, surface the fix. Ask the user to authorize Exa through Cline's MCP auth flow when available. Do not fall back to generic web search when the user explicitly asked for Exa.
+
+## Data-Sharing Boundary
+
+Search queries and fetched URLs are sent to Exa. Before searching or fetching, decide whether the query, URL, or requested page contains private source code, secrets, customer data, internal hostnames, tokenized links, unreleased business plans, or confidential text. If it does, ask the user before sending it to Exa. When possible, rewrite private details into public-safe search terms.
 
 Do not paste API keys, tokens, cookies, full private stack traces, proprietary source files, private URLs, or signed download links into search queries or fetch requests.
 
-## Auth and Rate Limits
+## Date Calculation (Do This First)
 
-If Exa returns an auth or rate-limit error, surface that directly. Ask the user to authorize Exa through Cline's MCP auth flow or provide an Exa API key using the server's supported setup path. Do not silently fall back to generic search when the user explicitly asked for Exa.
+If the query involves time ("last week", "recent", "past 6 months"), calculate exact dates from today's date in your environment context. Write out the calculation explicitly before doing anything else. Never eyeball dates or reuse dates from examples.
 
-## Search Planning
+## Step 1: Assess the Query
 
-Classify the request before searching:
+Read the user's query and determine two things:
 
-- Simple lookup: one or two targeted searches, then fetch the best source if needed.
-- Current status or news: search with exact dates or date ranges derived from today's date.
-- Comparison or best-of: define evaluation criteria before searching.
-- Company or market research: search by company name, category terms, customer segment, funding, competitors, and product pages.
-- Literature or technical research: include official docs, papers, release notes, standards, and reputable engineering writeups.
-- Exhaustive or deep research: split into independent search angles and merge results carefully.
+How complex is this?
+- Extremely Simple (e.g. reading the contents of 1-2 pages): Handle it yourself. Read `references/searching.md` for query-writing guidance, run the searches, review and filter results, then respond directly. No subagents needed.
+- Moderate (when a fast or low-effort search is requested): Delegate to 1 subagent to keep your context window clean.
+- Advanced (clear topic, clear filters, a few parallel searches): Light subagent use. One round of parallel subagents, then compile.
+- Complex (cross-referencing across entity types, multi-hop chains, exhaustive coverage, semantic filtering): Full multi-pass with parallel subagents.
 
-For ambiguous depth, ask whether the user wants a quick pass or a deeper sweep.
+Confirm when ambiguous:
+If the query could reasonably be handled as Extremely Simple/Moderate OR as Advanced/Complex and the choice would materially change time, breadth, or output size, pause and ask the user before proceeding. Otherwise default to a concise first pass and mention that you can go deeper. When asking, present:
+1. Your interpretation of the query
+2. The two (or more) plausible complexity levels
+3. What each level would look like in practice (e.g., "I can do a quick 1-2 search lookup, or I can fan out across 3-4 search workstreams to get deeper coverage")
+4. Let the user choose
 
-## Source Handling
+Examples of ambiguous queries:
+- "What are the best LLM fine-tuning frameworks?" -- could be a quick opinionated list (Moderate) or an exhaustive evaluated comparison (Complex)
+- "Find competitors to Acme Corp" -- could be a quick search for known competitors (Moderate) or a deep sweep across funding databases, press, and niche directories (Complex)
+- "What's the latest on WebGPU?" -- could be one news search (Extremely Simple) or a multi-angle survey of specs, browser support, community adoption, and benchmarks (Advanced)
 
-- Prefer primary sources: official docs, product pages, standards, papers, changelogs, filings, or direct company material.
-- Use reputable secondary sources for interpretation, market context, or independent confirmation.
-- Deduplicate by URL and entity.
-- Fetch pages when snippets are insufficient or when a claim needs verification.
-- Track dates for news, product changes, releases, and pricing.
-- Avoid relying on SEO copies of the same content.
+Do NOT ask for confirmation when:
+- The query is clearly extremely simple (fact lookups, single-entity questions)
+- The query is clearly complex (explicit multi-constraint, "find everything", "exhaustive", "comprehensive")
+- The user has already specified depth ("do a deep dive", "quick answer")
+- A reasonable concise first pass would answer the request without much extra cost
 
-## Query Patterns
+Note: if the user explicitly asks for something (e.g. "100" of something), continue to work until you've achieved it.
 
-Start specific, then broaden:
+What work needs to happen? Identify which of these apply (most queries use 3-5):
 
-- Exact entity plus task: `Acme product documentation API rate limits`.
-- Category plus constraint: `open source vector database hybrid search benchmark 2026`.
-- Source-targeted: `site:docs.example.com authentication redirect uri`.
-- Recent updates: include exact date ranges when the user asks for recent or latest information.
-- Alternatives: combine product names with `competitors`, `alternatives`, `versus`, `pricing`, or `case study`.
+1. Seed from user input: The user provided a list of entities to start from (company names, tickers, paper titles). Each seed becomes a parallel workstream.
+2. Define what qualifies: What makes a result a valid "row"? Translate the user's criteria into concrete checks.
+3. Define what to capture: What fields ("columns") does each result need? Build the schema before searching.
+4. Search broadly: Generate diverse queries and run them to find candidates. This is where subagents do the heavy lifting.
+5. Extract structured data: Pull specific fields from raw search results into the schema.
+6. Filter: Apply hard constraints (dates, geography, thresholds) and soft judgments (quality, relevance, semantic checks).
+7. Merge and deduplicate: Combine results from multiple subagents. Same URL = drop duplicate. Same entity from different sources = merge fields, keep best data.
+8. Score and rank: For "best of" (e.g. "what's the best ___?") queries, define the scoring criteria explicitly, then rank.
+9. Synthesize narrative: For research queries, organize findings by theme and write prose with citations.
 
-If results are weak, change the angle instead of only swapping synonyms.
+## Step 2: Dispatch Subagents
 
-## Answer Shape
+### What subagents do
 
-For research answers, include:
+Subagents run Exa searches and process the results. They keep raw search output out of your context window. Each subagent should:
+- Read the reference file(s) you point it to
+- Run the specific searches you assign
+- Return compact, structured output
 
-- Direct answer or recommendation.
-- Key evidence with source URLs or cited source names.
-- Important caveats, freshness limits, and contradictions.
-- A short next-step list when more verification would materially improve confidence.
+### How to dispatch
 
-For tables, define columns before searching and keep empty fields explicit rather than guessing.
+Use Cline's subagent/delegation tool if it is available. If no subagent tool is available in the current host, do the work directly in the main thread while keeping raw result summaries compact. Reference file paths are relative to the directory this file was loaded from.
+
+Tell each subagent:
+1. Which reference file(s) to read for instructions (always include the absolute path)
+2. What specific searches to run or what specific work to do
+3. What output format to return
+
+Template:
+```
+Read the file at [this skill's directory]/references/searching.md for instructions on how to query Exa effectively.
+
+Then do the following:
+[specific task description]
+[specific queries to run, if you are prescribing them]
+[validation criteria -- what makes a result qualify, so the subagent filters before returning]
+
+Return: [output format -- e.g. "compact JSON with name, url, snippet per result" or "markdown table with columns X, Y, Z"].
+
+End with EXACTLY: `sources_reviewed: N` where N = sum of `numResults` across every `web_search_exa` call (incl. retries). E.g. calls with numResults 10, 10, 5 -> `sources_reviewed: 25`.
+```
+
+Pass the `sources_reviewed` instruction line to every subagent verbatim -- don't paraphrase.
+### Which reference files to point subagents to
+
+Always point subagents to `references/searching.md`. It contains Exa query guidance and an index of domain-specific pattern files that the subagent will select from based on its task.
+
+Point to whichever of these also apply:
+
+| File | Point a subagent here when... |
+|---|---|
+| `references/extraction.md` | The subagent needs to extract specific data points into a schema you defined |
+| `references/filtering.md` | The subagent needs to evaluate results against criteria (especially semantic/soft filters) |
+| `references/synthesis.md` | The subagent is producing a prose synthesis rather than structured data |
+| `references/source-quality.md` | The subagent needs to assess source credibility, especially for "best of", ranking, or expert-finding queries |
+
+### How to split work across subagents
+
+If running parallel subagents, decompose the primary task/question into sub-questions to cover different search territories.
+
+For example, "best open-source LLM fine-tuning frameworks for production use" can be decomposed into multiple parallel sub-questions:
+1. "What open-source LLM fine-tuning frameworks do production engineers recommend, and what do they say about using them in real deployments?"
+2. "What open-source LLM fine-tuning tools have launched or gained traction in the last 6 months that aren't yet widely known?"
+3. "What are the most common complaints, failure modes, and reasons teams migrated away from specific open-source LLM fine-tuning frameworks in production?"
+
+Depending on your "How complex is this?" analysis: Some need 2-3; some need many. Some need several different angles, creative thought patterns, adversarial perspectives. It depends on what the user is asking for and how deep they want you to go.
+
+Give the sub-question directly to the subagent in its prompt.
+
+### Subagent sizing
+
+- Aim for 3-5 searches per subagent
+- Parallelize aggressively -- independent workstreams should be separate subagents launched in a single message
+- Do not use `run_in_background` -- dispatch all subagents in one message and wait for their results
+- For per-seed work (enriching a list of 20 companies), batch 3-5 seeds per subagent
+
+### Token isolation
+
+Never run bulk searches in your main context. The whole point of subagents is to keep raw search output out of your context window. Subagents process results and return only distilled output.
+
+### When things go wrong
+
+- Subagent returns empty: Rephrase queries with different angles, not synonyms. If still empty, the topic may have limited web coverage -- report that.
+- Subagent returns off-topic results: Queries were too vague. Retry with longer, more specific queries.
+
+## Step 3: Compile Results
+
+After subagents return:
+
+Deduplicate:
+1. Collect all results into a single list
+2. Remove exact URL duplicates
+3. Same entity from different sources: merge fields, keep the most complete/recent data
+4. Track: "Deduplicated X results down to Y unique entries"
+
+Validate coverage:
+- Are there obvious gaps? (missing time periods, missing geographic regions, missing entity types)
+- For each gap found, run targeted follow-up searches (via subagent if multiple queries are needed, direct if extremely simple)
+- For "find everything" queries, check if results from different subagents overlap heavily (good sign) or are completely disjoint (may indicate missed angles)
+
+Format the output:
+
+If you used subagents, open with: "I used Exa to review {X} sources across {Y} subagents. Here's what was found:" (X = sum of `sources_reviewed` across all subagents and passes plus any direct searches you ran; Y = total subagents dispatched. Pluralize naturally.)
+
+Then: Format output compactly enough to scan in the Cline UI. Include hyperlinked text where relevant. Below it, you may also include things (in a short, easy-to-read format) that:
+- ("Result") directly answer the original user request (in few words; make every word count)
+- ("Process") include anything worth noting about your process and what you consider to be high-signal in this domain vs. what you filtered out.
+- ("Patterns") any patterns identified that are non-obvious, require n-th order thinking, and are not included or alluded to in the rest of the output but might be interesting to the user.
+- ("Notes") mention only notable findings from this research task that are not included elsewhere.
+
+If the user asked for a durable artifact, or if the full output would be too long for a readable chat response, offer to write the full result in the most useful file format (`.csv` or `.md`) under `./exa-results/<topic>-<YYYY-MM-DD>`.
+
+General output rules:
+- No emojis unless the user requested them
+- Include in-line 1-word or multi-word hyperlinks throughout outputs where hyperlinking is a value-add.
+- Prefer tables over lists (fall back to lists only when fields are non-uniform or values are too long to fit cleanly)
+
+## Multi-Pass Queries
+
+Some queries require multiple sequential passes where later passes depend on earlier results. Common patterns:
+
+Entity chaining (multi-hop): Pass 1 finds entities (companies), Pass 2 finds related entities per result (people at those companies), Pass 3 enriches those (their public statements). Each pass is a round of parallel subagents.
+
+Exploratory then targeted: Pass 1 scouts the landscape broadly, Pass 2 searches deeply in the most promising directions found in Pass 1.
+
+Criteria discovery: When "best" isn't predefined, Pass 1 surveys what practitioners actually value, Pass 2 searches for candidates matching those criteria.
+
+Between passes, compile and deduplicate before dispatching the next round.
+
+## Evaluating Source Quality
+
+Source quality matters most for "best of", ranking, expert-finding, and best-practices queries, but is useful context for almost any research task.
+
+At the subagent level: Point subagents to `references/source-quality.md` so they tag source quality in their output. This lets you weight results during compilation.
+
+At the orchestrator level, when compiling subagent results:
+
+1. Convergence across high-signal sources: Convergence alone isn't meaningful (3 low-quality sources agreeing is just shared noise). What matters is when multiple independent, high-signal sources (practitioners, people with skin in the game) converge on the same finding.
+2. Practitioner vs commentator: Weight practitioners (people doing the work) higher than commentators (people writing about the work).
+3. Via negativa: Before synthesizing, define who to exclude (sources with misaligned incentives, no skin in the game, or unfalsifiable claims). Filtering out noise is more valuable than seeking brilliance.
+4. Red-team your compiled results: What perspectives are missing? What biases might be distorting the aggregate? If a gap emerges, run a targeted follow-up.
+5. Ideas over entities: For expert-finding and best-practices queries, the primary output is convergent truths, not a ranked list of names. Lead with what the best sources agree on, then cite who said it.
+
+## Gotchas
+
+- Over-execution on simple queries: If the user asks "what year was X founded", don't spin up subagents. One search, one answer.
+- Under-execution on hard queries: If the query has 4+ constraints, temporal joins, or semantic filtering, a single search will not cut it. Fan out.
+- Synonym queries: Running "overrated AI tools" and "overhyped AI tools" as separate subagent queries wastes tokens. These hit the same embedding region. Diversify by angle instead.
+- Forgetting to deduplicate: Multiple subagents will return overlapping results. Always deduplicate before synthesis.
+- Treating Exa results as validated: Exa returns similarity, not yet validated. A result appearing in search output does not mean it meets the user's criteria. You must validate.
+- Date drift: Always calculate dates from the current environment date. Never reuse dates from these instructions or from previous queries.

--- a/plugins/exa/skills/exa-research/references/extraction.md
+++ b/plugins/exa/skills/exa-research/references/extraction.md
@@ -1,0 +1,63 @@
+# Extracting Structured Data from Search Results
+
+After running searches, you need to extract structured information from the results. This file covers how to do that well.
+
+## When You Have Enough from Snippets
+
+Exa search results include titles, URLs, and text snippets ("highlights"). For many fields (company name, person name, funding round, publication date), the snippet is sufficient. Extract directly from what you have before fetching full pages.
+
+## When to Deep-Read with web_fetch_exa
+
+Fetch the full page when:
+- The snippet mentions what you need but doesn't include the actual value
+- You need to read body text to make a judgment call (e.g. "does this blog post show genuine design opinion or is it generic?")
+- You need to extract multiple fields from a single rich source (case study page, team page, filing)
+- The task requires reading beyond the first few sentences
+
+```
+web_fetch_exa {
+  "urls": ["https://source-1.com", "https://source-2.com"],
+}
+```
+
+Batch up to 5-10 URLs per fetch call to minimize round trips. Avoid using `maxCharacters` param or `head`/`tail` bash tools; the point is to understand full page context.
+
+## Extracting into a Schema
+
+When you've been given a schema (the "columns" for the result), extract each field per result:
+
+1. Structured fields (name, date, URL, funding amount, ticker): Extract the literal value. If not present, mark as missing rather than guessing.
+
+2. Categorical fields (industry, stage, role level): Map to the closest category. Note uncertainty if the mapping is ambiguous.
+
+3. Semantic fields (sentiment, whether something qualifies as "genuine opinion", relevance to a theme): Read the content and make a judgment call. Include a brief rationale so downstream synthesis can weigh your assessment.
+
+4. Negation fields ("no review mentions X", "no Series A announcement"): These require checking that something is absent. Search for the positive case; if nothing surfaces, report absence with confidence level based on how thorough your coverage was.
+
+## Handling Missing Data
+
+- Mark fields as "not found" rather than guessing or leaving blank
+- Distinguish "confirmed absent" (searched thoroughly, not there) from "not found" (didn't have access or coverage was limited)
+- If a source is paywalled or inaccessible, note that explicitly
+
+## Confidence Signals
+
+When extracting, note the strength of the evidence:
+- Direct: The source explicitly states the value (e.g. "We raised $20M in Series B")
+- Inferred: The value is derived from context (e.g. headcount estimated from team page photos)
+- Uncertain: Single indirect signal, could be wrong
+
+## Output Format
+
+Return extracted data as compact structured output. For lists of entities:
+
+```
+[
+  { "name": "...", "field_1": "...", "field_2": "...", "source": "url", "confidence": "direct" },
+  ...
+]
+```
+
+Or as a markdown table if that better suits your task's instructions.
+
+Keep output compact. Your results will be merged with results from other searches, so verbosity at this stage compounds.

--- a/plugins/exa/skills/exa-research/references/filtering.md
+++ b/plugins/exa/skills/exa-research/references/filtering.md
@@ -1,0 +1,48 @@
+# Filtering Results
+
+After extracting data from search results, you may need to filter rows based on criteria from the original query. This file covers how to apply filters effectively.
+
+## Hard Filters
+
+Hard filters have clear, binary criteria: a date range, a geographic constraint, a numeric threshold, a category membership.
+
+Apply these mechanically:
+- Check each row against the criterion
+- Remove rows that fail
+- No judgment call needed
+
+Examples: "published in 2025", "based in SF or NYC", "under $500B market cap", "excluding Novo Nordisk"
+
+Negation filters ("excluding X", "not sponsored by Y") are hard filters applied in reverse. Check for the presence of the excluded value and remove matches.
+
+## Soft Filters
+
+Soft filters require judgment: "genuine design opinion" vs "generic blog post", "actually shipping" vs "just evaluating", "high-signal" vs "noise".
+
+For these:
+1. Read the relevant content (use `web_fetch_exa` if snippets are insufficient)
+2. Make a judgment call based on the content
+3. Include a brief rationale for each keep/drop decision so your reasoning is visible
+
+Semantic negation is a type of soft filter: "no review mentions smell, noise, or pest complaints" requires reading review content and detecting whether these topics appear, even if phrased differently.
+
+## Filter Order
+
+Apply filters in this order to minimize wasted work:
+1. Hard filters first -- cheap, mechanical, eliminates rows before you spend tokens on judgment
+2. Soft filters second -- only on rows that passed hard filters
+
+## Temporal Filters
+
+Queries often involve time: "in the last 6 months", "began enrolling in 2025", "recent".
+
+- Calculate exact date boundaries from the current date before filtering
+- Check publication/event dates against the boundary
+- If a date is ambiguous (e.g. "early 2025"), note the uncertainty rather than silently including or excluding
+
+## Completeness vs Precision
+
+The original query determines the balance:
+- "Find every..." or "exhaustive" -- err on the side of including borderline cases, flag them as uncertain
+- "Find the best..." or "top N" -- err on the side of precision, drop borderline cases
+- Default: include borderline cases with a flag, let downstream processing decide

--- a/plugins/exa/skills/exa-research/references/patterns-code.md
+++ b/plugins/exa/skills/exa-research/references/patterns-code.md
@@ -1,0 +1,16 @@
+# Query Patterns: Code and Documentation
+
+Always include programming language and framework/library in your query.
+
+```
+// API usage
+web_search_exa { "query": "Stripe API create subscription Node.js code example", "numResults": 5 }
+
+// Error resolution
+web_search_exa { "query": "React hydration mismatch server client explanation fix", "numResults": 10 }
+
+// GitHub implementations
+web_search_exa { "query": "GitHub repository [library] example project open source", "numResults": 10 }
+```
+
+Use `web_fetch_exa` to read official docs when you know the URL.

--- a/plugins/exa/skills/exa-research/references/patterns-companies.md
+++ b/plugins/exa/skills/exa-research/references/patterns-companies.md
@@ -1,0 +1,27 @@
+# Query Patterns: Companies
+
+Use `category:company` for structured company data (funding, headcount, description).
+
+```
+// By category
+web_search_exa { "query": "category:company AI infrastructure startups San Francisco", "numResults": 10 }
+
+// By stage
+web_search_exa { "query": "category:company Series B fintech payments", "numResults": 10 }
+
+// Similar to known company
+web_search_exa { "query": "category:company companies like Stripe", "numResults": 8 }
+```
+
+For competitive intelligence, layer multiple angles:
+```
+web_search_exa { "query": "category:company companies like [target]", "numResults": 10 }
+web_search_exa { "query": "category:company [category] software tools", "numResults": 15 }
+web_search_exa { "query": "[category] startup launch funding announcement recently", "numResults": 15 }
+```
+
+For funding/investors:
+```
+web_search_exa { "query": "[company] funding round raised investors", "numResults": 5 }
+web_search_exa { "query": "category:company [company]", "numResults": 5 }
+```

--- a/plugins/exa/skills/exa-research/references/patterns-news.md
+++ b/plugins/exa/skills/exa-research/references/patterns-news.md
@@ -1,0 +1,12 @@
+# Query Patterns: News and Recent Events
+
+```
+web_search_exa { "query": "category:news [topic] announcement", "numResults": 15 }
+web_search_exa { "query": "[topic] news update latest development [month year]", "numResults": 15 }
+```
+
+For reactions/sentiment on recent events, search across platforms:
+```
+web_search_exa { "query": "[event] reaction analysis commentary", "numResults": 12 }
+web_search_exa { "query": "[event] criticism concerns issues bugs", "numResults": 15 }
+```

--- a/plugins/exa/skills/exa-research/references/patterns-papers.md
+++ b/plugins/exa/skills/exa-research/references/patterns-papers.md
@@ -1,0 +1,19 @@
+# Query Patterns: Research Papers
+
+Use `category:research paper` for Exa's paper index.
+
+```
+// By topic
+web_search_exa { "query": "category:research paper sparse attention mechanisms for long context transformers", "numResults": 12 }
+
+// Survey/review papers
+web_search_exa { "query": "category:research paper [topic] comprehensive survey review", "numResults": 10 }
+
+// By author
+web_search_exa { "query": "category:research paper [author name] [topic]", "numResults": 5 }
+
+// By recency (encode time in query)
+web_search_exa { "query": "category:research paper large language model advances 2025 2026", "numResults": 15 }
+```
+
+To find seminal papers: search for survey papers first, then deep-read them to extract foundational references.

--- a/plugins/exa/skills/exa-research/references/patterns-people.md
+++ b/plugins/exa/skills/exa-research/references/patterns-people.md
@@ -1,0 +1,30 @@
+# Query Patterns: People
+
+Use `category:people` for LinkedIn-weighted results. For discovery queries, be specific -- vague queries like `"category:people researcher founder CEO startup"` will match many irrelevant LinkedIn profiles. Include specific companies, timeframes, or roles to narrow results.
+
+```
+// By company + role
+web_search_exa { "query": "category:people engineer at OpenAI", "numResults": 10 }
+web_search_exa { "query": "category:people VP director at Cursor", "numResults": 10 }
+
+// By role + location
+web_search_exa { "query": "category:people Head of Growth B2B SaaS startup San Francisco", "numResults": 12 }
+
+// Specific person
+web_search_exa { "query": "category:people Jane Smith Anthropic machine learning", "numResults": 5 }
+```
+
+For comprehensive company coverage, search by department and seniority in parallel:
+```
+web_search_exa { "query": "category:people engineering at Acme", "numResults": 10 }
+web_search_exa { "query": "category:people product design at Acme", "numResults": 10 }
+web_search_exa { "query": "category:people sales marketing at Acme", "numResults": 10 }
+```
+
+Supplement with non-LinkedIn sources:
+```
+web_search_exa { "query": "Acme team page employees about us", "numResults": 5 }
+web_search_exa { "query": "joined Acme recently hired new role announcement", "numResults": 5 }
+```
+
+Deduplicate by LinkedIn URL (canonical) or name + current company (fallback).

--- a/plugins/exa/skills/exa-research/references/patterns-relationships.md
+++ b/plugins/exa/skills/exa-research/references/patterns-relationships.md
@@ -1,0 +1,29 @@
+# Query Patterns: Hidden Relationships
+
+Finding connections that aren't explicitly listed anywhere. Direct queries ("X clients") return articles about them, not actual connections. Use indirect signals instead.
+
+Start with the subject's own platforms:
+```
+web_search_exa { "query": "[subject] official website blog podcast", "numResults": 5 }
+web_search_exa { "query": "[subject] conversation interview testimonial guest", "numResults": 8 }
+web_fetch_exa { "urls": ["https://subject-website.com/blog", "https://subject-website.com/about"] }
+```
+
+For B2B (company -> customers):
+```
+web_search_exa { "query": "[company] case study customer success story", "numResults": 5 }
+web_fetch_exa { "urls": ["https://company.com/customers", "https://company.com/case-studies"] }
+```
+
+Indirect signal searches:
+```
+// Testimonials
+web_search_exa { "query": "personal blog [subject] changed my life testimonial", "numResults": 15 }
+
+// Duration markers (high confidence -- people don't fabricate decades)
+web_search_exa { "query": "[subject] years decades longtime worked with known since", "numResults": 10 }
+
+// Terminology detection: find insider terms, then search for people using them
+web_search_exa { "query": "[subject] method terminology concepts framework", "numResults": 5 }
+web_search_exa { "query": "[unique term 1] [unique term 2] personal story", "numResults": 10 }
+```

--- a/plugins/exa/skills/exa-research/references/searching.md
+++ b/plugins/exa/skills/exa-research/references/searching.md
@@ -1,0 +1,92 @@
+# Searching with Exa
+
+You have two tools:
+- `web_search_exa` -- search by query. Supports `query` and `numResults` params. Use `category:<type>` inline in the query string for category filtering.
+- `web_fetch_exa` -- read full content from known URLs. Use after search when snippets are insufficient.
+
+Do NOT use `web_search_advanced_exa` or any other Exa tools. Only use these two Exa tools. Do not shell out or write files just to process Exa result dumps; filter and summarize results inline.
+
+## How Exa Search Works
+
+Exa uses vector embeddings, not keywords. It finds pages semantically similar to your query. It does not match keywords exactly, directly understand boolean logic (AND/OR/NOT), or validate that results meet your criteria. You are describing a target page, and Exa returns the nearest neighbors in embedding space.
+
+## Writing Good Queries
+
+Describe the page you want to find, not the fact you want to know.
+
+| Looking for | Bad query | Good query |
+|---|---|---|
+| Blog posts about X | "X" | "detailed blog post about X written by a practitioner" |
+| Company doing Y | "Y company" | "category:company startup building Y for enterprise" |
+| Person at company | "person at company" | "category:people senior engineer at Acme" |
+
+Write queries as natural grammatical phrases.
+
+`numResults` sizing -- match to query precision:
+
+| Query precision | numResults | Example |
+|---|---|---|
+| Named entity (specific person/company) | 5 | `"WaveForms AI founding story funding details"` |
+| Precise filter (narrow category + constraints) | 10 | `"category:company developer tools API testing Series A"` |
+| Broad discovery (wide category, few constraints) | 15 | `"category:news engineer launches startup 2025 2026"` |
+
+Never use numResults above 25. If you need more coverage, run more queries with different angles at n=10-15 rather than one query at n=50.
+
+Use category filters when searching for a specific entity type. Available inline categories: `company`, `research paper`, `news`, `personal site`, `people`. Add `category:<type>` at the start of your query string.
+
+```
+web_search_exa { "query": "category:research paper sparse attention mechanisms for long context", "numResults": 10 }
+web_search_exa { "query": "category:people VP Engineering AI infrastructure San Francisco", "numResults": 10 }
+web_search_exa { "query": "category:company developer tools for API testing", "numResults": 10 }
+```
+
+## Query Diversity
+
+When you need to run multiple queries on the same topic, make sure they target genuinely different angles, not just synonym swaps. "overhyped" vs "overrated" vs "disappointment" are the same angle. A skeptic angle vs a builder angle vs a practitioner angle are genuinely different.
+
+Word order affects embeddings. "Python async patterns for web scraping" and "web scraping async patterns in Python" can sometimes return different results. Use this to your advantage when you need coverage -- run 2-3 phrasings in parallel.
+
+## Encoding Time
+
+If your task involves time ("last week", "recent", "this month"), calculate exact dates FIRST from the current date in your environment context. Then encode dates semantically in the query: "published in March 2026" rather than using date filters. Never eyeball dates.
+
+## Anti-Patterns
+
+- Boolean operators ("AND", "NOT") are just words to Exa, not operators
+- Quotes don't force exact phrase matching
+- Very short queries (1-2 words) produce scattered, low-quality results
+- Don't use dates from examples -- always calculate from the current date
+
+## When Searches Return Nothing
+
+If a query returns 0 or only irrelevant results:
+a. Make the query longer and more specific
+b. Try a different angle, not a synonym swap
+c. If multiple angles return nothing, the topic likely has limited web coverage -- report that rather than fabricating results
+
+## Domain-Specific Patterns
+
+If your task involves any of these domains, read the relevant pattern file(s) for specialized query strategies. Pick whichever files match your task -- most tasks use 1-2.
+
+| File (same directory as this file) | Domain |
+|---|---|
+| `patterns-people.md` | People by role, company, location |
+| `patterns-companies.md` | Companies by category, stage, competitors, funding |
+| `patterns-papers.md` | Academic/research papers |
+| `patterns-relationships.md` | Hidden connections (clients, collaborators) |
+| `patterns-code.md` | Code, APIs, docs, errors |
+| `patterns-news.md` | News, recent events, reactions |
+
+## When `web_fetch_exa` Fails
+
+Fall back to fetching with any other fetch tool you have access to. If that also fails, skip it and work with remaining sources.
+
+## After Getting Results
+
+Exa returns similarity, not validation. You must review titles/snippets and discard irrelevant results using your judgment. Don't assume all results match your criteria. For the most promising results, use `web_fetch_exa` to read the full content.
+
+```
+web_fetch_exa {
+  "urls": ["https://promising-url-1.com", "https://promising-url-2.com"],
+}
+```

--- a/plugins/exa/skills/exa-research/references/source-quality.md
+++ b/plugins/exa/skills/exa-research/references/source-quality.md
@@ -1,0 +1,46 @@
+# Evaluating Source Quality
+
+When assessing sources during search and extraction, tag quality signals in your output so results can be weighted and ranked downstream.
+
+## Noise Signals -- Filter Out First
+
+Before deep-reading, check for these disqualifiers:
+
+| Signal | What to look for |
+|--------|-----------------|
+| No skin in the game | Theorists who don't do the work -- no portfolio, no shipped products, no verifiable results |
+| Misaligned incentives | Paid to sell, not to be right (sponsored content, vendor blogs, affiliate-heavy) |
+| Circular credentials | Validated only by peers in the same bubble -- no external evidence of impact |
+| Positive-only advice | No tradeoffs, no failure modes discussed -- "just do X" with no caveats |
+| Temporal decay | Shifted from doing to teaching/advising. Check: are they still actively building/practicing? |
+
+## Practitioner vs Commentator
+
+The most important distinction. Practitioners do the work; commentators write about the work.
+
+Practitioner signals: shipped products, open-source contributions, case studies with specific numbers, "we built X and here's what happened"
+
+Commentator signals: roundup posts, "top 10" lists, content primarily linking to others' work, no first-hand experience described
+
+Note this distinction in your quality tags.
+
+## Verification Searches
+
+When validating a source's credibility (for expert-finding and best-of queries):
+
+```
+// Who cites them?
+web_search_exa { "query": "[name] recommended by experts practitioners", "numResults": 5 }
+
+// Track record?
+web_search_exa { "query": "[name] results portfolio case study shipped", "numResults": 5 }
+
+// Criticism?
+web_search_exa { "query": "[name] criticism overrated wrong", "numResults": 5 }
+```
+
+Only run verification searches when the task specifically calls for evaluating source credibility. For standard search tasks, just tag what you observe from the content you already have.
+
+## Tagging in Output
+
+For each source, include a short free-form `quality` string describing what you observed -- e.g. "shipped the product, writes from direct experience" or "roundup blog, no original work shown, links to others." Don't classify into categories. Just describe what you see so the signal is preserved for downstream ranking.

--- a/plugins/exa/skills/exa-research/references/synthesis.md
+++ b/plugins/exa/skills/exa-research/references/synthesis.md
@@ -1,0 +1,55 @@
+# Synthesizing Research into Narrative
+
+When the task calls for a narrative answer (not a list or table), this file covers how to synthesize findings from multiple sources into a coherent, well-structured response.
+
+## When Synthesis Applies
+
+Synthesis is the right output format when:
+- The user is asking "what do people say about X" or "what's the current state of Y"
+- The answer requires integrating perspectives from multiple sources
+- The output should be prose with citations, not a table of entities
+
+## Structure
+
+### Lead with the answer
+
+Put the core finding or conclusion first. The user should get value from the first paragraph alone.
+
+### Organize by theme, not by source
+
+Bad: "Source A says X. Source B says Y. Source C says Z."
+Good: "Theme 1: [insight supported by A, B]. Theme 2: [insight supported by C, with counterpoint from A]."
+
+### Surface disagreement explicitly
+
+When credible sources disagree, don't collapse to consensus. Present both sides with their evidence:
+- "On [topic], [position A] (supported by [sources]) vs [position B] (supported by [sources]). [When each applies or why they diverge]."
+
+### Include confidence signals
+
+- How many independent sources support a claim?
+- How fresh is the evidence?
+- Are the sources practitioners or commentators?
+
+## Thematic Clustering
+
+When dealing with many reactions or perspectives (e.g. "what are people saying about X"):
+
+1. Read through all results
+2. Identify recurring themes (not just topics -- themes have a stance or direction)
+3. Group results by theme
+4. For each theme: state the theme, cite 2-3 representative sources, note the volume
+5. Flag outlier themes that appear only once but carry important signal
+
+## Citation Practice
+
+- Every factual claim gets a source URL
+- Prefer inline citations: "Engineers report 3x latency reduction ([source](url))"
+- For quotes, include the exact text and attribute it
+
+## Common Mistakes
+
+- Source-by-source summaries: Feels comprehensive but is unreadable and doesn't synthesize
+- Collapsing disagreement: Picking a winner instead of presenting the landscape
+- Missing recency: Treating 2023 sources as current for fast-moving topics
+- Over-synthesis: Producing a full essay when the user asked a narrow question


### PR DESCRIPTION
## Exa

Adds an Exa plugin for web research, source discovery, page extraction, and multi-source synthesis. It is intended for users who want Cline to use Exa for current web research, documentation and code lookup, competitive research, literature scans, company research, and targeted extraction from known URLs.

The plugin keeps the runtime shape lightweight. It registers Exa's remote MCP endpoint directly instead of vendoring or launching a local MCP server package, and it limits the exposed Exa tool surface to web search and page fetch so the agent has one clear research path.

## Cline Primitives

This package uses MCP and bundled skills.

The `exa` MCP server is registered with streamable HTTP and exposes `web_search_exa` plus `web_fetch_exa`. The registration intentionally avoids static auth headers so Cline can surface the MCP auth flow when Exa requests authentication.

The `exa-research` skill guides research planning, query writing, source filtering, extraction, deduplication, freshness checks, source-quality evaluation, and final synthesis. It includes reference docs for general Exa search behavior plus common patterns for code/docs, companies, news, papers, people, hidden relationships, extraction, filtering, source quality, and synthesis.

The bundled skills' `exa:data-sharing-boundary` guidance reminds Cline that search queries and fetched URLs are sent to Exa, and asks the agent to avoid sending private code, secrets, customer data, internal URLs, tokenized links, unreleased plans, or confidential text unless the user explicitly accepts that boundary.

## Requirements

Users need network access to Exa and the public web. Anonymous use may be rate-limited, so users should expect to authorize Exa through Cline's MCP auth flow if the server requests it.

Search queries and fetched URLs are sent to Exa. The bundled skills make that trust boundary explicit before private or confidential material is sent outside the local workspace.
