### PR TITLE
feat: add knowledge-catalog plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Each plugin lives in `plugins/<slug>`. The directory name is the install keyword
 | `gitignore-read-files-guard` | A hook that blocks file access to `.gitignore` ignored paths. |
 | `goal` | Completion nudges for active goals with a slash command and completion tool. |
 | `intercom-support-triage-slack` | Intercom conversation triage tools for support workflows. |
+| `knowledge-catalog` | Google Cloud Knowledge Catalog discovery skill. |
 | `linear` | Linear SDK scripting skill for issue, project, team, cycle, and comment workflows. |
 | `mac-notify` | macOS notifications when a Cline run completes. |
 | `nanobanana` | Image generation through OpenRouter and Gemini image models. |

--- a/plugins/knowledge-catalog/README.md
+++ b/plugins/knowledge-catalog/README.md
@@ -1,0 +1,43 @@
+# knowledge-catalog
+
+Adds Google Cloud Knowledge Catalog discovery workflows for Cline.
+
+## What It Does
+
+Installs the `knowledge-catalog-discovery` skill. The skill helps Cline search and inspect Google Cloud Knowledge Catalog and Dataplex metadata for data assets, entries, aspect types, and related context.
+
+The plugin does not register an MCP server, does not run install-time setup, and does not bundle wrapper scripts. When a task needs live catalog data, the skill guides Cline to run the official toolbox command explicitly through the user's configured Google Cloud environment.
+
+## Install
+
+```bash
+cline plugin install knowledge-catalog
+```
+
+For local development from this repository:
+
+```bash
+cline plugin install ./plugins/knowledge-catalog --cwd .
+```
+
+## Example Usage
+
+After installation, ask Cline:
+
+```text
+Find Knowledge Catalog entries related to customer orders in my analytics project and show the most relevant table metadata.
+```
+
+## Requirements
+
+- A Google Cloud project with the Dataplex API enabled.
+- Application Default Credentials available to the shell running Cline.
+- `DATAPLEX_PROJECT` set to the default project when the request does not specify one.
+- Node and npm available for `npx --yes @toolbox-sdk/server@1.1.0`.
+- IAM permissions for catalog reads, such as Knowledge Catalog viewer access with `dataplex.projects.search`, `dataplex.entries.get`, and aspect type read permissions. Enabling the API may require separate Service Usage permissions.
+
+## Security Notes
+
+Knowledge Catalog can reveal metadata about datasets, tables, views, owners, tags, and governance aspects. The skill defaults to bounded searches, asks for scope when a request is ambiguous, and does not perform catalog mutations.
+
+The toolbox command may download the `@toolbox-sdk/server` package through `npx` on first use. That does not happen during plugin installation.

--- a/plugins/knowledge-catalog/index.ts
+++ b/plugins/knowledge-catalog/index.ts
@@ -1,0 +1,10 @@
+import type { AgentPlugin } from "@cline/sdk"
+
+const plugin: AgentPlugin = {
+	name: "knowledge-catalog",
+	manifest: {
+		capabilities: ["skills"],
+	},
+}
+
+export default plugin

--- a/plugins/knowledge-catalog/package.json
+++ b/plugins/knowledge-catalog/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "knowledge-catalog",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Cline plugin that bundles a Google Cloud Knowledge Catalog discovery skill.",
+  "cline": {
+    "plugins": [
+      {
+        "paths": [
+          "./index.ts"
+        ],
+        "capabilities": [
+          "skills"
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/knowledge-catalog/skills/knowledge-catalog-discovery/SKILL.md
+++ b/plugins/knowledge-catalog/skills/knowledge-catalog-discovery/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: knowledge-catalog-discovery
+description: Use this skill to search and inspect Google Cloud Knowledge Catalog or Dataplex metadata, including catalog entries, entry context, data asset metadata, aspect types, tables, datasets, views, owners, and governance aspects.
+---
+
+# Knowledge Catalog Discovery
+
+Use this skill when the user wants to discover or inspect Google Cloud Knowledge Catalog metadata.
+
+## Requirements
+
+Before live catalog access:
+
+- Make sure a project or scope is known. If the user does not provide one, use `DATAPLEX_PROJECT` as `projects/$DATAPLEX_PROJECT`.
+- Make sure Node and npm are available before using `npx`.
+- Let the first bounded toolbox read reveal Application Default Credential, API enablement, IAM, or quota failures, then report the exact failure.
+
+If credentials or project context are missing, ask the user for the missing setup instead of guessing.
+
+## Execution Model
+
+Use the official toolbox server through `npx` only when live catalog data is needed:
+
+```bash
+npx --yes @toolbox-sdk/server@1.1.0 --log-level error --prebuilt dataplex invoke <tool-name> '<json-args>'
+```
+
+This may download `@toolbox-sdk/server` on first use. Do not run it only to prove the plugin exists.
+
+Set a Cline-specific user agent when useful:
+
+```bash
+npx --yes @toolbox-sdk/server@1.1.0 --log-level error --prebuilt dataplex --user-agent-metadata cline invoke search_entries '<json-args>'
+```
+
+## Tools
+
+### search_entries
+
+Searches catalog entries for data assets such as tables, datasets, and views.
+
+Use this for broad discovery, but keep searches bounded:
+
+```bash
+npx --yes @toolbox-sdk/server@1.1.0 --log-level error --prebuilt dataplex invoke search_entries '{"query":"type:table customer orders","scope":"projects/my-project","pageSize":5,"orderBy":"relevance"}'
+```
+
+Arguments:
+
+- `query`: required Dataplex search query. Prefer specific filters such as `type:table`, names, business terms, or owners.
+- `scope`: optional `projects/<project-id>`, `projects/<project-number>`, or `organizations/<org-id>`. If omitted by the user and `DATAPLEX_PROJECT` is set, use `projects/$DATAPLEX_PROJECT`.
+- `pageSize`: optional result count. Default to 5 for exploratory searches.
+- `orderBy`: optional. Common values are `relevance`, `last_modified_timestamp`, and `last_modified_timestamp asc`.
+
+Avoid broad unfiltered searches. If the user asks for a vague term, start with `pageSize:5` and refine from returned names and entry types.
+
+### lookup_entry
+
+Retrieves metadata for one specific entry resource name:
+
+```bash
+npx --yes @toolbox-sdk/server@1.1.0 --log-level error --prebuilt dataplex invoke lookup_entry '{"entry":"projects/my-project/locations/us/entryGroups/@bigquery/entries/table-entry","view":2}'
+```
+
+Arguments:
+
+- `entry`: required entry resource name.
+- `view`: optional. Use `2` for normal full metadata, `3` for custom aspect selection, or `4` when the user needs all aspects.
+- `aspectTypes`: optional array of aspect type names. Use only with view `3`.
+
+Use `lookup_entry` after `search_entries` finds a likely resource.
+
+### lookup_context
+
+Retrieves richer context and relationships for up to 10 resources in the same location:
+
+```bash
+npx --yes @toolbox-sdk/server@1.1.0 --log-level error --prebuilt dataplex invoke lookup_context '{"resources":["projects/my-project/locations/us/entryGroups/@bigquery/entries/table-entry"]}'
+```
+
+Use this to understand related assets, lineage-like context, or surrounding metadata after identifying candidate entries.
+
+### search_aspect_types
+
+Searches aspect types relevant to a term or governance concept:
+
+```bash
+npx --yes @toolbox-sdk/server@1.1.0 --log-level error --prebuilt dataplex invoke search_aspect_types '{"query":"pii","pageSize":5,"orderBy":"relevance"}'
+```
+
+Use this when the user asks about governance tags, business metadata, or custom aspects and you need to discover the right aspect type before requesting it from entries.
+
+## Workflow
+
+1. Clarify project, organization, location, and asset type when the request is ambiguous. If only project is missing and `DATAPLEX_PROJECT` is set, use `projects/$DATAPLEX_PROJECT`.
+2. Start with `search_entries` using a specific query and small `pageSize`.
+3. Use `lookup_entry` for the best candidates.
+4. Use `lookup_context` when relationships or nearby resources matter.
+5. Use `search_aspect_types` before requesting custom aspects by name.
+6. Summarize entry names, resource names, asset types, owners, descriptions, aspects, and any uncertainty.
+
+## Guardrails
+
+- Do not perform catalog mutations from this skill.
+- Do not run unbounded searches.
+- Do not expose credentials or ADC token material.
+- Do not assume a project if neither `DATAPLEX_PROJECT` nor the user provides one.
+- Treat catalog metadata as sensitive company data.
+- If a command fails due to credentials, IAM, API enablement, or quota, report the exact failure and stop.


### PR DESCRIPTION
## knowledge-catalog

Adds a Google Cloud Knowledge Catalog plugin for Cline users who need to discover and inspect Dataplex and Knowledge Catalog metadata from their coding workflow.

This is a skill-only plugin. It intentionally does not register an MCP server, run install-time setup, or copy agent-specific wrapper scripts. Live catalog access goes through explicit toolbox commands in the user's session, so installing the plugin does not download packages, contact Google Cloud, or mutate local configuration.

## Cline Primitives

This plugin bundles one skill: `knowledge-catalog-discovery`.

The skill guides Cline through bounded read workflows for:

- `search_entries` to find data assets such as tables, datasets, and views.
- `lookup_entry` to inspect a specific catalog entry.
- `lookup_context` to retrieve richer context and related resources.
- `search_aspect_types` to discover governance or business metadata aspects.

The skill uses the official toolbox command shape when live data is needed:

```text
npx --yes @toolbox-sdk/server@1.1.0 --log-level error --prebuilt dataplex invoke <tool-name> '<json-args>'
```

It keeps searches bounded by default, uses `DATAPLEX_PROJECT` as the default project scope when the user does not provide one, and reports credential, IAM, API enablement, or quota failures from the first bounded read instead of turning every lookup into a setup questionnaire.

## Requirements

Users need a Google Cloud project with the Dataplex API enabled, Application Default Credentials available to the shell running Cline, and Node/npm available for `npx`. For read workflows, the authenticated principal needs Knowledge Catalog read permissions such as catalog viewer access for project search, entry reads, and aspect type reads. Enabling APIs may require separate Service Usage permissions.

Knowledge Catalog metadata can expose sensitive information about datasets, tables, owners, tags, and governance aspects. The bundled skill does not perform catalog mutations, avoids unbounded searches, and tells Cline not to expose ADC token material.
