### PR TITLE
feat: add frontend design plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Each plugin lives in `plugins/<slug>`. The directory name is the install keyword
 | `custom-compaction` | Provider message compaction through a plugin message builder. |
 | `clickhouse-data-analyst` | ClickHouse data analyst skill with supporting analysis and ClickHouse sub-skills. |
 | `env-blocker` | A hook that blocks reads of secret `.env` files. |
+| `frontend-design` | Domain-aware frontend design guidance as a bundled Cline skill. |
 | `gitignore-read-files-guard` | A hook that blocks file access to `.gitignore` ignored paths. |
 | `goal` | Completion nudges for active goals with a slash command and completion tool. |
 | `intercom-support-triage-slack` | Intercom conversation triage tools for support workflows. |

--- a/plugins/frontend-design/README.md
+++ b/plugins/frontend-design/README.md
@@ -1,0 +1,45 @@
+# Frontend Design
+
+Frontend Design adds a Cline skill for building polished, domain-appropriate web interfaces. It helps Cline choose a clear visual direction, respect existing design systems, and verify that layouts work across practical desktop and mobile sizes.
+
+The skill is useful for web apps, dashboards, tools, landing pages, forms, component systems, and visual interaction states. It does not install dependencies, call external services, or run generated applications on its own.
+
+## What It Does
+
+This plugin bundles one skill:
+
+- `frontend-design`: Guides frontend implementation with product context, interaction ergonomics, visual hierarchy, responsive layout constraints, accessibility states, meaningful asset choices, and practical visual QA.
+
+## Install
+
+```bash
+cline plugin install frontend-design
+```
+
+For local development from this repository:
+
+```bash
+cline plugin install ./plugins/frontend-design --cwd .
+```
+
+## Example Usage
+
+```text
+Build a dense admin dashboard for triaging payment disputes.
+```
+
+```text
+Redesign this settings page so the account and billing flows are easier to scan.
+```
+
+```text
+Create a product landing page for a hardware developer kit.
+```
+
+## Requirements
+
+No API key, account, browser service, or local CLI is required. The skill applies to whatever frontend stack is already present in the workspace, and it should follow the project conventions before introducing new libraries or visual patterns.
+
+## Notes
+
+The plugin does not add browser automation, screenshot capture, asset generation, or a dev server. When those tools already exist in the project or host environment, the skill should use them for visual inspection; otherwise it should state what was verified by code review, build output, or static inspection.

--- a/plugins/frontend-design/index.ts
+++ b/plugins/frontend-design/index.ts
@@ -1,0 +1,10 @@
+import type { AgentPlugin } from "@cline/sdk"
+
+const plugin: AgentPlugin = {
+	name: "frontend-design",
+	manifest: {
+		capabilities: ["skills"],
+	},
+}
+
+export default plugin

--- a/plugins/frontend-design/package.json
+++ b/plugins/frontend-design/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "frontend-design",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Cline plugin that bundles a domain-aware frontend design skill.",
+  "cline": {
+    "plugins": [
+      {
+        "paths": [
+          "./index.ts"
+        ],
+        "capabilities": [
+          "skills"
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/frontend-design/skills/frontend-design/SKILL.md
+++ b/plugins/frontend-design/skills/frontend-design/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: frontend-design
+description: Design and implement polished, domain-appropriate frontend interfaces in Cline. Use when building or revising web apps, pages, dashboards, forms, components, design systems, or visual interaction states.
+---
+
+# Frontend Design
+
+Use this skill when the user asks to build, redesign, or polish a frontend interface.
+
+## Orientation
+
+Start by identifying the product type, audience, primary workflow, and existing visual system. Read nearby components, routes, styles, tokens, and screenshots before choosing a direction. The goal is not novelty for its own sake; it is an interface that fits the domain and feels intentionally designed.
+
+When the project already has a design system, stay inside it unless the user asks for a new direction. Reuse local components, icon libraries, spacing scales, color tokens, typography, and interaction patterns before adding new ones.
+
+## Product Fit
+
+Match the visual and interaction density to the product:
+
+- Operational tools, SaaS dashboards, CRMs, admin panels, and developer consoles should feel calm, scan-friendly, efficient, and repeatable. Favor clear tables, filters, navigation, compact panels, predictable controls, and restrained styling.
+- Brand, product, venue, portfolio, and campaign pages can use stronger art direction, richer imagery, expressive typography, and memorable first-viewport composition when that serves the offer.
+- Games, creative tools, and playful consumer surfaces can be more illustrative, animated, and tactile, but the core interaction still needs to be usable.
+- Settings, forms, onboarding, checkout, account, auth, and support flows should prioritize clarity, trust, completion speed, validation, and recovery from mistakes.
+
+## Implementation Bar
+
+Build the actual usable screen or component first. Avoid making a marketing shell when the user asked for an app, tool, workflow, or game.
+
+Use real controls for real jobs: icon buttons for familiar actions, toggles for binary settings, menus for option sets, sliders or inputs for numeric values, tabs for peer views, and clear command buttons for irreversible or high-intent actions. Include empty, loading, error, disabled, focused, hover, selected, and active states when they are part of the workflow.
+
+Keep layout stable. Use responsive constraints such as grid tracks, minmax values, fixed aspect ratios, container-relative sizing, and predictable toolbar dimensions so dynamic labels, icons, counters, cards, and board cells do not shift or overlap.
+
+Use meaningful visual assets for websites and games, and for other interfaces when assets carry product meaning. Prefer actual product, place, object, state, gameplay, or person imagery over vague atmospheric decoration. Do not add decorative orbs, bokeh blobs, or generic gradients as a substitute for useful visual content.
+
+## Visual Quality
+
+Choose a clear design direction and execute it consistently. Color, type, spacing, borders, shadows, and motion should support the workflow and subject matter.
+
+Avoid one-note palettes and default-looking composition. Use contrast, accent colors, hierarchy, and whitespace deliberately. Do not rely on the same purple, blue-slate, beige, or brown-orange theme across unrelated products.
+
+Typography should fit the context and remain readable. Use existing type choices when the app has them. If choosing new fonts or sizes, make sure labels fit their containers at mobile and desktop widths, long words wrap cleanly, and compact panels do not use hero-scale type.
+
+Motion should clarify cause and effect. Keep animation purposeful, short, and respectful of reduced-motion preferences. Avoid motion that delays repeated workflows or hides information.
+
+## Accessibility And Trust
+
+Preserve semantic HTML where possible. Keep keyboard navigation, focus states, color contrast, labels, hit targets, and screen-reader names in mind while implementing. Do not hide essential information inside hover-only affordances.
+
+For data, payments, admin, auth, deployment, destructive actions, or customer-content workflows, make state and consequences visible. Confirmation, undo, preview, and audit-friendly copy matter more than decoration.
+
+## Verification
+
+Before calling the work finished, inspect the result in realistic desktop and mobile viewports when the stack supports it. Use screenshots or browser previews when available. Fix overlapping text, clipped buttons, unstable controls, broken images, unreadable contrast, awkward scroll areas, and first-viewport composition issues.
+
+Run the project's relevant formatter, typecheck, tests, or build command when available and proportionate to the change. If visual inspection is impractical, state what was verified and what remains unverified.


### PR DESCRIPTION
## Frontend Design

Adds a `frontend-design` plugin for Cline users who want stronger frontend implementation guidance without installing any runtime services. The plugin is intentionally skill-only: it gives Cline a durable checklist for product fit, interaction design, visual hierarchy, responsive constraints, accessibility, and visual verification while leaving execution to the project's existing frontend stack.

The skill is adapted for Cline's product expectations rather than treating every UI as a flashy landing page. It explicitly distinguishes operational tools and dashboards from brand pages, games, settings flows, and transactional workflows, so the agent can choose the right density and visual tone for the job.

## Cline Primitives

This plugin bundles one skill:

- `frontend-design`: Applies when building or revising web apps, pages, dashboards, forms, components, design systems, or visual interaction states. It guides Cline to inspect existing components and styles first, use meaningful assets where appropriate, keep layouts stable across viewport sizes, include relevant UI states, preserve accessibility basics, and verify the result with available browser or preview tooling.

There are no MCP servers, hooks, slash commands, tools, background processes, or install-time scripts in this plugin.

## Requirements

No API key, account, local CLI, browser service, or external dependency is required. The plugin does not add browser automation, screenshot capture, asset generation, or a dev server. If those capabilities already exist in the workspace or host environment, the skill tells Cline to use them for visual inspection; otherwise it should clearly state what was verified by code review, build output, or static inspection.
