### PR TITLE
feat: add gopls lsp plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Each plugin lives in `plugins/<slug>`. The directory name is the install keyword
 | `clickhouse-data-analyst` | ClickHouse data analyst skill with supporting analysis and ClickHouse sub-skills. |
 | `env-blocker` | A hook that blocks reads of secret `.env` files. |
 | `gitignore-read-files-guard` | A hook that blocks file access to `.gitignore` ignored paths. |
+| `gopls-lsp` | Go diagnostics through local `gopls check` as a bounded Cline tool. |
 | `goal` | Completion nudges for active goals with a slash command and completion tool. |
 | `intercom-support-triage-slack` | Intercom conversation triage tools for support workflows. |
 | `linear` | Linear SDK scripting skill for issue, project, team, cycle, and comment workflows. |

--- a/plugins/gopls-lsp/README.md
+++ b/plugins/gopls-lsp/README.md
@@ -1,0 +1,26 @@
+# gopls-lsp
+
+Adds Go diagnostics through the local `gopls` language server.
+
+## What It Adds
+
+This plugin registers `gopls_check`, a Cline tool that runs `gopls check` for one `.go` source file inside the current workspace. It returns diagnostics, command output, and setup errors as structured data so Cline can explain what is wrong without launching a long-running language server process.
+
+This is a bounded local diagnostics tool, not a persistent LSP client. It is useful when Cline needs Go type, compiler, or package diagnostics for a specific file before editing or reviewing Go code.
+
+## Requirements
+
+- Go project files in the current workspace.
+- `gopls` installed and available on `PATH`.
+
+Install `gopls` with:
+
+```bash
+go install golang.org/x/tools/gopls@latest
+```
+
+Ensure `$GOPATH/bin` or `$HOME/go/bin` is on `PATH`.
+
+## Trust Boundary
+
+The plugin itself does not call a network service. It invokes the local `gopls` binary, which reads and analyzes the workspace Go project using the user's local Go environment. Use it on Go workspaces you trust.

--- a/plugins/gopls-lsp/index.ts
+++ b/plugins/gopls-lsp/index.ts
@@ -1,0 +1,196 @@
+import { execFile } from "node:child_process"
+import { existsSync, statSync } from "node:fs"
+import { extname, isAbsolute, relative, resolve } from "node:path"
+import { promisify } from "node:util"
+import { type AgentPlugin, createTool } from "@cline/core"
+
+const execFileAsync = promisify(execFile)
+const TIMEOUT_MS = 30_000
+const MAX_BUFFER = 1024 * 1024
+
+type GoplsCheckInput = {
+	file?: string
+}
+
+type CommandError = Error & {
+	code?: string | number
+	signal?: string
+	stdout?: string | Buffer
+	stderr?: string | Buffer
+}
+
+function toText(value: string | Buffer | undefined): string {
+	return Buffer.isBuffer(value) ? value.toString("utf8") : value ?? ""
+}
+
+function isInsideWorkspace(workspaceRoot: string, filePath: string): boolean {
+	const rel = relative(workspaceRoot, filePath)
+	return rel === "" || (!rel.startsWith("..") && !isAbsolute(rel))
+}
+
+function parseDiagnostics(output: string) {
+	return output
+		.split(/\r?\n/)
+		.map((line) => line.trim())
+		.filter(Boolean)
+		.map((line) => {
+			const match = line.match(/^(.*?):(\d+):(\d+):\s*(.*)$/)
+			if (!match) {
+				return { raw: line, message: line }
+			}
+
+			return {
+				file: match[1],
+				line: Number(match[2]),
+				column: Number(match[3]),
+				message: match[4],
+				raw: line,
+			}
+		})
+}
+
+function createGoplsCheckTool(workspaceRoot: string) {
+	return createTool({
+		name: "gopls_check",
+		description:
+			"Run `gopls check` on one Go source file in the current workspace and return diagnostics. " +
+			"Use this when you need Go compiler/type diagnostics for a specific file without running the whole test suite.",
+		inputSchema: {
+			type: "object",
+			properties: {
+				file: {
+					type: "string",
+					description:
+						"Path to a .go file, either absolute or relative to the current workspace.",
+				},
+			},
+			required: ["file"],
+			additionalProperties: false,
+		},
+		timeoutMs: TIMEOUT_MS,
+		retryable: false,
+		async execute(input: unknown) {
+			const { file } = (input ?? {}) as GoplsCheckInput
+			if (typeof file !== "string" || file.trim() === "") {
+				return { ok: false, error: "file is required" }
+			}
+
+			const resolvedFile = isAbsolute(file)
+				? resolve(file)
+				: resolve(workspaceRoot, file)
+
+			if (!isInsideWorkspace(workspaceRoot, resolvedFile)) {
+				return {
+					ok: false,
+					error: "file must be inside the current workspace",
+					workspaceRoot,
+					file: resolvedFile,
+				}
+			}
+
+			if (extname(resolvedFile) !== ".go") {
+				return {
+					ok: false,
+					error: "file must be a .go source file",
+					file: resolvedFile,
+				}
+			}
+
+			if (!existsSync(resolvedFile)) {
+				return {
+					ok: false,
+					error: "file does not exist",
+					file: resolvedFile,
+				}
+			}
+
+			if (!statSync(resolvedFile).isFile()) {
+				return {
+					ok: false,
+					error: "file is not a regular file",
+					file: resolvedFile,
+				}
+			}
+
+			try {
+				const { stdout, stderr } = await execFileAsync(
+					"gopls",
+					["check", resolvedFile],
+					{
+						cwd: workspaceRoot,
+						timeout: TIMEOUT_MS,
+						maxBuffer: MAX_BUFFER,
+					},
+				)
+				const output = [stdout, stderr].filter(Boolean).join("\n")
+
+				return {
+					ok: true,
+					file: resolvedFile,
+					relativeFile: relative(workspaceRoot, resolvedFile),
+					diagnostics: parseDiagnostics(output),
+					hasDiagnostics: output.trim().length > 0,
+					stdout: stdout.trim(),
+					stderr: stderr.trim(),
+				}
+			} catch (error) {
+				const commandError = error as CommandError
+				const stdout = toText(commandError.stdout)
+				const stderr = toText(commandError.stderr)
+
+				if (commandError.code === "ENOENT") {
+					return {
+						ok: false,
+						error: "gopls is not installed or is not on PATH",
+						setup: "Install it with `go install golang.org/x/tools/gopls@latest` and ensure GOPATH/bin is on PATH.",
+						file: resolvedFile,
+						relativeFile: relative(workspaceRoot, resolvedFile),
+					}
+				}
+
+				const output = [stdout, stderr].filter(Boolean).join("\n")
+				const diagnostics = parseDiagnostics(output)
+
+				if (diagnostics.length > 0) {
+					return {
+						ok: true,
+						file: resolvedFile,
+						relativeFile: relative(workspaceRoot, resolvedFile),
+						diagnostics,
+						hasDiagnostics: true,
+						exitCode: commandError.code,
+						signal: commandError.signal,
+						stdout: stdout.trim(),
+						stderr: stderr.trim(),
+					}
+				}
+
+				return {
+					ok: false,
+					error: "gopls check failed without diagnostic output",
+					file: resolvedFile,
+					relativeFile: relative(workspaceRoot, resolvedFile),
+					exitCode: commandError.code,
+					signal: commandError.signal,
+					diagnostics,
+					stdout: stdout.trim(),
+					stderr: stderr.trim(),
+					message: commandError.message,
+				}
+			}
+		},
+	})
+}
+
+const plugin: AgentPlugin = {
+	name: "gopls-lsp",
+	manifest: {
+		capabilities: ["tools"],
+	},
+	setup(api, ctx) {
+		const workspaceRoot = resolve(ctx.workspaceInfo?.rootPath ?? process.cwd())
+		api.registerTool(createGoplsCheckTool(workspaceRoot))
+	},
+}
+
+export default plugin


### PR DESCRIPTION
## gopls-lsp

Adds Go diagnostics for Cline users through the local `gopls` language server. The plugin gives Cline a focused way to ask for compiler, type, and package diagnostics on a specific Go source file before editing or reviewing code.

This is intentionally not a persistent LSP client. It exposes the useful part Cline can support cleanly today: a bounded on-demand diagnostics check for one file inside the current workspace.

## Cline Primitives

Registers one tool, `gopls_check`.

`gopls_check` runs `gopls check <file>` with the session workspace as the working directory. It accepts an absolute or workspace-relative `.go` file path, rejects paths outside the workspace, and returns structured output with diagnostics, stdout, stderr, and setup errors.

Diagnostic exits are treated as successful tool output with `ok: true` and `hasDiagnostics: true`, so Cline can read and act on the reported Go issues. Invocation failures such as a missing `gopls` binary, invalid file path, non-Go file, or command failure without diagnostic output are returned as structured `ok: false` results.

## Requirements

Users need a Go workspace and `gopls` available on `PATH`. They can install it with:

```bash
go install golang.org/x/tools/gopls@latest
```

The plugin does not call a network service itself. It invokes the user's local `gopls` binary, which reads and analyzes the workspace Go project using the user's Go environment, module cache, and toolchain configuration. It should be used on Go workspaces the user trusts.
