### PR TITLE
feat: add hunter plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Each plugin lives in `plugins/<slug>`. The directory name is the install keyword
 | `env-blocker` | A hook that blocks reads of secret `.env` files. |
 | `gitignore-read-files-guard` | A hook that blocks file access to `.gitignore` ignored paths. |
 | `goal` | Completion nudges for active goals with a slash command and completion tool. |
+| `hunter` | Hunter MCP plus skills for email finding, verification, enrichment, lead lists, and prospecting workflows. |
 | `intercom-support-triage-slack` | Intercom conversation triage tools for support workflows. |
 | `linear` | Linear SDK scripting skill for issue, project, team, cycle, and comment workflows. |
 | `mac-notify` | macOS notifications when a Cline run completes. |

--- a/plugins/hunter/LICENSE.hunter
+++ b/plugins/hunter/LICENSE.hunter
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Hunter.io
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/plugins/hunter/README.md
+++ b/plugins/hunter/README.md
@@ -1,0 +1,25 @@
+# hunter
+
+Adds Hunter prospecting workflows to Cline with bundled skills and the Hunter MCP server.
+
+## What It Adds
+
+This plugin includes Cline skills for common Hunter workflows:
+
+- Finding professional email addresses from a name and company.
+- Searching company domains for public contacts.
+- Verifying deliverability before outreach.
+- Enriching company and person records.
+- Discovering companies by criteria.
+- Building lead lists and preparing campaign recipients.
+- Running end-to-end prospecting workflows with credit-aware checkpoints.
+
+It also registers the `hunter` MCP server at `https://mcp.hunter.io/mcp`. The MCP server exposes Hunter tools for contact search, email verification, enrichment, lead-list management, and campaign recipient workflows.
+
+## Requirements
+
+The MCP server requires a Hunter account and authentication through the Hunter MCP flow. Hunter plan limits and credit costs apply.
+
+## Trust Boundary
+
+Hunter workflows can reveal personal contact data, consume search or verification credits, save leads, and add recipients to campaigns. Cline should confirm bulk credit usage, list/campaign mutations, and any outreach-adjacent action before making changes.

--- a/plugins/hunter/index.ts
+++ b/plugins/hunter/index.ts
@@ -1,0 +1,25 @@
+import type { AgentPlugin } from "@cline/sdk"
+
+const plugin: AgentPlugin = {
+	name: "hunter",
+	manifest: {
+		capabilities: ["skills", "mcp"],
+	},
+	setup(api) {
+		api.registerMcpServer({
+			name: "hunter",
+			transport: {
+				type: "streamableHttp",
+				url: "https://mcp.hunter.io/mcp",
+			},
+			metadata: {
+				displayName: "Hunter",
+				description:
+					"Find, verify, enrich, and organize professional contacts for B2B prospecting workflows.",
+				requiresAuthentication: true,
+			},
+		})
+	},
+}
+
+export default plugin

--- a/plugins/hunter/index.ts
+++ b/plugins/hunter/index.ts
@@ -3,7 +3,7 @@ import type { AgentPlugin } from "@cline/sdk"
 const plugin: AgentPlugin = {
 	name: "hunter",
 	manifest: {
-		capabilities: ["skills", "mcp"],
+		capabilities: ["skills", "mcp", "rules"],
 	},
 	setup(api) {
 		api.registerMcpServer({
@@ -18,6 +18,18 @@ const plugin: AgentPlugin = {
 					"Find, verify, enrich, and organize professional contacts for B2B prospecting workflows.",
 				requiresAuthentication: true,
 			},
+		})
+
+		api.registerRule({
+			id: "hunter:prospecting-safety",
+			source: "hunter",
+			content: [
+				"Hunter workflows can expose personal contact data, consume Hunter credits, save or update leads, and add recipients to campaigns.",
+				"Before running credit-consuming searches, inferred-domain searches, bulk verification, enrichment, lead/list mutations, or campaign-recipient changes, summarize the target scope, estimated credits, affected records, and ask for explicit confirmation.",
+				"Treat discovered email addresses, contact profiles, enrichment data, campaign recipients, and Hunter search results as sensitive business and personal data. Share only what is needed for the user's task.",
+				"Do not add recipients to running or active campaigns without an extra confirmation that names the campaign, status, recipient count, and outreach/schedule risk.",
+				"Do not write Hunter API keys, OAuth tokens, contact exports, lead lists, or raw personal contact data into source-controlled files.",
+			].join("\n"),
 		})
 	},
 }

--- a/plugins/hunter/index.ts
+++ b/plugins/hunter/index.ts
@@ -3,7 +3,7 @@ import type { AgentPlugin } from "@cline/sdk"
 const plugin: AgentPlugin = {
 	name: "hunter",
 	manifest: {
-		capabilities: ["skills", "mcp", "rules"],
+		capabilities: ["skills", "mcp"],
 	},
 	setup(api) {
 		api.registerMcpServer({
@@ -18,18 +18,6 @@ const plugin: AgentPlugin = {
 					"Find, verify, enrich, and organize professional contacts for B2B prospecting workflows.",
 				requiresAuthentication: true,
 			},
-		})
-
-		api.registerRule({
-			id: "hunter:prospecting-safety",
-			source: "hunter",
-			content: [
-				"Hunter workflows can expose personal contact data, consume Hunter credits, save or update leads, and add recipients to campaigns.",
-				"Before running credit-consuming searches, inferred-domain searches, bulk verification, enrichment, lead/list mutations, or campaign-recipient changes, summarize the target scope, estimated credits, affected records, and ask for explicit confirmation.",
-				"Treat discovered email addresses, contact profiles, enrichment data, campaign recipients, and Hunter search results as sensitive business and personal data. Share only what is needed for the user's task.",
-				"Do not add recipients to running or active campaigns without an extra confirmation that names the campaign, status, recipient count, and outreach/schedule risk.",
-				"Do not write Hunter API keys, OAuth tokens, contact exports, lead lists, or raw personal contact data into source-controlled files.",
-			].join("\n"),
 		})
 	},
 }

--- a/plugins/hunter/package.json
+++ b/plugins/hunter/package.json
@@ -3,12 +3,17 @@
   "version": "0.0.0",
   "private": true,
   "type": "module",
-  "description": "Cline plugin that bundles Hunter prospecting skills, a safety rule, and the Hunter MCP server.",
+  "description": "Cline plugin that bundles Hunter prospecting skills and the Hunter MCP server.",
   "cline": {
     "plugins": [
       {
-        "paths": ["./index.ts"],
-        "capabilities": ["skills", "mcp", "rules"]
+        "paths": [
+          "./index.ts"
+        ],
+        "capabilities": [
+          "skills",
+          "mcp"
+        ]
       }
     ]
   }

--- a/plugins/hunter/package.json
+++ b/plugins/hunter/package.json
@@ -3,12 +3,12 @@
   "version": "0.0.0",
   "private": true,
   "type": "module",
-  "description": "Cline plugin that bundles Hunter prospecting skills and registers the Hunter MCP server.",
+  "description": "Cline plugin that bundles Hunter prospecting skills, a safety rule, and the Hunter MCP server.",
   "cline": {
     "plugins": [
       {
         "paths": ["./index.ts"],
-        "capabilities": ["skills", "mcp"]
+        "capabilities": ["skills", "mcp", "rules"]
       }
     ]
   }

--- a/plugins/hunter/package.json
+++ b/plugins/hunter/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "hunter",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Cline plugin that bundles Hunter prospecting skills and registers the Hunter MCP server.",
+  "cline": {
+    "plugins": [
+      {
+        "paths": ["./index.ts"],
+        "capabilities": ["skills", "mcp"]
+      }
+    ]
+  }
+}

--- a/plugins/hunter/skills/campaign-setup/SKILL.md
+++ b/plugins/hunter/skills/campaign-setup/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: hunter-campaign-setup
+description: Prepares a Hunter email campaign by adding recipients from Hunter leads. Use when the user explicitly wants to add recipients to a Hunter campaign or prepare Hunter outreach.
+user-invocable: true
+argument-hint: Add my fintech leads to the Q2 Outreach campaign
+---
+
+# Campaign Setup
+
+Add recipients to a Hunter campaign and prepare it for sending.
+
+## Examples
+
+- "Add my fintech leads to the Q2 Outreach campaign"
+- `"Set up my campaign with these contacts"`
+- `"Add the leads from my SaaS list to campaign 12345"`
+- `"Prepare the outreach campaign"`
+
+## Workflow
+
+### Step 1: Identify the Campaign
+
+- If the user provides a campaign ID or name, use it directly.
+- Otherwise, use the Hunter list campaigns MCP action to show available campaigns and ask the user to choose.
+
+```
+# Your Campaigns
+
+| ID | Name | Status | Recipients |
+|----|------|--------|------------|
+| 123 | Q2 Outreach | draft | 0 |
+| 456 | Product Launch | running | 150 |
+
+Which campaign would you like to add recipients to?
+```
+
+### Step 2: Identify Recipients
+
+Determine the source of recipients:
+
+- From a leads list - use Hunter lead listing with the leads list ID to get the emails.
+- From specific emails - the user provides email addresses directly.
+- From lead IDs - the user provides lead IDs.
+- From a previous search - use contacts already found.
+
+Prefer draft campaigns. If the selected campaign is running or active, stop and ask for explicit confirmation before adding recipients. Include the campaign ID, campaign name, status, and current recipient count, and explain that active campaigns may send according to their existing Hunter schedule.
+
+### Step 3: Add Recipients
+
+Before adding recipients, summarize the campaign, recipient source, recipient count, and whether batching is needed. Ask the user to confirm before using the Hunter add campaign recipients MCP action.
+
+Use the Hunter add campaign recipients MCP action with the campaign ID and email addresses or lead IDs only after confirmation. Max 50 per request - batch larger lists automatically.
+
+Report progress: "Adding batch 1 of 3 (50 recipients)..."
+
+### Step 4: Present Summary
+
+```
+# Campaign Ready: [Campaign Name]
+
+Recipients added: [count]
+
+View campaign: https://hunter.io/campaigns/{campaign_id}
+
+## Important
+Before starting the campaign, verify in Hunter that:
+- Email subject and body are configured
+- A sending email account is connected
+- Follow-up steps are set up (if desired)
+
+Campaign creation and editing must be done in the Hunter UI:
+https://hunter.io/campaigns/{campaign_id}
+
+## Next Steps
+1. Review and edit the campaign in Hunter
+2. Start the campaign in Hunter only after reviewing the content, sender, and schedule
+3. Check campaign status with Hunter
+4. Add more recipients
+```
+
+## Credit Cost
+
+Free - adding recipients to a campaign does not consume credits.
+
+## Important Notes
+
+- Max 50 recipients per Hunter add campaign recipients request - batch larger lists
+- Campaign creation, subject/body editing, and follow-up configuration are done in the Hunter UI (not available via API)
+- Do not start campaigns from this skill. Starting outreach is a separate user-controlled action in Hunter.
+- Use Hunter campaign recipient listing to check who is already in the campaign
+- Use Hunter campaign recipient removal only when the user explicitly asks to remove contacts

--- a/plugins/hunter/skills/company-enrichment/SKILL.md
+++ b/plugins/hunter/skills/company-enrichment/SKILL.md
@@ -1,0 +1,64 @@
+---
+name: hunter-company-enrichment
+description: Retrieves Hunter company information including industry, size, location, and description from a domain name. Use when the user explicitly wants Hunter company enrichment.
+user-invocable: true
+argument-hint: stripe.com
+---
+
+# Company Enrichment
+
+Get a detailed profile of any company from its domain name.
+
+## Examples
+
+- "stripe.com"
+- `"Tell me about acme.com"`
+- `"What does notion.so do?"`
+- `"Company info for figma.com"`
+- `"Look up HubSpot"`
+
+## Steps
+
+1. Parse the input. Extract the `domain`.
+   - "stripe.com" -> use directly
+   - "Stripe" -> infer domain as "stripe.com"
+   - If the domain is inferred rather than provided, confirm it before spending Hunter enrichment credits.
+
+2. Use the Hunter company enrichment MCP action with the domain.
+
+3. Present the company profile:
+
+```
+# Company: Stripe (stripe.com)
+
+| Field | Value |
+|-------|-------|
+| Industry | Financial Technology |
+| Size | 5,000-10,000 employees |
+| Founded | 2010 |
+| Headquarters | San Francisco, CA |
+| Type | Private |
+
+## Description
+Stripe builds economic infrastructure for the internet, enabling businesses to accept payments and manage their businesses online.
+
+## Social Profiles
+- LinkedIn: linkedin.com/company/stripe
+- Twitter: @stripe
+
+## Next Actions
+1. Find contacts at stripe.com with Hunter domain search
+2. Search for similar companies with Hunter discovery
+3. Find a specific person's email at Stripe with Hunter email finder
+4. Save this company to your Hunter leads
+```
+
+4. If the domain is unknown, respond: "No company data available for [domain]. Try checking the spelling, or use Hunter discovery to search for companies by name."
+
+## Credit Cost
+
+Costs 1 enrichment credit - only charged if data is found.
+
+## Success Criteria
+
+Company name, industry, and size returned.

--- a/plugins/hunter/skills/discover/SKILL.md
+++ b/plugins/hunter/skills/discover/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: hunter-discover
+description: Searches Hunter for companies matching criteria like industry, size, location, and technologies. Use when the user explicitly wants Hunter company discovery or a Hunter target account list. This is a free operation that does not consume credits.
+user-invocable: true
+argument-hint: fintech startups in France with 50-200 employees
+---
+
+# Company Discovery
+
+Search for companies matching any criteria. This is completely free -- no credits consumed.
+
+## Examples
+
+- "fintech startups in France"
+- "SaaS companies using Salesforce"
+- `"Find healthcare companies in Germany with 100+ employees"`
+- `"Companies similar to Notion"`
+- `"Series B startups in Europe"`
+- `"Tech companies in San Francisco with 50-200 people"`
+
+## Steps
+
+1. Pass the user's query directly to the Hunter company discovery MCP action. It accepts natural language and handles parsing.
+
+2. Present the results:
+
+```
+# Hunter Discovery: Fintech Startups in France
+
+Found: 43 companies | Showing: 10
+
+| Company | Domain | Industry | Size | Location |
+|---------|--------|----------|------|----------|
+| Qonto | qonto.com | Fintech | 150 | Paris, FR |
+| Pennylane | pennylane.com | Fintech | 120 | Paris, FR |
+| Swan | swan.io | Fintech | 95 | Paris, FR |
+| Spendesk | spendesk.com | Fintech | 180 | Paris, FR |
+| ... | ... | ... | ... | ... |
+
+## Next Actions
+1. Show more results (use offset to paginate)
+2. Find contacts at one of these companies with Hunter domain search
+3. Enrich a company for more details with Hunter company enrichment
+4. Save companies as Hunter leads
+5. Narrow the search (e.g., "only companies using React")
+6. Find similar companies (e.g., "companies like Qonto")
+```
+
+3. If results are too broad (hundreds of companies), suggest narrowing: "That's a broad search. Try adding filters like industry, company size, location, or technology to narrow the results."
+
+4. If zero results, suggest loosening criteria: "No companies found matching those exact criteria. Try broadening your search -- for example, expand the location or employee range."
+
+5. Remind users this is free. Encourage exploration: "Hunter discovery is free -- feel free to refine your search as many times as you'd like."
+
+## Success Criteria
+
+At least one company returned matching the user's criteria.

--- a/plugins/hunter/skills/domain-search/SKILL.md
+++ b/plugins/hunter/skills/domain-search/SKILL.md
@@ -41,7 +41,7 @@ Find all contacts and email addresses associated with a company domain.
    - "senior people" -> `seniority: "senior,executive"`
    - No filter specified -> show the top contacts by confidence score
 
-4. Present the results:
+3. Present the results:
 
 ```
 # Contacts at Stripe (stripe.com)

--- a/plugins/hunter/skills/domain-search/SKILL.md
+++ b/plugins/hunter/skills/domain-search/SKILL.md
@@ -1,0 +1,79 @@
+---
+name: hunter-domain-search
+description: Finds Hunter contacts and publicly available email addresses at a company domain. Use when the user explicitly wants Hunter domain search, contacts at a domain, or professional emails for an organization.
+user-invocable: true
+argument-hint: stripe.com
+---
+
+# Domain Search
+
+Find all contacts and email addresses associated with a company domain.
+
+## Examples
+
+- "stripe.com"
+- "Notion"
+- `"Who works at figma.com?"`
+- `"Find me contacts at Salesforce"`
+- `"Show me the marketing team at hubspot.com"`
+- `"List executives at acme.com"`
+
+## Steps
+
+1. Parse the input. Extract the `domain`.
+   - "stripe.com" -> use directly
+   - "Stripe" or "stripe" -> infer domain as "stripe.com"
+   - If unsure about the domain, ask the user to confirm.
+   - If the domain is inferred rather than provided, confirm it before spending Hunter search credits.
+
+2. Use the Hunter domain search MCP action with the domain. Use server-side filters when the user specifies criteria:
+   - `type`: `personal` or `generic`
+   - `seniority`: comma-separated from `junior`, `senior`, `executive`
+   - `department`: comma-separated from `executive`, `it`, `finance`, `management`, `sales`, `legal`, `support`, `hr`, `marketing`, `communication`, `education`, `design`, `health`, `operations`
+   - `required_field`: `full_name`, `position`, or `phone_number` - only return results where this field has a value
+   - `limit`: 1-100 (default 10)
+   - `offset`: for pagination
+
+   Mapping user requests to filters:
+   - "marketing team" -> `department: "marketing"`
+   - "executives" / "C-suite" / "leadership" -> `seniority: "executive"`
+   - "engineering" / "developers" -> `department: "it"`
+   - "senior people" -> `seniority: "senior,executive"`
+   - No filter specified -> show the top contacts by confidence score
+
+4. Present the results:
+
+```
+# Contacts at Stripe (stripe.com)
+
+Found: 247 contacts | Showing: 10
+
+| Name | Position | Email | Confidence |
+|------|----------|-------|------------|
+| Patrick Collison | CEO | patrick@stripe.com | 97% |
+| John Collison | President | john@stripe.com | 95% |
+| David Singleton | CTO | david.singleton@stripe.com | 88% |
+| ... | ... | ... | ... |
+
+## Next Actions
+1. Show more contacts (use offset to paginate)
+2. Filter by department (e.g., "show me the marketing team")
+3. Verify email addresses (1 verification credit each)
+4. Save contacts as Hunter leads
+5. Enrich Stripe with Hunter company enrichment
+```
+
+5. If the user asks for more, present the next batch of results.
+
+6. If zero results, suggest:
+   - Check the domain spelling
+   - The company may be too new or too small for our database
+   - Try Hunter company discovery to find similar companies
+
+## Credit Cost
+
+Costs 1 search credit per 10 emails returned (rounded up) - only charged if emails are found.
+
+## Success Criteria
+
+At least one contact returned with name, email, and confidence score.

--- a/plugins/hunter/skills/email-finder/SKILL.md
+++ b/plugins/hunter/skills/email-finder/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: hunter-email-finder
+description: Finds a professional email address with Hunter from a person's name and company domain. Use when the user explicitly wants Hunter to find a specific person's work email.
+user-invocable: true
+argument-hint: Jane Smith at stripe.com
+---
+
+# Email Finder
+
+Find the most likely email address for a person at a company using their name and domain.
+
+## Examples
+
+- "Jane Smith at stripe.com"
+- "the CEO of notion.so"
+- `"What's John Doe's email at acme.com?"`
+- `"Find the email for Sarah Chen at Figma"`
+- `"How can I reach Marc Benioff at Salesforce?"`
+
+## Steps
+
+1. Parse the input. Extract the person's `full_name` and the company `domain`.
+   - "Jane Smith at Stripe" -> `full_name`: "Jane Smith", `domain`: "stripe.com"
+   - If the user provides a company name instead of a domain, infer the likely domain (e.g., "Stripe" -> "stripe.com")
+   - If the domain is inferred rather than provided, confirm it before spending Hunter search credits.
+   - If only a role is given (e.g., "the CTO of Notion"), note that Hunter email finding requires a name. Suggest using Hunter domain search on the domain first to find the person's name, then come back to find their email.
+
+2. Use the Hunter email finder MCP action with the person's full name and domain.
+
+3. Present the result:
+
+```
+# Email Found: Jane Smith @ Stripe
+
+| Field | Value |
+|-------|-------|
+| Email | jane.smith@stripe.com |
+| Score | 92 |
+| Domain | stripe.com |
+| Verification | valid |
+
+## Sources
+- stripe.com/team (last seen: 2026-02-15)
+- LinkedIn profile (last seen: 2026-01-20)
+
+## Next Actions
+1. Verify this email address with Hunter email verification
+2. Save as a Hunter lead
+3. Enrich this contact with Hunter person enrichment
+4. Find more contacts at stripe.com with Hunter domain search
+```
+
+4. If no email is found, suggest alternatives:
+   - "I couldn't find an email for [name] at [domain]. Would you like me to search all contacts at [domain] instead? That might help find the right person."
+   - Suggest checking the spelling of the name or trying a different domain variation.
+
+## Credit Cost
+
+Costs 1 search credit - only charged if an email is found.
+
+## Success Criteria
+
+Email address returned with score and at least one source.

--- a/plugins/hunter/skills/email-verifier/SKILL.md
+++ b/plugins/hunter/skills/email-verifier/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: hunter-email-verifier
+description: Verifies whether an email address is deliverable using Hunter. Use when the user explicitly wants Hunter email verification or asks to assess deliverability before sending.
+user-invocable: true
+argument-hint: jane@stripe.com
+---
+
+# Email Verifier
+
+Check whether an email address is deliverable before you send to it.
+
+## Examples
+
+- "jane@stripe.com"
+- `"Is john@acme.com a valid email?"`
+- `"Check if sarah@notion.so is deliverable"`
+- `"Verify these emails: a@x.com, b@y.com, c@z.com"`
+- `"Can I send to hello@example.com?"`
+
+## Steps
+
+1. Parse the input. Extract the `email` address(es).
+
+2. Use the Hunter email verifier MCP action for each email.
+
+3. Present the result with an actionable recommendation:
+
+```
+# Verification: jane@stripe.com
+
+| Check | Result |
+|-------|--------|
+| Status | valid |
+| Score | 91 |
+| MX Records | Valid |
+| SMTP Check | Valid |
+| Accept All | No |
+| Disposable | No |
+
+## Recommendation
+Safe to send. This email address is deliverable with high confidence.
+
+## Next Actions
+1. Find more contacts at stripe.com
+2. Enrich this contact with personal details
+```
+
+4. Interpret the result clearly based on the `status` field:
+   - `valid` (score 80+) -> "Safe to send. This email address is deliverable with high confidence."
+   - `accept_all` -> "Proceed with caution. This mail server accepts all addresses, so delivery is not guaranteed even though SMTP checks pass."
+   - `unknown` -> "Unable to determine deliverability. The mail server didn't respond clearly -- consider sending a low-priority test first."
+   - `invalid` (score below 50) -> "Do not send. This address is likely invalid and will bounce."
+   - Disposable email (`disposable: true`) -> Add: "This is a disposable/temporary email address. It may stop working at any time."
+   - Pending (HTTP 202 response) -> "Verification is still in progress. Try again in a few seconds."
+
+5. For multiple emails, verify each separately and present a summary:
+
+```
+# Verification Summary
+
+| Email | Status | Score | Recommendation |
+|-------|--------|-------|----------------|
+| jane@stripe.com | valid | 91 | Safe to send |
+| john@acme.com | accept_all | 62 | Proceed with caution |
+| test@fake.com | invalid | 12 | Do not send |
+
+Results: 1 valid, 1 accept_all, 1 invalid
+```
+
+## Credit Cost
+
+Costs 1 verification credit per email - only charged for valid, invalid, or accept_all results.
+
+## Success Criteria
+
+Verification status returned with a clear, actionable recommendation the user can act on immediately.

--- a/plugins/hunter/skills/list-builder/SKILL.md
+++ b/plugins/hunter/skills/list-builder/SKILL.md
@@ -1,0 +1,70 @@
+---
+name: hunter-list-builder
+description: Creates and populates a Hunter leads list from contacts or domains. Use when the user explicitly wants to save contacts into Hunter leads, organize Hunter search results, or build a Hunter prospect list.
+user-invocable: true
+argument-hint: Create a list of marketing leads from SaaS companies
+---
+
+# List Builder
+
+Create a Hunter leads list and populate it with contacts from search results, enrichment, or manual input.
+
+## Examples
+
+- "Create a list of marketing leads from SaaS companies"
+- `"Save these contacts to a new list called Q2 Outreach"`
+- `"Build a list from the domain search results"`
+- `"Organize my prospects into a leads list"`
+
+## Workflow
+
+### Step 1: Determine the Source
+
+Parse the user's request to identify where leads come from:
+
+- From a previous search - use contacts already found via Hunter domain search or company discovery.
+- From specific emails/contacts - the user provides email addresses directly.
+- From a new search - run Hunter company discovery and domain search first, then save results.
+
+### Step 2: Create the List
+
+Before creating or updating Hunter leads, summarize the list name, source, expected lead count, and any credit-consuming searches used to gather the contacts. Ask the user to confirm.
+
+Use the Hunter create leads list MCP action with a descriptive name only after confirmation. If the user doesn't provide a name, suggest one based on the context (e.g., "Fintech CTOs - France - 2026-04-08").
+
+Present the deep-link: "List created: https://hunter.io/leads?leads_list_id={id}"
+
+### Step 3: Add Leads
+
+For each contact, use the Hunter upsert lead MCP action with the contact's data and the new leads list ID. Prefer upsert behavior to avoid duplicates.
+
+Include all available fields: `email`, `first_name`, `last_name`, `position`, `company`, `linkedin_url`, etc.
+
+Report progress: "Adding lead 5 of 20..."
+
+### Step 4: Present Summary
+
+```
+# List Created: [List Name]
+
+Leads added: [count] | Duplicates skipped: [count]
+
+View in Hunter: https://hunter.io/leads?leads_list_id={id}
+
+## Next Steps
+1. Add more leads to this list
+2. Add leads to a Hunter campaign
+3. Merge with another Hunter leads list
+4. Search for more contacts with Hunter domain search or company discovery
+```
+
+## Credit Cost
+
+Free - Hunter list creation and lead upsert actions do not consume credits. Only the initial Hunter search uses credits if leads come from a new search.
+
+## Important Notes
+
+- Use Hunter upsert behavior to avoid creating duplicate leads
+- Use Hunter lead existence checks before adding if unsure
+- Max 100 leads per page when listing - use offset to paginate
+- Lists can be merged later with Hunter list merge actions

--- a/plugins/hunter/skills/person-enrichment/SKILL.md
+++ b/plugins/hunter/skills/person-enrichment/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: hunter-person-enrichment
+description: Retrieves Hunter person information from an email address, including name, position, company, and social profiles. Use when the user explicitly wants Hunter person enrichment.
+user-invocable: true
+argument-hint: jane@stripe.com
+---
+
+# Person Enrichment
+
+Get a detailed profile of a person from their email address.
+
+## Examples
+
+- "jane@stripe.com"
+- `"What do you know about john@acme.com?"`
+- `"Who is sarah@notion.so?"`
+- `"Enrich this contact: marc@salesforce.com"`
+- `"Get me details on hello@figma.com"`
+
+## Steps
+
+1. Parse the input. Extract the `email` address.
+
+2. Use the Hunter person enrichment MCP action with the email.
+
+3. Present the person profile:
+
+```
+# Person: Jane Smith (jane@stripe.com)
+
+| Field | Value |
+|-------|-------|
+| Name | Jane Smith |
+| Position | VP of Engineering |
+| Company | Stripe |
+| Location | San Francisco, CA |
+| LinkedIn | linkedin.com/in/janesmith |
+| Twitter | @janesmith |
+
+## Next Actions
+1. Verify this email address with Hunter email verification
+2. Save as a Hunter lead
+3. Find more contacts at stripe.com with Hunter domain search
+4. Enrich Stripe with Hunter company enrichment
+```
+
+4. If no data is found, respond: "No data available for [email]. Try enriching their company domain instead, or use Hunter domain search to find other contacts at this company."
+
+## Credit Cost
+
+Costs 1 enrichment credit - only charged if data is found.
+
+## Success Criteria
+
+Person's name and position returned from the email address.

--- a/plugins/hunter/skills/prospecting/SKILL.md
+++ b/plugins/hunter/skills/prospecting/SKILL.md
@@ -1,0 +1,102 @@
+---
+name: hunter-prospecting
+description: Runs end-to-end B2B prospecting with Hunter by chaining company discovery, contact search, email verification, and enrichment. Use when the user explicitly wants Hunter-powered prospecting, lead discovery, or contact qualification.
+user-invocable: true
+argument-hint: Find CTOs at fintech startups in Europe
+---
+
+# Prospecting
+
+Chain Hunter MCP actions into a complete prospecting workflow. Discover companies, find contacts, verify emails, and enrich -- all in one go.
+
+## Examples
+
+- "Find CTOs at fintech startups in France"
+- "decision-makers at Stripe, Notion, and Figma"
+- `"Build me a list of marketing leads at SaaS companies in Germany"`
+- `"I need 20 VPs of Sales at mid-size tech companies"`
+- `"Find people to reach out to at companies using Salesforce in healthcare"`
+
+## Workflow
+
+### Step 1: Identify Companies
+
+Parse the user's request to determine the starting point:
+
+- Specific companies provided (e.g., "Stripe, Notion, Figma") -- skip to Step 2.
+- Criteria provided (e.g., "fintech startups in France") -- use the Hunter company discovery MCP action with the criteria as the query.
+
+If Hunter discovery returns more than 10 companies, present the full list and ask:
+
+> "I found [N] companies matching your criteria. Here are the top results. Which ones should I search for contacts? You can select specific companies or say 'proceed with all' (note: each Domain Search uses 1 credit per 10 results returned)."
+
+### Step 2: Find Contacts
+
+For each company, use the Hunter domain search MCP action with the company's domain. If a domain was inferred rather than returned by Hunter discovery or provided by the user, confirm it before spending search credits. Use server-side filters:
+- "CTOs" or "engineering leaders" -> `department: "it"`, `seniority: "executive"`
+- "marketing team" -> `department: "marketing"`
+- "executives" or "C-suite" -> `seniority: "executive"`
+- "senior people" -> `seniority: "senior,executive"`
+
+Report progress for multi-company searches: "Searching stripe.com... found 15 contacts. Moving to notion.so..."
+
+### Step 3: Verify Emails (Optional)
+
+> Before verifying, confirm credit usage: "I found [N] contacts across [M] companies. Verifying all emails will use [N] verification credits. Proceed?"
+
+Only verify after the user confirms. Use the Hunter email verification MCP action for each contact's email.
+
+If the user says "skip verification," present unverified results instead.
+
+### Step 4: Enrich (Optional)
+
+If the user asks for more company context, use the Hunter company enrichment MCP action for each company's domain. Only run this step if requested -- do not run by default.
+
+### Step 5: Save to Hunter Leads
+
+After presenting results, offer to save contacts:
+
+> "Would you like me to save these contacts to your Hunter leads? I can create a new list for them."
+
+If the user confirms:
+1. Use the Hunter create leads list MCP action with a descriptive name (e.g., "Fintech CTOs - France - 2026-04-08").
+2. For each contact, use the Hunter upsert lead MCP action with the contact's data and the new leads list ID.
+3. Present the deep-link: "View your leads list: https://hunter.io/leads?leads_list_id={id}"
+
+### Step 6: Present Results
+
+Present a consolidated table grouped by company:
+
+```
+# Prospect List: [Description]
+
+Companies: [count] | Contacts: [count] | Verified: [deliverable] deliverable, [risky] risky
+
+## [Company Name] (domain.com)
+Industry | Size | Location
+
+| Name | Position | Email | Verified |
+|------|----------|-------|----------|
+| ... | ... | ... | valid / accept_all / invalid / unknown |
+
+## Next Steps
+1. Save contacts to a Hunter leads list
+2. Add contacts to a Hunter campaign
+3. Verify the risky addresses again later
+4. Search for more companies with different criteria
+```
+
+## Credit Costs
+
+- Hunter company discovery - Free (no credits)
+- Hunter domain search - 1 search credit per 10 emails returned (rounded up)
+- Hunter email verification - 1 verification credit per email
+- Hunter company enrichment - 1 enrichment credit per domain
+- Hunter lead/list/company save actions - Free (no credits)
+
+## Important Notes
+
+- Always confirm before running verification on large batches
+- If a company returns zero contacts, skip it and note it in the output
+- If the user interrupts mid-workflow, present partial results gathered so far
+- Prefer Hunter upsert lead behavior over creating duplicate leads


### PR DESCRIPTION
## hunter

Adds a Hunter plugin for B2B prospecting workflows in Cline. It helps users find and verify professional email addresses, search company domains for contacts, enrich people and companies, build Hunter lead lists, and prepare campaign recipient lists.

## Cline Primitives

This plugin uses MCP and bundled skills.

The `hunter` MCP server points at `https://mcp.hunter.io/mcp` and exposes Hunter actions for contact search, email verification, enrichment, lead-list management, and campaign-recipient workflows. The plugin does not write static auth headers, so authentication stays with the Hunter MCP flow.

The bundled skills are prefixed with `hunter-` and cover email finding, domain search, email verification, company discovery, company/person enrichment, lead-list building, campaign recipient setup, and end-to-end prospecting. The skills include credit-aware checkpoints and avoid assuming exact MCP tool IDs, so they guide the model by Hunter action instead of brittle tool names.

The bundled skills' safety guidance treats discovered contact data as sensitive, requires explicit confirmation before credit-consuming or mutating Hunter actions, and adds an extra confirmation step before recipients are added to running or active campaigns.

## Requirements

Users need a Hunter account and must authenticate with the Hunter MCP server before live Hunter tools can be used. Hunter plan limits and search, verification, and enrichment credit costs still apply.

## Trust Boundary

Hunter workflows can expose personal contact data, consume Hunter credits, save leads, and add recipients to campaigns. The plugin guidance requires confirmation before bulk verification, inferred-domain credit usage, lead/list mutations, and campaign-recipient changes. Running or active campaigns get an extra confirmation step because adding recipients may affect scheduled outreach.