### PR TITLE
feat: add laravel-boost plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Each plugin lives in `plugins/<slug>`. The directory name is the install keyword
 | `gitignore-read-files-guard` | A hook that blocks file access to `.gitignore` ignored paths. |
 | `goal` | Completion nudges for active goals with a slash command and completion tool. |
 | `intercom-support-triage-slack` | Intercom conversation triage tools for support workflows. |
+| `laravel-boost` | Laravel Boost MCP tools from the active Laravel application. |
 | `linear` | Linear SDK scripting skill for issue, project, team, cycle, and comment workflows. |
 | `mac-notify` | macOS notifications when a Cline run completes. |
 | `nanobanana` | Image generation through OpenRouter and Gemini image models. |

--- a/plugins/laravel-boost/README.md
+++ b/plugins/laravel-boost/README.md
@@ -1,0 +1,31 @@
+# laravel-boost
+
+Connects Cline to Laravel Boost in the current Laravel application.
+
+## What It Does
+
+Registers the `laravel-boost` MCP server by running `php artisan boost:mcp` from the active workspace root. The active workspace root must be the Laravel application directory that contains `artisan`; for monorepos, install or run Cline with the Laravel app subdirectory as the workspace.
+
+Once Laravel Boost is installed and configured in the app, Cline can use the MCP tools exposed by that application for framework-aware Laravel development.
+
+## Install
+
+```bash
+cline plugin install laravel-boost
+```
+
+For local development from this repository:
+
+```bash
+cline plugin install ./plugins/laravel-boost --cwd /path/to/laravel-app
+```
+
+## Requirements
+
+- A Laravel application as the active workspace root, with `artisan` at the workspace root.
+- PHP available on `PATH`.
+- Laravel Boost installed and configured in the application so `php artisan boost:mcp` starts successfully.
+
+## Security Notes
+
+The MCP server runs inside the active Laravel project and can expose application-specific framework tools. Install it only in workspaces you trust, and review any Laravel Boost tools before allowing changes that affect application code, data, or configuration.

--- a/plugins/laravel-boost/index.ts
+++ b/plugins/laravel-boost/index.ts
@@ -1,0 +1,34 @@
+import type { AgentPlugin } from "@cline/core";
+
+const plugin: AgentPlugin = {
+	name: "laravel-boost",
+	manifest: {
+		capabilities: ["mcp"],
+	},
+
+	setup(api, ctx) {
+		const workspaceRoot = ctx.workspaceInfo?.rootPath?.trim();
+		if (!workspaceRoot) {
+			throw new Error(
+				"laravel-boost requires a workspace root so it can run php artisan boost:mcp from the Laravel application.",
+			);
+		}
+
+		api.registerMcpServer({
+			name: "laravel-boost",
+			transport: {
+				type: "stdio",
+				command: "php",
+				args: ["artisan", "boost:mcp"],
+				cwd: workspaceRoot,
+			},
+			metadata: {
+				description:
+					"Expose Laravel Boost MCP tools from the current Laravel application.",
+			},
+		});
+	},
+};
+
+export { plugin };
+export default plugin;


### PR DESCRIPTION
## Laravel Boost

Adds a Laravel Boost plugin for Cline users working inside Laravel applications. The plugin connects Cline to the app's own Laravel Boost MCP server so framework-aware tools can be exposed directly from the current project.

## Cline Primitives

This plugin registers one MCP server:

- `laravel-boost`: a stdio MCP server launched with `php artisan boost:mcp`.

The server is intentionally run from the active workspace root rather than from the installed plugin directory. That keeps the command scoped to the Laravel application the user is working in and avoids pretending Laravel Boost is a global service.

## Requirements

- The active Cline workspace root must be the Laravel app directory containing `artisan`.
- PHP must be available on `PATH`.
- Laravel Boost must already be installed and configured in the application.

For monorepos, users should install or run Cline with the Laravel app subdirectory as the workspace root. The plugin does not try to discover nested Laravel apps or install Laravel Boost automatically, which keeps install behavior predictable and avoids running project setup commands on behalf of the user.

## Trust Boundary

The MCP server runs application code through Artisan inside the workspace. Users should enable it only in Laravel projects they trust and review MCP tool actions before allowing changes that affect application code, data, or configuration.
