### PR TITLE
feat: add jfrog plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Each plugin lives in `plugins/<slug>`. The directory name is the install keyword
 | `gitignore-read-files-guard` | A hook that blocks file access to `.gitignore` ignored paths. |
 | `goal` | Completion nudges for active goals with a slash command and completion tool. |
 | `intercom-support-triage-slack` | Intercom conversation triage tools for support workflows. |
+| `jfrog` | JFrog Platform and package safety workflow skills. |
 | `linear` | Linear SDK scripting skill for issue, project, team, cycle, and comment workflows. |
 | `mac-notify` | macOS notifications when a Cline run completes. |
 | `nanobanana` | Image generation through OpenRouter and Gemini image models. |

--- a/plugins/jfrog/README.md
+++ b/plugins/jfrog/README.md
@@ -1,0 +1,51 @@
+# jfrog
+
+Adds JFrog Platform workflow skills for Cline.
+
+## What It Does
+
+This plugin ships two bundled skills:
+
+- `jfrog`: Guides Cline through JFrog Platform work with Artifactory, Xray, access tokens, projects, release bundles, build metadata, and REST or GraphQL fallbacks.
+- `jfrog-package-safety-and-download`: Guides package safety checks and downloads through JFrog Public Catalog, stored packages, curation policy, and Artifactory remote caches.
+
+The plugin does not register an MCP server and does not run startup hooks. Cline uses the user configured JFrog CLI and explicit tool calls when a JFrog task requires local commands or network access.
+
+## Install
+
+```bash
+cline plugin install jfrog
+```
+
+For local development from this repository:
+
+```bash
+cline plugin install ./plugins/jfrog --cwd .
+```
+
+## Example Usage
+
+After installation, ask Cline:
+
+```text
+List the Artifactory repositories in my default JFrog server and summarize which ones are remote caches.
+```
+
+Or:
+
+```text
+Check whether lodash 4.17.21 is allowed by our JFrog package curation policy before I add it.
+```
+
+## Requirements
+
+- JFrog Platform URL and access token.
+- JFrog CLI `jf` configured with the target server when CLI operations are needed.
+- `curl` and `jq` for API and GraphQL workflows.
+- Network access to the relevant JFrog services.
+
+## Security Notes
+
+JFrog operations can read or mutate artifact repositories, security policies, users, tokens, projects, and release lifecycle state. The bundled skills require Cline to resolve exactly one target server before acting, prefer read operations first, and require explicit user confirmation for destructive or privileged mutations.
+
+Maven, npm, PyPI, Go, NuGet, Docker, and other package downloads can introduce supply-chain risk. Package downloads should go through the configured JFrog repositories or curation-aware flow, and Cline should stop when a package is blocked by policy.

--- a/plugins/jfrog/index.ts
+++ b/plugins/jfrog/index.ts
@@ -1,0 +1,10 @@
+import type { AgentPlugin } from "@cline/sdk"
+
+const plugin: AgentPlugin = {
+	name: "jfrog",
+	manifest: {
+		capabilities: ["skills"],
+	},
+}
+
+export default plugin

--- a/plugins/jfrog/package.json
+++ b/plugins/jfrog/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "jfrog",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Cline plugin that bundles JFrog Platform and package safety skills.",
+  "cline": {
+    "plugins": [
+      {
+        "paths": [
+          "./index.ts"
+        ],
+        "capabilities": [
+          "skills"
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/jfrog/skills/jfrog-package-safety-and-download/SKILL.md
+++ b/plugins/jfrog/skills/jfrog-package-safety-and-download/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: jfrog-package-safety-and-download
+description: Use this skill when the user asks whether a package is safe, approved, curated, allowed, present in JFrog, or should be downloaded through Artifactory for npm, Maven, PyPI, Go, NuGet, Docker, or similar ecosystems.
+---
+
+# JFrog Package Safety And Download
+
+Use this workflow for package safety checks and package downloads through JFrog. For pure CVE lookups without a package download or approval question, use the base `jfrog` skill instead.
+
+## Prerequisites
+
+Read the `jfrog` skill first for server selection, authentication, command execution, and mutation safety. Resolve exactly one JFrog server before querying package state.
+
+## Workflow
+
+1. Identify the package ecosystem, name, and requested version. If the ecosystem is ambiguous, ask the user to choose.
+2. Search JFrog Public Catalog for the public package.
+3. If Public Catalog does not have it, search stored packages in the user's JFrog Platform.
+4. Determine the version to evaluate. Use the requested version if given; otherwise use the latest version reported by the authoritative source.
+5. Check whether that exact package version already exists in the user's JFrog Platform and record repository locations.
+6. If it exists in local or federated storage, report that it can be downloaded from JFrog and provide the exact download approach.
+7. If it exists only through a remote cache or is not cached, check whether curation is entitled and whether policy allows the package version.
+8. If curation blocks the package, report the block and stop. Do not download around policy.
+9. If allowed, download only through the approved Artifactory remote repository or curation-aware package manager path requested by the user.
+
+## Public Catalog and Stored Package Queries
+
+Use OneModel GraphQL through the same server resolved by the `jfrog` skill. Build payloads with `jq -n --arg` and save responses to temp files if more than one parsing pass is needed.
+
+When the package type is known, query the exact type and name first. When the package type is unknown, search by name and ask the user to disambiguate if multiple ecosystems match.
+
+Prefer these concepts when interpreting results:
+
+- Public package: package metadata, latest version, security and catalog signals from JFrog Public Catalog.
+- Stored package: package metadata and versions already known to the user's JFrog Platform.
+- Package version locations: repositories and artifact paths where that exact version exists.
+
+## Curation Check
+
+If curation is available, use the Xray curation package status API before download:
+
+```bash
+BODY="/tmp/jfrog-curation-$$.json"
+HTTP_CODE=$(jf xr curl -s -o "$BODY" -w "%{http_code}" \
+  -XPOST "/api/v1/curation/package_status/all_repos" \
+  -H "Content-Type: application/json" \
+  -d '{"packageType":"npm","packageName":"lodash","packageVersion":"4.17.21"}' \
+  --server-id <server-id>)
+echo "$HTTP_CODE"
+echo "$BODY"
+```
+
+Interpret HTTP results carefully:
+
+- `200`: package version is allowed by curation policy.
+- `403`: package version is blocked. Report the policy reason and stop.
+- Other status: report the failure and ask how to proceed.
+
+Supported package type values are usually lowercase values such as `npm`, `pypi`, `maven`, `go`, `nuget`, `docker`, and `gradle`.
+
+## Download Guidance
+
+Use a destination file path, not a bare directory, when downloading one artifact.
+
+For local or federated Artifactory locations:
+
+```bash
+jf rt dl "<repositoryKey>/<artifactPath>" "./downloads/<filename>" --flat --server-id <server-id>
+```
+
+For remote repositories, prefer the proxy endpoint when the artifact may not already be cached. If OneModel returns a `-cache` repository key, remove the `-cache` suffix to form the parent remote repository key for proxy endpoints.
+
+Common protocol path patterns:
+
+- npm: `/api/npm/<repo>/<pkg>/-/<pkg>-<version>.tgz`
+- PyPI: `/api/pypi/<repo>/packages/<pkg>/<version>/<pkg>-<version>.tar.gz`
+- Maven: `/<repo>/<group-path>/<artifact>/<version>/<artifact>-<version>.jar`
+- Go: `/api/go/<repo>/<module>/@v/<version>.zip`
+
+Always use redirects for binary downloads through remote endpoints:
+
+```bash
+jf rt curl -s -L -XGET "/api/npm/<repo>/<path>" -o "./downloads/<filename>" --server-id <server-id>
+```
+
+## Guardrails
+
+- Do not download a package that curation blocks.
+- Do not bypass JFrog by downloading directly from the public internet unless the user explicitly requests it after seeing the JFrog result.
+- Do not infer safety from popularity alone. Prefer JFrog catalog, stored package, Xray, and curation signals.
+- Do not mutate repository configuration to make a package downloadable unless the user explicitly asks.
+- Do not retry against another JFrog server after auth, permission, network, or not-found errors.
+- Ask before writing package files into the repository. Prefer a user-approved downloads directory.

--- a/plugins/jfrog/skills/jfrog/SKILL.md
+++ b/plugins/jfrog/skills/jfrog/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: jfrog
+description: Use this skill for JFrog Platform tasks involving Artifactory repositories and artifacts, Xray security scans, access tokens, users, groups, projects, build metadata, release bundles, evidence, AppTrust, curation, OneModel GraphQL, or JFrog CLI setup.
+---
+
+# JFrog Platform
+
+Use this skill when the user wants Cline to work with JFrog Platform resources through the user's configured JFrog CLI and APIs.
+
+## Requirements
+
+Before running JFrog commands, verify the needed local tools:
+
+- `jf` for JFrog CLI workflows
+- `curl` for REST and GraphQL requests
+- `jq` for JSON parsing
+
+If `jf` is missing, explain that the user needs to install the JFrog CLI and configure a server. Do not run interactive setup commands unless the user explicitly asks for setup help.
+
+## Server Selection
+
+Resolve exactly one target server before any operation:
+
+1. If the user names a server id, use only that server with `--server-id`.
+2. If the user does not name a server, inspect `jf config show` and use only the current default server.
+3. If there is no default or the named server is missing, stop and ask the user which server to use.
+
+Never fall back to another configured server after an error. A different server can hold different permissions, repositories, packages, and users.
+
+## Authentication
+
+Prefer existing `jf` configuration. For plain REST or GraphQL calls outside Artifactory and Xray, extract only the fields needed for the request. Do not print the decoded JFrog config:
+
+```bash
+CONFIG_JSON=$(jf config export <server-id> | base64 -d)
+JFROG_URL=$(printf '%s' "$CONFIG_JSON" | jq -r '.url // empty' | sed 's:/*$::')
+JFROG_ACCESS_TOKEN=$(printf '%s' "$CONFIG_JSON" | jq -r '.accessToken // empty')
+unset CONFIG_JSON
+```
+
+Use the base URL and access token only for the same resolved server. Do not print access tokens in chat, write them to files, or include them in command output.
+
+## Command Discovery
+
+Check help before using a command you are unsure about:
+
+```bash
+jf --help
+jf rt --help
+jf xr --help
+jf <command> --help
+```
+
+Common namespaces:
+
+- `jf rt`: Artifactory repositories, files, builds, permissions, users, groups, replication, properties, and AQL through REST.
+- `jf xr`: Xray watches, policies, violations, scans, curation, and security findings.
+- `jf config`: local server configuration.
+- `jf evd`: evidence.
+- `jf at` or `jf apptrust`: AppTrust.
+- `jf ds`: Distribution and release lifecycle.
+
+Do not use JFrog Pipelines APIs or `jf pl`; that product is sunset.
+
+## Execution Rules
+
+Before each JFrog operation:
+
+1. Confirm the operation is needed for the user's request.
+2. Resolve the server using the rules above.
+3. Prefer read-only discovery before mutation.
+4. Confirm with the user before create, update, delete, upload, token creation, permission changes, promotion, distribution, or any other privileged mutation. For high-impact actions, confirm after resolving the exact server and target resource, even if the user initially asked for the action.
+5. If a command fails with auth, permission, network, or not-found errors, stop and report the exact failure. Do not retry against another server.
+6. Do not invent helper mutations to satisfy preconditions. If an artifact, repo, build, project, or package is missing, report the gap and ask before creating, copying, uploading, or moving anything.
+
+## REST and GraphQL Patterns
+
+Use `jf rt curl` for Artifactory APIs:
+
+```bash
+jf rt curl -s -XGET /api/repositories --server-id <server-id> | jq .
+```
+
+Use `jf xr curl` for Xray APIs:
+
+```bash
+jf xr curl -s -XGET /api/v2/watches --server-id <server-id> | jq .
+```
+
+For other platform APIs, use `curl` with credentials from the same resolved server.
+
+For OneModel GraphQL, build JSON with `jq -n --arg` instead of manually escaping a GraphQL string:
+
+```bash
+QUERY='{ storedPackages { searchPackages(first: 5) { totalCount } } }'
+PAYLOAD=$(jq -n --arg q "$QUERY" '{"query": $q}')
+curl -s -XPOST "$JFROG_URL/onemodel/api/v1/graphql" \
+  -H "Authorization: Bearer $JFROG_ACCESS_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d "$PAYLOAD" | jq .
+```
+
+Save network responses to temp files when parsing may need retries:
+
+```bash
+OUT="/tmp/jfrog-response-$$.json"
+jf rt curl -s -XGET /api/repositories --server-id <server-id> > "$OUT"
+echo "$OUT"
+jq . "$OUT"
+```
+
+Do not repeat the same network request just to retry a `jq` filter.
+
+## Query and Operation Guidance
+
+- Artifacts and remote cache content: prefer direct Artifactory REST or AQL through `jf rt curl`; avoid broad unbounded searches.
+- Build metadata: include project or build repo scope when required by the server.
+- Xray findings: distinguish violations, vulnerabilities, contextual analysis, curation blocks, and policy definitions.
+- Access tokens: confirm scope, audience, expiry, and target user before creation.
+- Projects and permissions: read existing membership and roles before proposing changes.
+- Release lifecycle: inspect current bundle, stage, evidence, and promotion status before mutating.
+- GraphQL schemas can differ by deployment. If a GraphQL query fails validation, fetch the schema from the same server and adjust the query rather than guessing fields.
+
+## Safety Defaults
+
+- Use non-interactive commands. Avoid `jf config add`, `jf login`, and template wizard commands during normal workflows.
+- Do not expose secrets in responses.
+- Do not write reports, temporary JSON, or generated files into the user's repository unless asked.
+- Use temp files under `/tmp` for transient API responses.
+- Keep package and artifact downloads in a user-approved destination.
+- Treat JFrog server data as sensitive company data.


### PR DESCRIPTION
## jfrog

Adds a JFrog Platform plugin for Cline users who work with Artifactory, Xray, package curation, release lifecycle state, access tokens, projects, and related platform APIs.

The source material included a startup Agent Guard hook that conditionally injected MCP-management guidance after checking JFrog account settings. This Cline plugin intentionally does not run startup hooks or register MCP servers. The Cline-native shape is a bundled skills package: Cline only uses these workflows when a JFrog task calls for them, and any CLI or network activity happens through explicit tool calls in the user's session.

## Cline Primitives

This plugin bundles two skills:

- `jfrog`: Platform operations guidance for JFrog CLI, Artifactory REST, Xray REST, platform REST, and OneModel GraphQL workflows. It covers server selection, authentication handling, command discovery, read-first operation planning, and mutation safety.
- `jfrog-package-safety-and-download`: Package safety and download workflow for npm, Maven, PyPI, Go, NuGet, Docker, and similar ecosystems. It guides Cline through Public Catalog checks, stored package lookups, curation policy checks, Artifactory remote cache behavior, and safe download paths.

The skills are intentionally compact rather than a wholesale reference dump. They preserve the core workflow and safety guidance while avoiding a large vendored reference corpus and hidden session-start behavior.

## Requirements

Users need a JFrog Platform URL and access token, plus the JFrog CLI `jf` configured for CLI-backed operations. API and GraphQL workflows also expect `curl` and `jq` to be available, and network access to the relevant JFrog services.

The skills treat JFrog server data as sensitive. They require resolving exactly one target server before acting, avoid printing decoded credentials, prefer read operations before mutation, and require confirmation for high-impact actions such as deletes, permission changes, token creation, uploads, promotions, and distribution operations.

Package downloads also carry supply-chain risk. The package safety skill tells Cline to stop when curation blocks a package, avoid bypassing JFrog unless the user explicitly asks after seeing the result, and ask before writing package files into a repository.
