### PR TITLE
feat: add jdtls-lsp plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Each plugin lives in `plugins/<slug>`. The directory name is the install keyword
 | `gitignore-read-files-guard` | A hook that blocks file access to `.gitignore` ignored paths. |
 | `goal` | Completion nudges for active goals with a slash command and completion tool. |
 | `intercom-support-triage-slack` | Intercom conversation triage tools for support workflows. |
+| `jdtls-lsp` | Java compile diagnostics for Maven, Gradle, and small javac-only projects. |
 | `linear` | Linear SDK scripting skill for issue, project, team, cycle, and comment workflows. |
 | `mac-notify` | macOS notifications when a Cline run completes. |
 | `nanobanana` | Image generation through OpenRouter and Gemini image models. |

--- a/plugins/jdtls-lsp/README.md
+++ b/plugins/jdtls-lsp/README.md
@@ -1,0 +1,45 @@
+# jdtls-lsp
+
+Adds Java compile diagnostics for Cline workspaces.
+
+## What It Does
+
+Registers `java_build_diagnostics(path?, buildSystem?, timeoutMs?)`. The tool detects a Java project and runs one bounded diagnostics command:
+
+- Maven: `mvnw` or `mvn -q -DskipTests compile`
+- Gradle: `gradlew` or `gradle --no-daemon --console=plain classes`
+- Plain Java: `javac -Xlint:all` for small source trees without a build file
+
+This is a Cline-native diagnostic tool, not a persistent Eclipse JDT.LS language server. It gives Cline a practical way to check Java compiler errors and warnings without pretending the host has generic LSP support.
+
+## Install
+
+```bash
+cline plugin install jdtls-lsp
+```
+
+For local development from this repository:
+
+```bash
+cline plugin install ./plugins/jdtls-lsp --cwd .
+```
+
+## Example Usage
+
+After installation, ask Cline:
+
+```text
+Check the Java compile errors in this project before changing the service layer.
+```
+
+Cline can call `java_build_diagnostics` when it needs compiler feedback for Maven, Gradle, or small javac-only Java projects.
+
+## Requirements
+
+- A project-compatible JDK.
+- Maven, Gradle, `mvnw`, `gradlew`, or `javac`, depending on the project.
+- Any dependency downloads or build credentials required by the project build.
+
+## Security Notes
+
+Maven and Gradle builds can execute project-defined build logic, including wrapper scripts and plugins. Use this plugin only in trusted workspaces, and review build files before running diagnostics in unfamiliar repositories.

--- a/plugins/jdtls-lsp/index.ts
+++ b/plugins/jdtls-lsp/index.ts
@@ -1,0 +1,392 @@
+import { spawn } from "node:child_process";
+import {
+	existsSync,
+	mkdirSync,
+	mkdtempSync,
+	readdirSync,
+	rmSync,
+	statSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import {
+	isAbsolute,
+	join,
+	relative,
+	resolve,
+} from "node:path";
+import {
+	type AgentPlugin,
+	type AgentToolContext,
+	createTool,
+} from "@cline/core";
+
+type BuildSystem = "auto" | "maven" | "gradle" | "javac";
+
+type CommandSpec = {
+	buildSystem: Exclude<BuildSystem, "auto">;
+	command: string;
+	args: string[];
+	cwd: string;
+	note?: string;
+	tempDir?: string;
+	shell?: boolean;
+};
+
+type CommandResult = {
+	exitCode: number | null;
+	signal: NodeJS.Signals | null;
+	timedOut: boolean;
+	stdout: string;
+	stderr: string;
+};
+
+const DEFAULT_TIMEOUT_MS = 60_000;
+const MIN_TIMEOUT_MS = 10_000;
+const MAX_TIMEOUT_MS = 180_000;
+const MAX_OUTPUT_CHARS = 20_000;
+const MAX_JAVA_FILES = 500;
+const SKIP_DIRS = new Set([
+	".git",
+	".gradle",
+	".idea",
+	".mvn",
+	"build",
+	"node_modules",
+	"out",
+	"target",
+]);
+
+function asObject(value: unknown): Record<string, unknown> {
+	return value && typeof value === "object" && !Array.isArray(value)
+		? (value as Record<string, unknown>)
+		: {};
+}
+
+function asString(value: unknown): string | undefined {
+	return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function asNumber(value: unknown): number | undefined {
+	return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function parseBuildSystem(value: unknown): BuildSystem {
+	if (
+		value === "maven" ||
+		value === "gradle" ||
+		value === "javac" ||
+		value === "auto" ||
+		value === undefined
+	) {
+		return value ?? "auto";
+	}
+	throw new Error("buildSystem must be one of: auto, maven, gradle, javac");
+}
+
+function clampTimeout(timeoutMs: number | undefined): number {
+	if (!timeoutMs) return DEFAULT_TIMEOUT_MS;
+	const timeout = Math.trunc(timeoutMs);
+	return Math.min(Math.max(timeout, MIN_TIMEOUT_MS), MAX_TIMEOUT_MS);
+}
+
+function isWithinDirectory(parent: string, child: string): boolean {
+	const rel = relative(parent, child);
+	return rel === "" || (!rel.startsWith("..") && !isAbsolute(rel));
+}
+
+function resolveTargetPath(baseCwd: string, inputPath: string | undefined) {
+	const base = resolve(baseCwd);
+	const target = inputPath ? resolve(base, inputPath) : base;
+	if (!isWithinDirectory(base, target)) {
+		throw new Error(`path must stay inside the workspace: ${base}`);
+	}
+	if (!existsSync(target)) {
+		throw new Error(`path does not exist: ${target}`);
+	}
+	return target;
+}
+
+function findNearestBuildRoot(
+	startPath: string,
+	workspaceRoot: string,
+	buildSystem: BuildSystem,
+): { root: string; buildSystem: Exclude<BuildSystem, "auto"> } | undefined {
+	let dir = statSync(startPath).isDirectory() ? startPath : resolve(startPath, "..");
+	while (isWithinDirectory(workspaceRoot, dir)) {
+		const hasMaven =
+			existsSync(join(dir, "pom.xml")) ||
+			existsSync(join(dir, "mvnw")) ||
+			existsSync(join(dir, "mvnw.cmd"));
+		const hasGradle =
+			existsSync(join(dir, "build.gradle")) ||
+			existsSync(join(dir, "build.gradle.kts")) ||
+			existsSync(join(dir, "gradlew")) ||
+			existsSync(join(dir, "gradlew.bat"));
+
+		if ((buildSystem === "auto" || buildSystem === "maven") && hasMaven) {
+			return { root: dir, buildSystem: "maven" };
+		}
+		if ((buildSystem === "auto" || buildSystem === "gradle") && hasGradle) {
+			return { root: dir, buildSystem: "gradle" };
+		}
+
+		const parent = resolve(dir, "..");
+		if (parent === dir) return undefined;
+		dir = parent;
+	}
+	return undefined;
+}
+
+function findWrapper(
+	startRoot: string,
+	workspaceRoot: string,
+	unixName: string,
+	winName: string,
+): string | undefined {
+	let dir = startRoot;
+	while (isWithinDirectory(workspaceRoot, dir)) {
+		const localName = process.platform === "win32" ? winName : unixName;
+		const localPath = join(dir, localName);
+		if (existsSync(localPath)) return localPath;
+		const parent = resolve(dir, "..");
+		if (parent === dir) return undefined;
+		dir = parent;
+	}
+	return undefined;
+}
+
+function executableInProject(
+	projectRoot: string,
+	workspaceRoot: string,
+	unixName: string,
+	winName: string,
+	fallbackName: string,
+) {
+	const wrapper = findWrapper(projectRoot, workspaceRoot, unixName, winName);
+	if (wrapper) return wrapper;
+	const localName = process.platform === "win32" ? winName : unixName;
+	const localPath = join(projectRoot, localName);
+	if (existsSync(localPath)) {
+		return localPath;
+	}
+	return fallbackName;
+}
+
+function collectJavaFiles(root: string): string[] {
+	const files: string[] = [];
+	function walk(dir: string) {
+		if (files.length > MAX_JAVA_FILES) return;
+		for (const entry of readdirSync(dir, { withFileTypes: true })) {
+			const path = join(dir, entry.name);
+			if (entry.isDirectory()) {
+				if (!SKIP_DIRS.has(entry.name)) walk(path);
+			} else if (entry.isFile() && entry.name.endsWith(".java")) {
+				files.push(path);
+			}
+		}
+	}
+	walk(root);
+	return files;
+}
+
+function createCommandSpec(
+	targetPath: string,
+	workspaceRoot: string,
+	buildSystem: BuildSystem,
+): CommandSpec {
+	const wantsMaven = buildSystem === "auto" || buildSystem === "maven";
+	const wantsGradle = buildSystem === "auto" || buildSystem === "gradle";
+	const nearestBuildRoot = findNearestBuildRoot(
+		targetPath,
+		workspaceRoot,
+		buildSystem,
+	);
+
+	if (wantsMaven && nearestBuildRoot?.buildSystem === "maven") {
+		const root = nearestBuildRoot.root;
+		const command = executableInProject(
+			root,
+			workspaceRoot,
+			"mvnw",
+			"mvnw.cmd",
+			"mvn",
+		);
+		return {
+			buildSystem: "maven",
+			command,
+			args: ["-q", "-DskipTests", "compile"],
+			cwd: root,
+			shell: process.platform === "win32" && command.endsWith(".cmd"),
+			note: "Runs Maven compile with tests skipped. If the project or a parent directory has mvnw, this uses the project wrapper.",
+		};
+	}
+	if (buildSystem === "maven") {
+		throw new Error("No pom.xml or Maven wrapper found for the requested path");
+	}
+
+	if (wantsGradle && nearestBuildRoot?.buildSystem === "gradle") {
+		const root = nearestBuildRoot.root;
+		const command = executableInProject(
+			root,
+			workspaceRoot,
+			"gradlew",
+			"gradlew.bat",
+			"gradle",
+		);
+		return {
+			buildSystem: "gradle",
+			command,
+			args: ["--no-daemon", "--console=plain", "classes"],
+			cwd: root,
+			shell: process.platform === "win32" && command.endsWith(".bat"),
+			note: "Runs Gradle classes. If the project or a parent directory has gradlew, this uses the project wrapper.",
+		};
+	}
+	if (buildSystem === "gradle") {
+		throw new Error("No Gradle build file or wrapper found for the requested path");
+	}
+
+	const javacRoot = statSync(targetPath).isDirectory()
+		? targetPath
+		: resolve(targetPath, "..");
+	const javaFiles = collectJavaFiles(javacRoot);
+	if (javaFiles.length === 0) {
+		throw new Error("No Java files found for javac diagnostics");
+	}
+	if (javaFiles.length > MAX_JAVA_FILES) {
+		throw new Error(
+			`Found more than ${MAX_JAVA_FILES} Java files; use Maven or Gradle for this project`,
+		);
+	}
+
+	const tempDir = mkdtempSync(join(tmpdir(), "cline-java-diagnostics-"));
+	const classesDir = join(tempDir, "classes");
+	mkdirSync(classesDir, { recursive: true });
+	return {
+		buildSystem: "javac",
+		command: "javac",
+		args: ["-Xlint:all", "-d", classesDir, ...javaFiles],
+		cwd: javacRoot,
+		tempDir,
+		note: "Runs javac directly for small Java source trees without Maven or Gradle. Dependency-aware projects should use their build system.",
+	};
+}
+
+function truncateOutput(text: string): string {
+	if (text.length <= MAX_OUTPUT_CHARS) return text;
+	return `${text.slice(0, MAX_OUTPUT_CHARS).trimEnd()}\n\n[truncated]`;
+}
+
+function runCommand(spec: CommandSpec, timeoutMs: number): Promise<CommandResult> {
+	return new Promise((resolveRun, reject) => {
+		const child = spawn(spec.command, spec.args, {
+			cwd: spec.cwd,
+			env: { ...process.env, NO_COLOR: "1", TERM: "dumb" },
+			shell: spec.shell,
+			stdio: ["ignore", "pipe", "pipe"],
+		});
+
+		let stdout = "";
+		let stderr = "";
+		let timedOut = false;
+
+		const timeout = setTimeout(() => {
+			timedOut = true;
+			child.kill("SIGTERM");
+		}, timeoutMs);
+
+		child.stdout?.on("data", (chunk) => {
+			stdout = truncateOutput(stdout + chunk.toString());
+		});
+		child.stderr?.on("data", (chunk) => {
+			stderr = truncateOutput(stderr + chunk.toString());
+		});
+		child.on("error", reject);
+		child.on("close", (exitCode, signal) => {
+			clearTimeout(timeout);
+			resolveRun({
+				exitCode,
+				signal,
+				timedOut,
+				stdout: stdout.trim(),
+				stderr: stderr.trim(),
+			});
+		});
+	});
+}
+
+async function javaBuildDiagnostics(
+	input: unknown,
+	context: AgentToolContext,
+) {
+	const args = asObject(input);
+	const targetPath = resolveTargetPath(context.cwd, asString(args.path));
+	const buildSystem = parseBuildSystem(args.buildSystem);
+	const timeoutMs = clampTimeout(asNumber(args.timeoutMs));
+	const spec = createCommandSpec(targetPath, resolve(context.cwd), buildSystem);
+
+	try {
+		const result = await runCommand(spec, timeoutMs);
+		return {
+			success: result.exitCode === 0 && !result.timedOut,
+			buildSystem: spec.buildSystem,
+			command: [spec.command, ...spec.args],
+			cwd: spec.cwd,
+			exitCode: result.exitCode,
+			signal: result.signal,
+			timedOut: result.timedOut,
+			stdout: result.stdout,
+			stderr: result.stderr,
+			note: spec.note,
+		};
+	} finally {
+		if (spec.tempDir) {
+			rmSync(spec.tempDir, { recursive: true, force: true });
+		}
+	}
+}
+
+const plugin: AgentPlugin = {
+	name: "jdtls-lsp",
+	manifest: { capabilities: ["tools"] },
+
+	setup(api) {
+		api.registerTool(
+			createTool({
+				name: "java_build_diagnostics",
+				description:
+					"Run Java compile diagnostics for the current workspace. Detects Maven, Gradle, or small javac-only projects and returns bounded stdout/stderr.",
+				inputSchema: {
+					type: "object",
+					properties: {
+						path: {
+							type: "string",
+							description:
+								"Workspace-relative file or directory to diagnose. Defaults to the workspace root.",
+						},
+						buildSystem: {
+							type: "string",
+							enum: ["auto", "maven", "gradle", "javac"],
+							description:
+								"Build system to use. Defaults to auto-detecting Maven, then Gradle, then javac.",
+						},
+						timeoutMs: {
+							type: "integer",
+							description:
+								"Timeout in milliseconds, clamped between 10000 and 180000. Defaults to 60000.",
+						},
+					},
+					additionalProperties: false,
+				},
+				timeoutMs: MAX_TIMEOUT_MS + 5_000,
+				retryable: false,
+				async execute(input, context) {
+					return javaBuildDiagnostics(input, context);
+				},
+			}),
+		);
+	},
+};
+
+export { plugin };
+export default plugin;


### PR DESCRIPTION
## jdtls-lsp

Adds a Java diagnostics plugin for Cline users working in Maven, Gradle, or small javac-only Java projects. Cline does not have a generic persistent LSP primitive yet, so this plugin adapts Java language-server value into an explicit compile-diagnostics tool that gives the agent concrete compiler feedback when needed.

## Cline Primitives

This plugin registers one tool: `java_build_diagnostics`.

The tool accepts an optional workspace-relative `path`, optional `buildSystem`, and optional timeout. In `auto` mode it detects the nearest applicable Java project root and runs one bounded diagnostics command:

```text
Maven:  mvnw or mvn -q -DskipTests compile
Gradle: gradlew or gradle --no-daemon --console=plain classes
Plain:  javac -Xlint:all for small source trees without a build file
```

It intentionally does not register a fake JDT.LS server. The end-user behavior is simpler and more honest: when Cline needs Java compiler feedback, it can call the tool and receive bounded stdout/stderr, exit status, timeout state, selected build system, and the command it ran.

A few implementation details are user-facing enough to matter:

- Auto-detection picks the nearest Maven or Gradle root so nested projects do not accidentally run an ancestor build.
- Maven and Gradle wrappers are preferred from the project root or a parent directory inside the workspace.
- Output is capped and commands have bounded timeouts so failed builds do not flood the conversation.
- `javac` fallback is limited to small source trees and writes class output to a temporary directory that is cleaned up after the tool call.

## Requirements

Users need a project-compatible JDK and whichever build entrypoint their project uses: Maven, Gradle, `mvnw`, `gradlew`, or `javac`. Projects that download dependencies during compilation may also need network access and configured build credentials.

Maven and Gradle can execute project-defined build logic, wrapper scripts, and plugins. This plugin should be used in trusted workspaces, and users should review unfamiliar build files before asking Cline to run diagnostics.
