### PR TITLE
feat: add learning-output-style plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Each plugin lives in `plugins/<slug>`. The directory name is the install keyword
 | `gitignore-read-files-guard` | A hook that blocks file access to `.gitignore` ignored paths. |
 | `goal` | Completion nudges for active goals with a slash command and completion tool. |
 | `intercom-support-triage-slack` | Intercom conversation triage tools for support workflows. |
+| `learning-output-style` | Interactive learning guidance through a Cline prompt rule. |
 | `linear` | Linear SDK scripting skill for issue, project, team, cycle, and comment workflows. |
 | `mac-notify` | macOS notifications when a Cline run completes. |
 | `nanobanana` | Image generation through OpenRouter and Gemini image models. |

--- a/plugins/learning-output-style/README.md
+++ b/plugins/learning-output-style/README.md
@@ -1,0 +1,29 @@
+# learning-output-style
+
+Adds an interactive learning style to Cline sessions.
+
+## What It Does
+
+Registers a prompt rule that asks Cline to turn useful decision points into small learning opportunities. For coding tasks, Cline may point to an exact file location, show a focused snippet or pseudocode shape, explain the tradeoff, and ask the user to write a small contribution before continuing.
+
+The rule also asks Cline to add concise educational explanations for non-obvious implementation choices and codebase patterns. It avoids decorative formatting and keeps explanations focused on the current task.
+
+## Install
+
+```bash
+cline plugin install learning-output-style
+```
+
+For local development from this repository:
+
+```bash
+cline plugin install ./plugins/learning-output-style --cwd .
+```
+
+## Requirements
+
+- No external services, credentials, or local runtimes.
+
+## Security Notes
+
+This plugin changes Cline's behavior by adding instructions to the runtime prompt. It does not run shell commands or access files by itself, but it can make sessions more interactive and slower because Cline may ask for user-written code at meaningful decision points.

--- a/plugins/learning-output-style/index.ts
+++ b/plugins/learning-output-style/index.ts
@@ -1,0 +1,35 @@
+import type { AgentPlugin } from "@cline/core";
+
+const LEARNING_RULE = `Learning mode is enabled for this session.
+
+Use an interactive teaching style when it helps the user build understanding, but keep task completion as the priority.
+
+When a coding task has a meaningful decision point, consider asking the user to write a small contribution before you continue. Good opportunities include business logic, algorithm choices, error handling policy, data structure design, user experience tradeoffs, and architecture decisions where the user's domain knowledge matters.
+
+Before requesting a contribution:
+- Prefer asking in chat with a focused snippet, pseudocode shape, or exact file location instead of modifying source just to create a placeholder.
+- Only add TODOs or placeholders to source files when the user explicitly wants pair-programming participation or has agreed to pause implementation for their contribution.
+- Explain why the decision matters and name the tradeoffs.
+- Keep the requested contribution small, normally around 5 to 10 lines.
+
+Do not request user contributions for boilerplate, repetitive edits, obvious implementations, configuration churn, mechanical refactors, or urgent fixes where pausing would slow the user down.
+
+Add brief educational explanations when they clarify a non-obvious implementation choice or codebase pattern. Keep these notes concise, specific to the current task, free of decorative banners, and out of source files unless the user asks for documentation.`;
+
+const plugin: AgentPlugin = {
+	name: "learning-output-style",
+	manifest: {
+		capabilities: ["rules"],
+	},
+
+	setup(api) {
+		api.registerRule({
+			id: "learning-output-style:interactive-learning",
+			source: "learning-output-style",
+			content: LEARNING_RULE,
+		});
+	},
+};
+
+export { plugin };
+export default plugin;


### PR DESCRIPTION
## Learning Output Style

Adds a Cline plugin for users who want sessions to feel more like interactive learning and pair programming. When installed, Cline is guided to explain meaningful implementation choices and occasionally invite the user to write a small, decision-heavy contribution.

## Cline Primitives

This plugin registers one prompt rule:

- `learning-output-style:interactive-learning`: adds learning-mode guidance to the runtime prompt.

The rule keeps task completion as the priority. It asks Cline to request user contributions only around meaningful decision points such as business logic, algorithm choices, error handling policy, data structure design, UX tradeoffs, or architecture decisions. It also tells Cline to avoid pausing for boilerplate, mechanical edits, urgent fixes, or obvious implementations.

The implementation uses a Cline rule instead of a runtime hook because the plugin is pure behavioral guidance. There is no subprocess to run, no JSON hook protocol, and no install-time setup.

## Requirements

- No API keys, services, or local runtimes are required.
- Users should expect more interactive sessions. This plugin can slow down task completion because Cline may ask for small user-written snippets when the learning value is high.

## Trust Boundary

The plugin only changes prompt behavior. It does not run shell commands, install dependencies, register MCP servers, or access files by itself. The main practical risk is workflow friction: users who want fully autonomous execution should leave it disabled.
