### PR TITLE
feat: add shopify-liquid plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Each plugin lives in `plugins/<slug>`. The directory name is the install keyword
 | `linear` | Linear SDK scripting skill for issue, project, team, cycle, and comment workflows. |
 | `mac-notify` | macOS notifications when a Cline run completes. |
 | `nanobanana` | Image generation through OpenRouter and Gemini image models. |
+| `shopify-liquid` | Shopify Liquid theme skills plus local `shopify theme check` diagnostics. |
 | `speak` | Speaks completed Cline replies with ElevenLabs text to speech. |
 | `typescript-lsp` | TypeScript language service `goto_definition` support. |
 | `weather-metrics` | Demo weather tool plus runtime metrics hooks. |

--- a/plugins/shopify-liquid/LICENSE.shopify-liquid-skills
+++ b/plugins/shopify-liquid/LICENSE.shopify-liquid-skills
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) Shopify
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/plugins/shopify-liquid/NOTICE.shopify-liquid-skills
+++ b/plugins/shopify-liquid/NOTICE.shopify-liquid-skills
@@ -1,0 +1,11 @@
+Shopify Liquid skill content
+
+This plugin includes Shopify Liquid theme skill material adapted for the Cline
+plugin ecosystem. The source manifest identifies the material as authored by
+Shopify and licensed under the MIT License.
+
+Source repository: https://github.com/Shopify/liquid-skills
+
+Adaptations for this plugin include Cline package metadata, bounded local
+diagnostics via `liquid_theme_diagnostics`, Markdown style normalization for
+this repository, and Cline workflow notes for local theme-check usage.

--- a/plugins/shopify-liquid/README.md
+++ b/plugins/shopify-liquid/README.md
@@ -1,0 +1,35 @@
+# shopify-liquid
+
+Adds Shopify Liquid theme guidance and diagnostics to Cline.
+
+## What It Does
+
+Registers `liquid_theme_diagnostics`, which runs `shopify theme check` in the active workspace or a theme subdirectory and returns bounded output. This gives Cline a practical diagnostics primitive for Liquid themes without pretending Cline has a persistent language-server plugin surface.
+
+It also bundles three skills:
+
+- `shopify-liquid-themes`: Liquid syntax, theme architecture, sections, blocks, snippets, schema, filters, objects, and tags.
+- `liquid-theme-standards`: CSS, JavaScript, and HTML standards for Shopify themes.
+- `liquid-theme-a11y`: Accessibility patterns for Shopify Liquid theme components.
+
+## Install
+
+```bash
+cline plugin install shopify-liquid
+```
+
+For local development from this repository:
+
+```bash
+cline plugin install /absolute/path/to/cline-plugins/plugins/shopify-liquid --cwd /path/to/theme
+```
+
+## Requirements
+
+- A Shopify Liquid theme workspace.
+- Shopify CLI available on `PATH` for `liquid_theme_diagnostics`.
+- No account or network access is required for the bundled skills.
+
+## Security Notes
+
+The diagnostics tool runs the local `shopify theme check` command in the selected workspace directory. Review the workspace before running local tooling from untrusted projects.

--- a/plugins/shopify-liquid/README.md
+++ b/plugins/shopify-liquid/README.md
@@ -8,9 +8,9 @@ Registers `liquid_theme_diagnostics`, which runs `shopify theme check` in the ac
 
 It also bundles three skills:
 
-- `shopify-liquid-themes`: Liquid syntax, theme architecture, sections, blocks, snippets, schema, filters, objects, and tags.
-- `liquid-theme-standards`: CSS, JavaScript, and HTML standards for Shopify themes.
-- `liquid-theme-a11y`: Accessibility patterns for Shopify Liquid theme components.
+- `shopify-liquid-themes`: Liquid syntax, theme architecture, sections, blocks, snippets, schema, filters, objects, tags, and detailed reference tables.
+- `liquid-theme-standards`: CSS, JavaScript, and HTML standards for Shopify themes, including bundled CSS and JavaScript pattern references.
+- `liquid-theme-a11y`: Accessibility patterns for Shopify Liquid theme components, including bundled component, focus, and keyboard references.
 
 ## Install
 
@@ -33,3 +33,7 @@ cline plugin install /absolute/path/to/cline-plugins/plugins/shopify-liquid --cw
 ## Security Notes
 
 The diagnostics tool runs the local `shopify theme check` command in the selected workspace directory. Review the workspace before running local tooling from untrusted projects.
+
+## Third-Party Notice
+
+The bundled Shopify Liquid skill material is licensed under MIT. See `LICENSE.shopify-liquid-skills` and `NOTICE.shopify-liquid-skills`.

--- a/plugins/shopify-liquid/index.ts
+++ b/plugins/shopify-liquid/index.ts
@@ -1,5 +1,5 @@
 import { spawn } from "node:child_process";
-import { existsSync, statSync } from "node:fs";
+import { existsSync, realpathSync, statSync } from "node:fs";
 import { isAbsolute, relative, resolve } from "node:path";
 import { type AgentPlugin, createTool } from "@cline/core";
 
@@ -22,7 +22,7 @@ const DEFAULT_TIMEOUT_MS = 55_000;
 const MAX_TIMEOUT_MS = 55_000;
 const MAX_OUTPUT_CHARS = 20_000;
 
-let workspaceRoot = process.cwd();
+let workspaceRoot = realpathSync(process.cwd());
 
 function clampTimeout(value: unknown): number {
 	if (typeof value !== "number" || !Number.isFinite(value)) {
@@ -55,19 +55,21 @@ function assertWithinWorkspace(path: string): void {
 }
 
 function resolveThemeDirectory(rawPath: string | undefined): string {
-	const target = rawPath
+	const requestedPath = rawPath
 		? isAbsolute(rawPath)
 			? resolve(rawPath)
 			: resolve(workspaceRoot, rawPath)
 		: workspaceRoot;
-	assertWithinWorkspace(target);
-	if (!existsSync(target)) {
-		throw new Error(`Theme path does not exist: ${target}`);
+	assertWithinWorkspace(requestedPath);
+	if (!existsSync(requestedPath)) {
+		throw new Error(`Theme path does not exist: ${requestedPath}`);
 	}
-	if (!statSync(target).isDirectory()) {
-		throw new Error(`Theme path must be a directory: ${target}`);
+	if (!statSync(requestedPath).isDirectory()) {
+		throw new Error(`Theme path must be a directory: ${requestedPath}`);
 	}
-	return target;
+	const realTarget = realpathSync(requestedPath);
+	assertWithinWorkspace(realTarget);
+	return realTarget;
 }
 
 function appendBoundedOutput(
@@ -214,7 +216,9 @@ const plugin: AgentPlugin = {
 	},
 
 	setup(api, ctx) {
-		workspaceRoot = ctx.workspaceInfo?.rootPath?.trim() || process.cwd();
+		workspaceRoot = realpathSync(
+			resolve(ctx.workspaceInfo?.rootPath?.trim() || process.cwd()),
+		);
 		api.registerTool(liquidThemeDiagnostics);
 	},
 };

--- a/plugins/shopify-liquid/index.ts
+++ b/plugins/shopify-liquid/index.ts
@@ -1,0 +1,223 @@
+import { spawn } from "node:child_process";
+import { existsSync, statSync } from "node:fs";
+import { isAbsolute, relative, resolve } from "node:path";
+import { type AgentPlugin, createTool } from "@cline/core";
+
+interface LiquidThemeDiagnosticsInput {
+	path?: string;
+	timeoutMs?: number;
+}
+
+interface LiquidThemeDiagnosticsOutput {
+	command: string;
+	cwd: string;
+	exitCode: number | null;
+	signal: string | null;
+	timedOut: boolean;
+	stdout: string;
+	stderr: string;
+}
+
+const DEFAULT_TIMEOUT_MS = 55_000;
+const MAX_TIMEOUT_MS = 55_000;
+const MAX_OUTPUT_CHARS = 20_000;
+
+let workspaceRoot = process.cwd();
+
+function clampTimeout(value: unknown): number {
+	if (typeof value !== "number" || !Number.isFinite(value)) {
+		return DEFAULT_TIMEOUT_MS;
+	}
+	return Math.min(Math.max(Math.trunc(value), 1_000), MAX_TIMEOUT_MS);
+}
+
+function asString(value: unknown): string | undefined {
+	return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+function parseInput(input: unknown): LiquidThemeDiagnosticsInput {
+	if (!input || typeof input !== "object") {
+		return {};
+	}
+	const record = input as Record<string, unknown>;
+	return {
+		path: asString(record.path),
+		timeoutMs:
+			typeof record.timeoutMs === "number" ? record.timeoutMs : undefined,
+	};
+}
+
+function assertWithinWorkspace(path: string): void {
+	const rel = relative(workspaceRoot, path);
+	if (rel.startsWith("..") || isAbsolute(rel)) {
+		throw new Error("path must stay inside the active workspace");
+	}
+}
+
+function resolveThemeDirectory(rawPath: string | undefined): string {
+	const target = rawPath
+		? isAbsolute(rawPath)
+			? resolve(rawPath)
+			: resolve(workspaceRoot, rawPath)
+		: workspaceRoot;
+	assertWithinWorkspace(target);
+	if (!existsSync(target)) {
+		throw new Error(`Theme path does not exist: ${target}`);
+	}
+	if (!statSync(target).isDirectory()) {
+		throw new Error(`Theme path must be a directory: ${target}`);
+	}
+	return target;
+}
+
+function appendBoundedOutput(
+	current: string,
+	chunk: unknown,
+	onTruncated: () => void,
+): string {
+	const next = current + String(chunk);
+	if (next.length <= MAX_OUTPUT_CHARS) {
+		return next;
+	}
+	onTruncated();
+	return next.slice(-MAX_OUTPUT_CHARS);
+}
+
+function formatBoundedOutput(text: string, truncated: boolean): string {
+	const trimmed = text.trim();
+	return truncated ? `[truncated earlier output]\n${trimmed}` : trimmed;
+}
+
+async function runThemeCheck(
+	cwd: string,
+	timeoutMs: number,
+): Promise<LiquidThemeDiagnosticsOutput> {
+	return await new Promise((resolvePromise, reject) => {
+		const child = spawn("shopify", ["theme", "check"], {
+			cwd,
+			detached: process.platform !== "win32",
+			stdio: ["ignore", "pipe", "pipe"],
+		});
+
+		let stdout = "";
+		let stderr = "";
+		let stdoutTruncated = false;
+		let stderrTruncated = false;
+		let timedOut = false;
+		let settled = false;
+
+		const finish = (
+			exitCode: number | null,
+			signal: NodeJS.Signals | null,
+		): void => {
+			if (settled) {
+				return;
+			}
+			settled = true;
+			clearTimeout(timer);
+			resolvePromise({
+				command: "shopify theme check",
+				cwd,
+				exitCode,
+				signal,
+				timedOut,
+				stdout: formatBoundedOutput(stdout, stdoutTruncated),
+				stderr: formatBoundedOutput(stderr, stderrTruncated),
+			});
+		};
+
+		const killProcess = (): void => {
+			timedOut = true;
+			if (process.platform !== "win32" && child.pid) {
+				try {
+					process.kill(-child.pid, "SIGTERM");
+				} catch {}
+			} else {
+				child.kill("SIGTERM");
+			}
+			setTimeout(() => {
+				if (settled) {
+					return;
+				}
+				if (process.platform !== "win32" && child.pid) {
+					try {
+						process.kill(-child.pid, "SIGKILL");
+					} catch {}
+				} else {
+					child.kill("SIGKILL");
+				}
+			}, 2_000).unref();
+		};
+
+		const timer = setTimeout(killProcess, timeoutMs);
+
+		child.stdout?.on("data", (chunk) => {
+			stdout = appendBoundedOutput(stdout, chunk, () => {
+				stdoutTruncated = true;
+			});
+		});
+		child.stderr?.on("data", (chunk) => {
+			stderr = appendBoundedOutput(stderr, chunk, () => {
+				stderrTruncated = true;
+			});
+		});
+		child.on("error", (error) => {
+			settled = true;
+			clearTimeout(timer);
+			reject(
+				error instanceof Error && "code" in error && error.code === "ENOENT"
+					? new Error(
+							"Shopify CLI was not found. Install @shopify/cli and make sure `shopify` is on PATH.",
+						)
+					: error,
+			);
+		});
+		child.on("close", finish);
+	});
+}
+
+const liquidThemeDiagnostics = createTool<
+	LiquidThemeDiagnosticsInput,
+	LiquidThemeDiagnosticsOutput
+>({
+	name: "liquid_theme_diagnostics",
+	description:
+		"Run `shopify theme check` in a Shopify Liquid theme directory and return bounded diagnostics output.",
+	inputSchema: {
+		type: "object",
+		properties: {
+			path: {
+				type: "string",
+				description:
+					"Optional theme directory inside the workspace. Defaults to the workspace root.",
+			},
+			timeoutMs: {
+				type: "number",
+				description:
+					"Optional timeout in milliseconds. Defaults to 55000 and is capped at 55000.",
+			},
+		},
+		additionalProperties: false,
+	},
+	retryable: false,
+	async execute(rawInput) {
+		const input = parseInput(rawInput);
+		const cwd = resolveThemeDirectory(input.path);
+		return await runThemeCheck(cwd, clampTimeout(input.timeoutMs));
+	},
+});
+
+const plugin: AgentPlugin = {
+	name: "shopify-liquid",
+	manifest: {
+		capabilities: ["tools", "skills"],
+	},
+
+	setup(api, ctx) {
+		workspaceRoot = ctx.workspaceInfo?.rootPath?.trim() || process.cwd();
+		api.registerTool(liquidThemeDiagnostics);
+	},
+};
+
+export { plugin };
+export default plugin;

--- a/plugins/shopify-liquid/package.json
+++ b/plugins/shopify-liquid/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "shopify-liquid",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Cline plugin for Shopify Liquid theme development.",
+  "cline": {
+    "plugins": [
+      {
+        "paths": [
+          "./index.ts"
+        ],
+        "capabilities": [
+          "tools",
+          "skills"
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/shopify-liquid/skills/liquid-theme-a11y/SKILL.md
+++ b/plugins/shopify-liquid/skills/liquid-theme-a11y/SKILL.md
@@ -1,36 +1,480 @@
 ---
 name: liquid-theme-a11y
-description: Implement and review WCAG-oriented accessibility patterns in Shopify Liquid themes, including product cards, carousels, cart drawers, price display, forms, filters, modals, keyboard support, focus management, and ARIA usage.
+description: "Implement WCAG 2.2 accessibility patterns in Shopify Liquid themes. Covers e-commerce-specific components including product cards, carousels, cart drawers, price display, forms, filters, and modals. Use when building accessible theme components, fixing accessibility issues, or reviewing ARIA patterns in .liquid files."
 ---
 
-# Liquid Theme Accessibility
+# Accessibility for Shopify Liquid Themes
 
-Use this skill when creating or reviewing accessible Shopify theme components.
+## Cline Workflow
 
-## Core Rules
+Use these patterns while creating or reviewing accessible Shopify theme components. If local diagnostics are useful and the workspace is trusted, run the plugin's `liquid_theme_diagnostics` tool after meaningful theme changes; do not start unrelated Shopify CLI commands just because the skill is active.
 
-- Prefer semantic HTML before ARIA.
-- Keep all interactive controls keyboard reachable.
-- Provide visible `:focus-visible` states with sufficient contrast.
-- Respect `prefers-reduced-motion`.
-- Use one main landmark and clear navigation labels.
-- Keep heading levels in order.
-- Avoid hiding useful content from screen readers unless it is truly decorative or duplicated.
+## Core Principle
 
-## Common Patterns
+Every interactive component must work with keyboard only, screen readers, and reduced-motion preferences. Start with semantic HTML - add ARIA only when native semantics are insufficient.
 
-- Product cards: use an `article`, one primary link, useful image alt text, and clear price context.
-- Modals and cart drawers: use `dialog` where possible, trap focus, restore focus to the trigger, and close with Escape.
-- Carousels: provide previous and next buttons, pause autoplay, announce slide context, and avoid auto-advancing when reduced motion is preferred.
-- Forms: pair labels with inputs, use `aria-invalid` only for invalid fields, and connect errors with `aria-describedby`.
-- Filters: use `fieldset`, `legend`, buttons with `aria-expanded`, and preserve keyboard navigation.
-- Prices: include context for sale prices, compare-at prices, unit prices, and currency.
+## Decision Table: Which Pattern?
 
-## Review Checklist
+| Component | HTML Element | ARIA Pattern | Reference |
+|-----------|-------------|-------------|-----------|
+| Expandable content | `<details>/<summary>` | None needed | [Accordion](#accordion) |
+| Modal/dialog | `<dialog>` | `aria-modal="true"` | [Modal](#modal) |
+| Tooltip/popup | `[popover]` attribute | `role="tooltip"` fallback | [Tooltip](#tooltip) |
+| Dropdown menu | `<nav>` + `<ul>` | `aria-expanded` on triggers | [Navigation](#dropdown-navigation) |
+| Tab interface | `<div>` | `role="tablist/tab/tabpanel"` | [Tabs](#tabs) |
+| Carousel/slider | `<div>` | `role="region"` + `aria-roledescription` | [Carousel](#carousel) |
+| Product card | `<article>` | `aria-labelledby` | [Product card](#product-card) |
+| Form | `<form>` | `aria-invalid`, `aria-describedby` | [Forms](#forms) |
+| Cart drawer | `<dialog>` | Focus trap | [Cart drawer](#cart-drawer) |
+| Price display | `<span>` | `aria-label` for context | [Prices](#price-display) |
+| Filters | `<form>` + `<fieldset>` | `aria-expanded` for disclosures | [Filters](#product-filters) |
 
-- Can every action be completed with keyboard only?
-- Is focus order predictable after open, close, add, remove, and filter actions?
-- Are controls named by visible text or accurate labels?
-- Are dynamic updates announced only when helpful?
-- Does the theme preserve accessibility strings through locales?
-- Does the implementation avoid ARIA that conflicts with native semantics?
+## Page Structure
+
+### Landmarks
+
+```html
+<body>
+  <a href="#main-content" class="skip-link">{{ 'accessibility.skip_to_content' | t }}</a>
+  <header role="banner">
+    <nav aria-label="{{ 'accessibility.main_navigation' | t }}">...</nav>
+  </header>
+  <main id="main-content">
+    <!-- All page content inside main -->
+  </main>
+  <footer role="contentinfo">
+    <nav aria-label="{{ 'accessibility.footer_navigation' | t }}">...</nav>
+  </footer>
+</body>
+```
+
+- Single `<header>`, `<main>`, `<footer>` per page
+- Multiple `<nav>` elements must have distinct `aria-label`
+- All content must live inside a landmark
+
+### Skip Link
+
+```css
+.skip-link {
+  position: absolute;
+  inset-inline-start: -999px;
+  z-index: 999;
+}
+.skip-link:focus {
+  position: fixed;
+  inset-block-start: 0;
+  inset-inline-start: 0;
+  padding: 1rem;
+  background: var(--color-background);
+  color: var(--color-foreground);
+}
+```
+
+### Headings
+
+- One `<h1>` per page, never skip levels (h1 -> h3)
+- Use real heading elements, not styled divs
+- Template: `<h1>` is typically the page/product title
+
+## Focus Management
+
+### Focus Indicators
+
+```css
+/* All interactive elements */
+:focus-visible {
+  outline: 2px solid rgb(var(--color-focus));
+  outline-offset: 2px;
+}
+
+/* High contrast mode */
+@media (forced-colors: active) {
+  :focus-visible {
+    outline: 3px solid LinkText;
+  }
+}
+```
+
+- Minimum 3:1 contrast ratio for focus indicators
+- Use `:focus-visible` (not `:focus`) to avoid showing on click
+- Never `outline: none` without a visible replacement
+
+### Focus Trapping (Modals/Drawers)
+
+- Trap focus inside modals, drawers, and dialogs
+- Return focus to trigger element on close
+- First focusable element gets focus on open
+- Query all focusable elements: `a[href], button:not([disabled]), input:not([disabled]), select, textarea, [tabindex]:not([tabindex="-1"])`
+
+See [focus and keyboard patterns](references/focus-and-keyboard.md) for full FocusTrap implementation.
+
+## Component Patterns
+
+### Product Card
+
+```html
+<article class="product-card" aria-labelledby="ProductTitle-{{ product.id }}">
+  <a href="{{ product.url }}" class="product-card__link" aria-labelledby="ProductTitle-{{ product.id }}">
+    <img
+      src="{{ product.featured_image | image_url: width: 400 }}"
+      alt="{{ product.featured_image.alt | escape }}"
+      loading="lazy"
+      width="{{ product.featured_image.width }}"
+      height="{{ product.featured_image.height }}"
+    >
+  </a>
+  <h3 id="ProductTitle-{{ product.id }}">
+    <a href="{{ product.url }}">{{ product.title }}</a>
+  </h3>
+  <div class="product-card__price" aria-label="{{ 'products.price_label' | t: price: product.price | money }}">
+    {{ product.price | money }}
+  </div>
+  <button
+    class="product-card__quick-add"
+    aria-label="{{ 'products.quick_add' | t: title: product.title }}"
+  >
+    {{ 'products.add_to_cart' | t }}
+  </button>
+</article>
+```
+
+Rules:
+- Keep every actionable control keyboard reachable, including quick add
+- Avoid duplicate tab stops for the same destination; make secondary actions explicit
+- `aria-labelledby` on `<article>` pointing to the title
+- Descriptive alt text on images; empty `alt=""` if decorative
+
+### Carousel
+
+```html
+<div
+  role="region"
+  aria-roledescription="carousel"
+  aria-label="{{ section.settings.heading | escape }}"
+>
+  <div class="carousel__controls">
+    <button
+      aria-label="{{ 'accessibility.previous_slide' | t }}"
+      aria-controls="CarouselSlides-{{ section.id }}"
+    >{% render 'icon-chevron-left' %}</button>
+    <button
+      aria-label="{{ 'accessibility.next_slide' | t }}"
+      aria-controls="CarouselSlides-{{ section.id }}"
+    >{% render 'icon-chevron-right' %}</button>
+    <button
+      aria-label="{{ 'accessibility.pause_slideshow' | t }}"
+      aria-pressed="false"
+    >{% render 'icon-pause' %}</button>
+  </div>
+
+  <div id="CarouselSlides-{{ section.id }}" aria-live="polite">
+    {% for slide in section.blocks %}
+      <div
+        role="group"
+        aria-roledescription="slide"
+        aria-label="{{ 'accessibility.slide_n_of_total' | t: n: forloop.index, total: forloop.length }}"
+        {% unless forloop.first %}aria-hidden="true"{% endunless %}
+      >
+        {{ slide.settings.content }}
+      </div>
+    {% endfor %}
+  </div>
+</div>
+```
+
+Rules:
+- Auto-rotation minimum 5 seconds, pause on hover/focus
+- Play/pause button required for auto-rotating carousels
+- `aria-live="polite"` on slide container (set to `"off"` during auto-rotation)
+- `aria-hidden="true"` on inactive slides
+- Each slide: `role="group"` + `aria-roledescription="slide"`
+
+### Modal
+
+```html
+<dialog
+  id="Modal-{{ section.id }}"
+  aria-labelledby="ModalTitle-{{ section.id }}"
+  aria-modal="true"
+>
+  <div class="modal__header">
+    <h2 id="ModalTitle-{{ section.id }}">{{ title }}</h2>
+    <button
+      type="button"
+      aria-label="{{ 'accessibility.close' | t }}"
+      on:click="/closeModal"
+    >{% render 'icon-close' %}</button>
+  </div>
+  <div class="modal__content">
+    <!-- Content -->
+  </div>
+</dialog>
+```
+
+Rules:
+- Prefer native `<dialog>` element for modal UI when feasible. `showModal()` provides native modal behavior, Escape-to-close, and backdrop handling, but `role="dialog"` remains a valid fallback when native `<dialog>` is not a good fit.
+- `aria-labelledby` pointing to the title (not `aria-label` with a string - `aria-labelledby` stays in sync when the title changes)
+- Close on Escape key (native with `<dialog>`)
+- Focus first interactive element on open
+- Return focus to trigger on close
+
+### Cart Drawer
+
+Same as modal pattern but with additional:
+- Live region for cart count updates: `<span aria-live="polite" aria-atomic="true">`
+- Clear "remove item" buttons with `aria-label="{{ 'cart.remove_item' | t: title: item.title }}"`
+- Quantity inputs with associated labels
+
+### Forms
+
+```html
+<form action="{{ routes.cart_url }}" method="post">
+  <div class="form__field">
+    <label for="Email-{{ section.id }}">{{ 'forms.email' | t }}</label>
+    <input
+      type="email"
+      id="Email-{{ section.id }}"
+      name="email"
+      required
+      aria-required="true"
+      autocomplete="email"
+      aria-describedby="EmailError-{{ section.id }}"
+    >
+    <p
+      id="EmailError-{{ section.id }}"
+      class="form__error"
+      role="alert"
+      hidden
+    >{{ 'forms.email_required' | t }}</p>
+  </div>
+</form>
+```
+
+Rules:
+- Every input has a visible `<label>` with matching `for`/`id`
+- Use `<fieldset>/<legend>` for radio/checkbox groups
+- Error messages: `role="alert"` + `aria-describedby` linking to input
+- `aria-invalid="true"` on invalid inputs
+- `autocomplete` attributes on common fields
+- Required fields: `required` + `aria-required="true"` + visual indicator
+
+### Product Filters
+
+```html
+<form class="facets">
+  <div class="facets__group">
+    <button
+      type="button"
+      aria-expanded="false"
+      aria-controls="FilterColor-{{ section.id }}"
+    >{{ 'filters.color' | t }}</button>
+    <fieldset id="FilterColor-{{ section.id }}" hidden>
+      <legend class="visually-hidden">{{ 'filters.filter_by_color' | t }}</legend>
+      {% for color in colors %}
+        <label>
+          <input type="checkbox" name="filter.color" value="{{ color }}">
+          {{ color }}
+        </label>
+      {% endfor %}
+    </fieldset>
+  </div>
+  <div aria-live="polite" aria-atomic="true">
+    {{ 'filters.results_count' | t: count: results.size }}
+  </div>
+</form>
+```
+
+### Price Display
+
+```html
+{% if product.compare_at_price > product.price %}
+  <div class="price" aria-label="{{ 'products.sale_price_label' | t: sale_price: product.price | money, original_price: product.compare_at_price | money }}">
+    <s aria-hidden="true">{{ product.compare_at_price | money }}</s>
+    <span>{{ product.price | money }}</span>
+  </div>
+{% else %}
+  <div class="price" aria-label="{{ 'products.price_label' | t: price: product.price | money }}">
+    {{ product.price | money }}
+  </div>
+{% endif %}
+```
+
+- Use `aria-label` on both sale and regular price paths - screen readers need context for any price display
+- `aria-hidden="true"` on the visual strikethrough to avoid duplicate reading
+
+### Accordion
+
+```html
+<details>
+  <summary>{{ block.settings.heading }}</summary>
+  <div class="accordion__content">
+    {{ block.settings.content }}
+  </div>
+</details>
+```
+
+Native `<details>/<summary>` provides keyboard and screen reader support automatically.
+
+### Tabs
+
+```html
+<div role="tablist" aria-label="{{ 'accessibility.product_tabs' | t }}">
+  {% for tab in tabs %}
+    <button
+      role="tab"
+      id="Tab-{{ tab.id }}"
+      aria-selected="{% if forloop.first %}true{% else %}false{% endif %}"
+      aria-controls="Panel-{{ tab.id }}"
+      tabindex="{% if forloop.first %}0{% else %}-1{% endif %}"
+    >{{ tab.title }}</button>
+  {% endfor %}
+</div>
+{% for tab in tabs %}
+  <div
+    role="tabpanel"
+    id="Panel-{{ tab.id }}"
+    aria-labelledby="Tab-{{ tab.id }}"
+    {% unless forloop.first %}hidden{% endunless %}
+    tabindex="0"
+  >{{ tab.content }}</div>
+{% endfor %}
+```
+
+- Arrow keys navigate between tabs (left/right)
+- Only active tab has `tabindex="0"`, others `-1`
+
+### Dropdown Navigation
+
+```html
+<nav aria-label="{{ 'accessibility.main_navigation' | t }}">
+  <ul role="list">
+    {% for link in linklists.main-menu.links %}
+      <li>
+        {% if link.links.size > 0 %}
+          <button aria-expanded="false" aria-controls="Submenu-{{ forloop.index }}">
+            {{ link.title }}
+          </button>
+          <ul id="Submenu-{{ forloop.index }}" hidden role="list">
+            {% for child in link.links %}
+              <li><a href="{{ child.url }}">{{ child.title }}</a></li>
+            {% endfor %}
+          </ul>
+        {% else %}
+          <a href="{{ link.url }}">{{ link.title }}</a>
+        {% endif %}
+      </li>
+    {% endfor %}
+  </ul>
+</nav>
+```
+
+### Tooltip
+
+```html
+<button aria-describedby="Tooltip-{{ block.id }}">
+  {{ 'labels.info' | t }}
+</button>
+<div id="Tooltip-{{ block.id }}" role="tooltip" popover>
+  {{ block.settings.tooltip_text }}
+</div>
+```
+
+## Mobile Accessibility
+
+- Touch targets: minimum 44x44px, 8px spacing between targets
+- No orientation lock: never restrict to portrait/landscape
+- No hover-only content: everything accessible via tap
+- Use `dvh` instead of `vh` for mobile viewport units
+
+## Animation & Motion
+
+```css
+/* Always provide reduced motion */
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}
+```
+
+- No flashing above 3 times per second
+- Auto-playing animations need pause/stop controls
+- Meaningful animations only - don't animate for decoration
+
+## Visually Hidden Utility
+
+```css
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+```
+
+Use for screen-reader-only content like labels and descriptions.
+
+## Progressive Enhancement
+
+Interactive components should work without JavaScript where possible. Provide `<noscript>` fallbacks for JS-dependent controls:
+
+```html
+{%- comment -%} Variant picker with noscript fallback {%- endcomment -%}
+<variant-picker>
+  <!-- JS-enhanced radio buttons / swatches here -->
+</variant-picker>
+<noscript>
+  <select name="id" aria-label="{{ 'products.select_variant' | t }}">
+    {% for variant in product.variants %}
+      <option value="{{ variant.id }}" {% unless variant.available %}disabled{% endunless %}>
+        {{ variant.title }} - {{ variant.price | money }}
+      </option>
+    {% endfor %}
+  </select>
+</noscript>
+```
+
+### Live Region for Dynamic Updates
+
+When selections change (variants, filters, cart), announce the change to screen readers:
+
+```html
+<div aria-live="polite" aria-atomic="true" class="visually-hidden">
+  {{ 'products.variant_selected' | t: variant: selected_variant.title }}
+</div>
+```
+
+Use the clear-then-set pattern in JS to ensure announcements fire reliably:
+
+```javascript
+announce(message) {
+  this.liveRegion.textContent = '';
+  requestAnimationFrame(() => {
+    this.liveRegion.textContent = message;
+  });
+}
+```
+
+## Color Contrast
+
+| Element | Minimum Ratio |
+|---------|---------------|
+| Normal text (<18px / <14px bold) | 4.5:1 |
+| Large text (>=18px / >=14px bold) | 3:1 |
+| UI components & graphics | 3:1 |
+| Focus indicators | 3:1 |
+
+Never rely solely on color to convey information - always pair with text, icons, or patterns.
+
+## References
+
+- [Component accessibility patterns](references/component-patterns.md)
+- [Focus and keyboard patterns](references/focus-and-keyboard.md)

--- a/plugins/shopify-liquid/skills/liquid-theme-a11y/SKILL.md
+++ b/plugins/shopify-liquid/skills/liquid-theme-a11y/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: liquid-theme-a11y
+description: Implement and review WCAG-oriented accessibility patterns in Shopify Liquid themes, including product cards, carousels, cart drawers, price display, forms, filters, modals, keyboard support, focus management, and ARIA usage.
+---
+
+# Liquid Theme Accessibility
+
+Use this skill when creating or reviewing accessible Shopify theme components.
+
+## Core Rules
+
+- Prefer semantic HTML before ARIA.
+- Keep all interactive controls keyboard reachable.
+- Provide visible `:focus-visible` states with sufficient contrast.
+- Respect `prefers-reduced-motion`.
+- Use one main landmark and clear navigation labels.
+- Keep heading levels in order.
+- Avoid hiding useful content from screen readers unless it is truly decorative or duplicated.
+
+## Common Patterns
+
+- Product cards: use an `article`, one primary link, useful image alt text, and clear price context.
+- Modals and cart drawers: use `dialog` where possible, trap focus, restore focus to the trigger, and close with Escape.
+- Carousels: provide previous and next buttons, pause autoplay, announce slide context, and avoid auto-advancing when reduced motion is preferred.
+- Forms: pair labels with inputs, use `aria-invalid` only for invalid fields, and connect errors with `aria-describedby`.
+- Filters: use `fieldset`, `legend`, buttons with `aria-expanded`, and preserve keyboard navigation.
+- Prices: include context for sale prices, compare-at prices, unit prices, and currency.
+
+## Review Checklist
+
+- Can every action be completed with keyboard only?
+- Is focus order predictable after open, close, add, remove, and filter actions?
+- Are controls named by visible text or accurate labels?
+- Are dynamic updates announced only when helpful?
+- Does the theme preserve accessibility strings through locales?
+- Does the implementation avoid ARIA that conflicts with native semantics?

--- a/plugins/shopify-liquid/skills/liquid-theme-a11y/references/component-patterns.md
+++ b/plugins/shopify-liquid/skills/liquid-theme-a11y/references/component-patterns.md
@@ -1,0 +1,231 @@
+# Component Accessibility Patterns
+
+Detailed ARIA patterns for e-commerce components beyond what's covered in SKILL.md.
+
+## Color Swatches
+
+```html
+<fieldset>
+  <legend>{{ 'products.color' | t }}</legend>
+  {% for color in product.options_by_name['Color'].values %}
+    <button
+      type="button"
+      role="radio"
+      aria-checked="{% if color == selected_color %}true{% else %}false{% endif %}"
+      aria-label="{{ color }}"
+      style="background-color: {{ color | handleize }}"
+      class="color-swatch"
+    >
+      <span class="visually-hidden">{{ color }}</span>
+    </button>
+  {% endfor %}
+</fieldset>
+```
+
+- Use `role="radio"` with `aria-checked` for single-select swatches
+- Always provide text label (visually hidden if needed)
+- Never rely on color alone - include text or pattern
+
+## Breadcrumbs
+
+```html
+<nav aria-label="{{ 'accessibility.breadcrumb' | t }}">
+  <ol role="list">
+    <li><a href="/">{{ 'general.home' | t }}</a></li>
+    <li><a href="{{ collection.url }}">{{ collection.title }}</a></li>
+    <li aria-current="page">{{ product.title }}</li>
+  </ol>
+</nav>
+```
+
+- `aria-current="page"` on the current page (last item, no link)
+- Use `<ol>` for ordered list semantics
+
+## Tables (Size Charts, Specs)
+
+```html
+<table>
+  <caption class="visually-hidden">{{ 'products.size_chart' | t }}</caption>
+  <thead>
+    <tr>
+      <th scope="col">{{ 'products.size' | t }}</th>
+      <th scope="col">{{ 'products.chest' | t }}</th>
+      <th scope="col">{{ 'products.waist' | t }}</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for row in size_data %}
+      <tr>
+        <th scope="row">{{ row.size }}</th>
+        <td>{{ row.chest }}</td>
+        <td>{{ row.waist }}</td>
+      </tr>
+    {% endfor %}
+  </tbody>
+</table>
+```
+
+- Always use `<th scope="col|row">` for header cells
+- `<caption>` describes the table purpose
+- Wrap in scrollable container for mobile: `<div role="region" tabindex="0" aria-label="...">`
+
+## Slider / Range Input
+
+```html
+<div role="group" aria-label="{{ 'filters.price_range' | t }}">
+  <label for="PriceMin-{{ section.id }}">{{ 'filters.min_price' | t }}</label>
+  <input
+    type="range"
+    id="PriceMin-{{ section.id }}"
+    min="0"
+    max="{{ max_price }}"
+    value="{{ min_value }}"
+    aria-valuemin="0"
+    aria-valuemax="{{ max_price }}"
+    aria-valuenow="{{ min_value }}"
+    aria-valuetext="{{ min_value | money }}"
+  >
+
+  <label for="PriceMax-{{ section.id }}">{{ 'filters.max_price' | t }}</label>
+  <input
+    type="range"
+    id="PriceMax-{{ section.id }}"
+    min="0"
+    max="{{ max_price }}"
+    value="{{ max_value }}"
+    aria-valuetext="{{ max_value | money }}"
+  >
+</div>
+```
+
+- `aria-valuetext` provides human-readable value (e.g., "$25.00" instead of "2500")
+
+## Switch / Toggle
+
+```html
+<button
+  role="switch"
+  aria-checked="false"
+  aria-label="{{ 'settings.dark_mode' | t }}"
+>
+  <span class="switch__thumb"></span>
+</button>
+```
+
+- `role="switch"` with `aria-checked="true|false"`
+- Toggle with Space or Enter key
+
+## Combobox / Autocomplete
+
+```html
+<div class="combobox">
+  <label for="Search-{{ section.id }}">{{ 'search.label' | t }}</label>
+  <input
+    type="text"
+    id="Search-{{ section.id }}"
+    role="combobox"
+    aria-expanded="false"
+    aria-autocomplete="list"
+    aria-controls="SearchResults-{{ section.id }}"
+    aria-activedescendant=""
+  >
+  <ul id="SearchResults-{{ section.id }}" role="listbox" hidden>
+    <!-- Suggestions populated via JS -->
+  </ul>
+</div>
+```
+
+- Arrow keys navigate suggestions, update `aria-activedescendant`
+- Escape clears, Enter selects
+- `aria-expanded` reflects listbox visibility
+
+## Disclosure (Show/Hide)
+
+```html
+<button
+  type="button"
+  aria-expanded="false"
+  aria-controls="Content-{{ block.id }}"
+>
+  {{ block.settings.label }}
+</button>
+<div id="Content-{{ block.id }}" hidden>
+  {{ block.settings.content }}
+</div>
+```
+
+Simple show/hide toggle. If the content is a list of items (like a menu), prefer `<details>/<summary>`.
+
+## Product Media Gallery
+
+```html
+<div role="region" aria-label="{{ 'products.media_gallery' | t }}">
+  <div class="gallery__main" aria-live="polite">
+    <img
+      id="MainImage-{{ section.id }}"
+      src="{{ current_image | image_url: width: 800 }}"
+      alt="{{ current_image.alt | escape }}"
+    >
+  </div>
+
+  <div class="gallery__thumbnails" role="list">
+    {% for media in product.media %}
+      <button
+        role="listitem"
+        aria-current="{% if forloop.first %}true{% else %}false{% endif %}"
+        aria-label="{{ 'products.view_image_n' | t: n: forloop.index }}"
+      >
+        <img
+          src="{{ media | image_url: width: 100 }}"
+          alt=""
+          loading="lazy"
+        >
+      </button>
+    {% endfor %}
+  </div>
+</div>
+```
+
+- `aria-current="true"` on active thumbnail
+- Empty `alt=""` on thumbnails (label via `aria-label`)
+- `aria-live="polite"` on main image container
+
+## Flip Card
+
+```html
+<div class="flip-card" tabindex="0" aria-label="{{ 'general.flip_to_reveal' | t }}">
+  <div class="flip-card__front" aria-hidden="false">
+    <!-- Front content -->
+  </div>
+  <div class="flip-card__back" aria-hidden="true">
+    <!-- Back content -->
+  </div>
+</div>
+```
+
+- Both sides must be accessible (toggle `aria-hidden`)
+- Respect `prefers-reduced-motion`: instant flip instead of animation
+- Keyboard: Enter/Space to flip
+
+## Live Regions for Dynamic Updates
+
+```html
+<!-- Cart count -->
+<span aria-live="polite" aria-atomic="true" class="visually-hidden">
+  {{ 'cart.item_count' | t: count: cart.item_count }}
+</span>
+
+<!-- Filter results count -->
+<div aria-live="polite" aria-atomic="true">
+  {{ 'filters.showing_results' | t: count: results.size }}
+</div>
+
+<!-- Form success -->
+<div role="status" aria-live="polite">
+  {{ 'forms.success_message' | t }}
+</div>
+```
+
+- `aria-live="polite"` for non-urgent updates (cart count, filter results)
+- `role="alert"` for errors (implicitly `aria-live="assertive"`)
+- `aria-atomic="true"` to read entire region on update

--- a/plugins/shopify-liquid/skills/liquid-theme-a11y/references/focus-and-keyboard.md
+++ b/plugins/shopify-liquid/skills/liquid-theme-a11y/references/focus-and-keyboard.md
@@ -1,0 +1,194 @@
+# Focus & Keyboard Patterns
+
+## Focus Order Principles
+
+1. DOM order = tab order - never use positive `tabindex` values
+2. `tabindex="0"` makes non-interactive elements focusable (use sparingly)
+3. `tabindex="-1"` removes from tab order but allows programmatic focus
+4. Never reorder focus with CSS (`order`, `flex-direction: row-reverse`) without matching DOM order
+
+## Focus Trapping
+
+```javascript
+class FocusTrap {
+  #focusableSelector = 'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+  trap(container) {
+    const focusable = container.querySelectorAll(this.#focusableSelector);
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+
+    container.addEventListener('keydown', (e) => {
+      if (e.key !== 'Tab') return;
+      if (e.shiftKey && document.activeElement === first) {
+        e.preventDefault();
+        last.focus();
+      } else if (!e.shiftKey && document.activeElement === last) {
+        e.preventDefault();
+        first.focus();
+      }
+    });
+
+    first?.focus();
+  }
+}
+```
+
+## Focus Management Patterns
+
+### Opening a Modal/Drawer
+
+```javascript
+openModal(trigger) {
+  this.lastFocusedElement = trigger; // Save return target
+  this.dialog.showModal();
+  const firstFocusable = this.dialog.querySelector(
+    'button, [href], input:not([disabled]), select, textarea, [tabindex]:not([tabindex="-1"])'
+  );
+  firstFocusable?.focus();
+}
+
+closeModal() {
+  this.dialog.close();
+  this.lastFocusedElement?.focus(); // Return focus
+}
+```
+
+### Dynamic Content Updates
+
+When content is loaded dynamically (AJAX filtering, infinite scroll):
+
+```javascript
+async loadContent(url) {
+  const response = await fetch(url);
+  const html = await response.text();
+  this.container.innerHTML = html;
+
+  // Announce to screen readers
+  this.liveRegion.textContent = `${resultCount} results loaded`;
+
+  // Move focus to results (not back to filter)
+  const firstResult = this.container.querySelector('.result-item');
+  firstResult?.focus();
+}
+```
+
+### Removing an Item
+
+When an item is removed from a list (cart items, wishlist):
+
+```javascript
+removeItem(item) {
+  const nextItem = item.nextElementSibling || item.previousElementSibling;
+  item.remove();
+
+  if (nextItem) {
+    nextItem.querySelector('button, a')?.focus();
+  } else {
+    // List is empty - focus the empty state or heading
+    this.emptyMessage?.focus();
+  }
+}
+```
+
+## Keyboard Shortcuts by Component
+
+### Tab List
+| Key | Action |
+|-----|--------|
+| Left/Right Arrow | Move between tabs |
+| Home | First tab |
+| End | Last tab |
+| Enter/Space | Activate tab |
+
+### Carousel
+| Key | Action |
+|-----|--------|
+| Left/Right Arrow | Previous/next slide |
+| Enter/Space | Pause/resume auto-rotation |
+
+### Combobox
+| Key | Action |
+|-----|--------|
+| Down Arrow | Open listbox / next option |
+| Up Arrow | Previous option |
+| Enter | Select current option |
+| Escape | Close listbox |
+
+### Modal/Dialog
+| Key | Action |
+|-----|--------|
+| Escape | Close |
+| Tab | Cycle through focusable elements (trapped) |
+| Shift+Tab | Reverse cycle |
+
+### Dropdown Menu
+| Key | Action |
+|-----|--------|
+| Enter/Space | Open submenu |
+| Escape | Close submenu |
+| Arrow keys | Navigate items |
+
+## Roving Tabindex Pattern
+
+For widget groups where only one item should be in tab order:
+
+```javascript
+class TabList {
+  #tabs;
+  #activeIndex = 0;
+
+  handleKeydown(event) {
+    const { key } = event;
+    let newIndex = this.#activeIndex;
+
+    if (key === 'ArrowRight') newIndex++;
+    else if (key === 'ArrowLeft') newIndex--;
+    else if (key === 'Home') newIndex = 0;
+    else if (key === 'End') newIndex = this.#tabs.length - 1;
+    else return;
+
+    event.preventDefault();
+
+    // Wrap around
+    newIndex = (newIndex + this.#tabs.length) % this.#tabs.length;
+
+    // Update tabindex
+    this.#tabs[this.#activeIndex].tabIndex = -1;
+    this.#tabs[newIndex].tabIndex = 0;
+    this.#tabs[newIndex].focus();
+
+    this.#activeIndex = newIndex;
+  }
+}
+```
+
+Use for: tab lists, radio groups, toolbars, menu bars.
+
+## Screen Reader Announcements
+
+### Pattern: Live Region Update
+
+```javascript
+announce(message) {
+  // Use existing live region
+  const region = document.querySelector('[aria-live="polite"]');
+  if (!region) return;
+
+  // Clear and re-set to trigger announcement
+  region.textContent = '';
+  requestAnimationFrame(() => {
+    region.textContent = message;
+  });
+}
+```
+
+### When to Announce
+
+| Event | Urgency | Method |
+|-------|---------|--------|
+| Cart item added | Polite | `aria-live="polite"` |
+| Form error | Assertive | `role="alert"` |
+| Filter results count | Polite | `aria-live="polite"` + `aria-atomic="true"` |
+| Page loaded (SPA) | Polite | Update `<title>` + announce |
+| Countdown timer | Polite | Update every 30s, not every second |

--- a/plugins/shopify-liquid/skills/liquid-theme-standards/SKILL.md
+++ b/plugins/shopify-liquid/skills/liquid-theme-standards/SKILL.md
@@ -1,0 +1,40 @@
+---
+name: liquid-theme-standards
+description: Apply CSS, JavaScript, and HTML coding standards for Shopify Liquid themes. Use when writing theme CSS, JavaScript, HTML, or component markup in .liquid files or theme assets.
+---
+
+# Liquid Theme Standards
+
+Use progressive enhancement: semantic HTML first, CSS second, JavaScript third.
+
+## CSS
+
+- Use theme design tokens and CSS custom properties instead of hardcoded colors, spacing, and typography.
+- Use logical properties such as `margin-inline`, `padding-block`, and `inset-inline-start` for RTL-friendly layouts.
+- Prefer single-class selectors and keep specificity low.
+- Avoid `!important` unless there is a documented theme integration reason.
+- Use BEM-style names when the theme already does: `.product-card`, `.product-card__title`, `.product-card--featured`.
+- Use `{% style %}` or inline custom properties for Liquid-driven values. Do not put Liquid inside `{% stylesheet %}`.
+
+## JavaScript
+
+- Prefer native browser APIs and custom elements over third-party dependencies.
+- Keep behavior resilient when JavaScript fails.
+- Scope DOM queries to the component root.
+- Clean up event listeners, observers, and timers when components disconnect.
+- Respect reduced-motion preferences for animations and scrolling.
+
+## HTML
+
+- Start from semantic elements: `button`, `a`, `form`, `details`, `summary`, `dialog`, `nav`, `main`, `section`, and `article`.
+- Keep image width, height, lazy-loading, and alt text intentional.
+- Use translation keys for merchant-facing labels and accessibility strings when the theme uses locales.
+- Preserve theme editor compatibility by keeping schema IDs stable unless the user asked for a breaking migration.
+
+## Review Checklist
+
+- Does the code match existing theme conventions?
+- Are settings names, defaults, and translation keys consistent?
+- Is CSS scoped and responsive?
+- Does JavaScript work with multiple section instances?
+- Can the component degrade gracefully without JavaScript?

--- a/plugins/shopify-liquid/skills/liquid-theme-standards/SKILL.md
+++ b/plugins/shopify-liquid/skills/liquid-theme-standards/SKILL.md
@@ -1,40 +1,433 @@
 ---
 name: liquid-theme-standards
-description: Apply CSS, JavaScript, and HTML coding standards for Shopify Liquid themes. Use when writing theme CSS, JavaScript, HTML, or component markup in .liquid files or theme assets.
+description: "CSS, JavaScript, and HTML coding standards for Shopify Liquid themes. Covers BEM naming inside stylesheet tags, design tokens, CSS custom properties, Web Components for themes, defensive CSS, and progressive enhancement. Use when writing CSS/JS/HTML in .liquid files or theme asset files."
 ---
 
-# Liquid Theme Standards
+# CSS, JS & HTML Standards for Shopify Liquid Themes
 
-Use progressive enhancement: semantic HTML first, CSS second, JavaScript third.
+## Cline Workflow
 
-## CSS
+Use these standards while editing Liquid, CSS, JavaScript, and HTML in a Shopify theme. If local diagnostics are useful and the workspace is trusted, run the plugin's `liquid_theme_diagnostics` tool after meaningful changes; it runs bounded `shopify theme check` output rather than a persistent language server.
 
-- Use theme design tokens and CSS custom properties instead of hardcoded colors, spacing, and typography.
-- Use logical properties such as `margin-inline`, `padding-block`, and `inset-inline-start` for RTL-friendly layouts.
-- Prefer single-class selectors and keep specificity low.
-- Avoid `!important` unless there is a documented theme integration reason.
-- Use BEM-style names when the theme already does: `.product-card`, `.product-card__title`, `.product-card--featured`.
-- Use `{% style %}` or inline custom properties for Liquid-driven values. Do not put Liquid inside `{% stylesheet %}`.
+## Core Principles
 
-## JavaScript
+1. Progressive enhancement - semantic HTML first, CSS second, JS third
+2. No external dependencies - native browser APIs only for JavaScript
+3. Design tokens - never hardcode colors, spacing, or fonts
+4. BEM naming - consistent class naming throughout
+5. Defensive CSS - handle edge cases gracefully
 
-- Prefer native browser APIs and custom elements over third-party dependencies.
-- Keep behavior resilient when JavaScript fails.
-- Scope DOM queries to the component root.
-- Clean up event listeners, observers, and timers when components disconnect.
-- Respect reduced-motion preferences for animations and scrolling.
+## CSS in Liquid Themes
 
-## HTML
+### Where CSS Lives
 
-- Start from semantic elements: `button`, `a`, `form`, `details`, `summary`, `dialog`, `nav`, `main`, `section`, and `article`.
-- Keep image width, height, lazy-loading, and alt text intentional.
-- Use translation keys for merchant-facing labels and accessibility strings when the theme uses locales.
-- Preserve theme editor compatibility by keeping schema IDs stable unless the user asked for a breaking migration.
+| Location | Liquid? | Use For |
+|----------|---------|---------|
+| `{% stylesheet %}` | No | Component-scoped styles (one per file) |
+| `{% style %}` | Yes | Dynamic values needing Liquid (e.g., color settings) |
+| `assets/*.css` | No | Shared/global styles |
 
-## Review Checklist
+Critical: `{% stylesheet %}` does NOT process Liquid. Use inline `style` attributes for dynamic values:
 
-- Does the code match existing theme conventions?
-- Are settings names, defaults, and translation keys consistent?
-- Is CSS scoped and responsive?
-- Does JavaScript work with multiple section instances?
-- Can the component degrade gracefully without JavaScript?
+```liquid
+{%- comment -%} Do: inline variables {%- endcomment -%}
+<div
+  class="hero"
+  style="--bg-color: {{ section.settings.bg_color }}; --padding: {{ section.settings.padding }}px;"
+>
+
+{%- comment -%} Don't: Liquid inside stylesheet {%- endcomment -%}
+{% stylesheet %}
+  .hero { background: {{ section.settings.bg_color }}; } /* Won't work */
+{% endstylesheet %}
+```
+
+### BEM Naming Convention
+
+```
+.block                      -> Component root: .product-card
+.block__element             -> Child: .product-card__title
+.block--modifier            -> Variant: .product-card--featured
+.block__element--modifier   -> Element variant: .product-card__title--large
+```
+
+Rules:
+- Hyphens separate words: `.product-card`, not `.productCard`
+- Single element level only: `.block__element`, never `.block__el1__el2`
+- Modifier always paired with base class: `class="btn btn--primary"`, never `class="btn--primary"` alone
+- Start new BEM scope when a child could be standalone
+
+```html
+<!-- Good: single element level -->
+<div class="product-card">
+  <h3 class="product-card__title">{{ product.title }}</h3>
+  <span class="product-card__button-label">{{ 'add_to_cart' | t }}</span>
+</div>
+
+<!-- Good: new BEM scope for standalone component -->
+<div class="product-card">
+  <button class="button button--primary">
+    <span class="button__label">{{ 'add_to_cart' | t }}</span>
+  </button>
+</div>
+```
+
+### Specificity
+
+- Target `0 1 0` (single class) wherever possible
+- Maximum `0 4 0` for complex parent-child cases
+- Never use IDs as selectors
+- Never use `!important` (comment why if absolutely forced to)
+- Avoid element selectors - use classes
+
+### CSS Nesting
+
+```css
+/* Do: media queries inside selectors */
+.header {
+  width: 100%;
+
+  @media screen and (min-width: 750px) {
+    width: auto;
+  }
+}
+
+/* Do: state modifiers with & */
+.button {
+  background: var(--color-primary);
+
+  &:hover { background: var(--color-primary-hover); }
+  &:focus-visible { outline: 2px solid var(--color-focus); }
+  &[disabled] { opacity: 0.5; }
+}
+
+/* Do: parent modifier affecting children (single level) */
+.card--featured {
+  .card__title { font-size: var(--font-size-xl); }
+}
+
+/* Don't: nested beyond first level */
+.parent {
+  .child {
+    .grandchild { } /* Too deep */
+  }
+}
+```
+
+### Design Tokens
+
+Use CSS custom properties for all values - never hardcode colors, spacing, or fonts. Define a consistent scale and reference it everywhere.
+
+Example scale (adapt to your theme's needs):
+
+```css
+:root {
+  /* Spacing - use a consistent scale */
+  --space-2xs: 0.5rem;    --space-xs: 0.75rem;   --space-sm: 1rem;
+  --space-md: 1.5rem;     --space-lg: 2rem;       --space-xl: 3rem;
+
+  /* Typography - relative units */
+  --font-size-sm: 0.875rem;  --font-size-base: 1rem;
+  --font-size-lg: 1.125rem;  --font-size-xl: 1.25rem;  --font-size-2xl: 1.5rem;
+}
+```
+
+Key principles:
+- Use `rem` for spacing and typography (respects user font size preferences)
+- Name tokens semantically: `--space-sm` not `--space-16`
+- Define in `:root` for global tokens, on component root for scoped tokens
+
+### CSS Variable Scoping
+
+Global - in `:root` for theme-wide values
+Component-scoped - on component root, namespaced:
+
+```css
+/* Do: namespaced */
+.facets {
+  --facets-padding: var(--space-md);
+  --facets-z-index: 3;
+}
+
+/* Don't: generic names that collide */
+.facets {
+  --padding: var(--space-md);
+  --z-index: 3;
+}
+```
+
+Override via inline style for section/block settings:
+
+```liquid
+<section
+  class="hero"
+  style="
+    --hero-bg: {{ section.settings.bg_color }};
+    --hero-padding: {{ section.settings.padding }}px;
+  "
+>
+```
+
+### CSS Property Order
+
+1. Layout - `position`, `display`, `flex-direction`, `grid-template-columns`
+2. Box model - `width`, `margin`, `padding`, `border`
+3. Typography - `font-family`, `font-size`, `line-height`, `color`
+4. Visual - `background`, `opacity`, `border-radius`
+5. Animation - `transition`, `animation`
+
+### Logical Properties (RTL Support)
+
+```css
+/* Do: logical properties */
+padding-inline: 2rem;
+padding-block: 1rem;
+margin-inline: auto;
+border-inline-end: 1px solid var(--color-border);
+text-align: start;
+inset: 0;
+
+/* Don't: physical properties */
+padding-left: 2rem;
+text-align: left;
+top: 0; right: 0; bottom: 0; left: 0;
+```
+
+### Defensive CSS
+
+```css
+.component {
+  overflow-wrap: break-word;        /* Prevent text overflow */
+  min-width: 0;                     /* Allow flex items to shrink */
+  max-width: 100%;                  /* Constrain images/media */
+  isolation: isolate;               /* Create stacking context */
+}
+
+.image-container {
+  aspect-ratio: 4 / 3;             /* Prevent layout shift */
+  background: var(--color-surface); /* Fallback for missing images */
+}
+```
+
+### Modern CSS Features
+
+```css
+/* Container queries for responsive components */
+.product-grid { container-type: inline-size; }
+@container (min-width: 400px) {
+  .product-card { grid-template-columns: 1fr 1fr; }
+}
+
+/* Fluid spacing */
+.section { padding: clamp(1rem, 4vw, 3rem); }
+
+/* Intrinsic sizing */
+.content { width: min(100%, 800px); }
+```
+
+### Performance
+
+- Animate only `transform` and `opacity` (never layout properties)
+- Use `will-change` sparingly - remove after animation
+- Use `contain: content` for isolated rendering
+- Use `dvh` instead of `vh` on mobile
+
+### Reduced Motion
+
+```css
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}
+```
+
+## JavaScript in Liquid Themes
+
+### Where JS Lives
+
+| Location | Liquid? | Use For |
+|----------|---------|---------|
+| `{% javascript %}` | No | Component-specific scripts (one per file) |
+| `assets/*.js` | No | Shared utilities, Web Components |
+
+### Web Component Pattern
+
+```javascript
+class ProductCard extends HTMLElement {
+  connectedCallback() {
+    this.button = this.querySelector('[data-add-to-cart]');
+    this.button?.addEventListener('click', this.#handleClick.bind(this));
+  }
+
+  disconnectedCallback() {
+    // Clean up event listeners, abort controllers
+  }
+
+  async #handleClick(event) {
+    event.preventDefault();
+    this.button.disabled = true;
+
+    try {
+      const formData = new FormData();
+      formData.append('id', this.dataset.variantId);
+      formData.append('quantity', '1');
+
+      const response = await fetch('/cart/add.js', {
+        method: 'POST',
+        body: formData
+      });
+
+      if (!response.ok) throw new Error('Failed');
+
+      this.dispatchEvent(new CustomEvent('cart:item-added', {
+        detail: await response.json(),
+        bubbles: true
+      }));
+    } catch (error) {
+      console.error('Add to cart error:', error);
+    } finally {
+      this.button.disabled = false;
+    }
+  }
+}
+
+customElements.define('product-card', ProductCard);
+```
+
+```liquid
+<product-card data-variant-id="{{ product.selected_or_first_available_variant.id }}">
+  <button data-add-to-cart>{{ 'products.add_to_cart' | t }}</button>
+</product-card>
+```
+
+### JavaScript Rules
+
+| Rule | Do | Don't |
+|------|-----|-------|
+| Loops | `for (const item of items)` | `items.forEach()` |
+| Async | `async`/`await` | `.then()` chains |
+| Variables | `const` by default | `let` unless reassigning |
+| Conditionals | Early returns | Nested `if/else` |
+| URLs | `new URL()` + `URLSearchParams` | String concatenation |
+| Dependencies | Native browser APIs | External libraries |
+| Private methods | `#methodName()` | `_methodName()` |
+| Types | JSDoc `@typedef`, `@param`, `@returns` | Untyped |
+
+### AbortController for Fetch
+
+```javascript
+class DataLoader extends HTMLElement {
+  #controller = null;
+
+  async load(url) {
+    this.#controller?.abort();
+    this.#controller = new AbortController();
+
+    try {
+      const response = await fetch(url, { signal: this.#controller.signal });
+      if (!response.ok) throw new Error(`HTTP ${response.status}`);
+      return await response.json();
+    } catch (error) {
+      if (error.name !== 'AbortError') throw error;
+      return null;
+    }
+  }
+
+  disconnectedCallback() {
+    this.#controller?.abort();
+  }
+}
+```
+
+### Component Communication
+
+Parent -> Child: Call public methods
+```javascript
+this.querySelector('child-component')?.publicMethod(data);
+```
+
+Child -> Parent: Dispatch custom events
+```javascript
+this.dispatchEvent(new CustomEvent('child:action', {
+  detail: { value },
+  bubbles: true
+}));
+```
+
+## HTML Standards
+
+### Native Elements First
+
+| Need | Use | Not |
+|------|-----|-----|
+| Expandable | `<details>/<summary>` | Custom accordion with JS |
+| Dialog/modal | `<dialog>` | Custom overlay div |
+| Tooltip/popup | `popover` attribute | Custom positioned div |
+| Search form | `<search>` | `<div class="search">` |
+| Form results | `<output>` | `<span class="result">` |
+
+### Progressive Enhancement
+
+```liquid
+{%- comment -%} Works without JS {%- endcomment -%}
+<details class="accordion">
+  <summary>{{ block.settings.heading }}</summary>
+  <div class="accordion__content">
+    {{ block.settings.content }}
+  </div>
+</details>
+
+{%- comment -%} Enhanced with JS {%- endcomment -%}
+{% javascript %}
+  // Optional: smooth animation, analytics tracking
+{% endjavascript %}
+```
+
+### Images
+
+```liquid
+{{ image | image_url: width: 800 | image_tag:
+  loading: 'lazy',
+  alt: image.alt | escape,
+  width: image.width,
+  height: image.height
+}}
+```
+
+- `loading="lazy"` on all below-fold images
+- Always set `width` and `height` to prevent layout shift
+- Descriptive `alt` text; empty `alt=""` for decorative images
+
+## JSON Template & Config Files
+
+Theme templates (`templates/*.json`), section groups (`sections/*.json`), and config files (`config/settings_data.json`) are all JSON. Use `jq` via the `bash` tool to make surgical edits - it's safer and more reliable than string-based find-and-replace for structured data.
+
+### Common patterns
+
+```bash
+# Add a section to a template
+jq '.sections.new_section = {"type": "hero", "settings": {"heading": "Welcome"}}' templates/index.json > /tmp/out && mv /tmp/out templates/index.json
+
+# Update a setting value
+jq '.current.sections.header.settings.logo_width = 200' config/settings_data.json > /tmp/out && mv /tmp/out config/settings_data.json
+
+# Reorder sections
+jq '.order += ["new_section"]' templates/index.json > /tmp/out && mv /tmp/out templates/index.json
+
+# Remove a section
+jq 'del(.sections.old_banner) | .order -= ["old_banner"]' templates/index.json > /tmp/out && mv /tmp/out templates/index.json
+
+# Read a nested value
+jq '.sections.header.settings' templates/index.json
+```
+
+Prefer `jq` over `edit` for any `.json` file modification - it validates structure, handles escaping, and avoids whitespace/formatting issues.
+
+## References
+
+- [CSS patterns and examples](references/css-patterns.md)
+- [JavaScript patterns and examples](references/javascript-patterns.md)

--- a/plugins/shopify-liquid/skills/liquid-theme-standards/references/css-patterns.md
+++ b/plugins/shopify-liquid/skills/liquid-theme-standards/references/css-patterns.md
@@ -1,0 +1,233 @@
+# CSS Patterns for Shopify Liquid Themes
+
+## Complete Component Example
+
+```liquid
+<section
+  class="featured-collection"
+  style="
+    --section-padding: {{ section.settings.padding | default: 60 }}px;
+    --columns: {{ section.settings.columns | default: 4 }};
+  "
+>
+  {% if section.settings.heading != blank %}
+    <h2 class="featured-collection__heading">{{ section.settings.heading }}</h2>
+  {% endif %}
+
+  <div class="featured-collection__grid">
+    {% for product in collection.products limit: section.settings.limit %}
+      {% render 'product-card', product: product %}
+    {% endfor %}
+  </div>
+</section>
+
+{% stylesheet %}
+  .featured-collection {
+    padding-block: var(--section-padding);
+    container-type: inline-size;
+  }
+
+  .featured-collection__heading {
+    font-size: var(--font-size-2xl);
+    margin-block-end: var(--space-lg);
+    text-align: center;
+  }
+
+  .featured-collection__grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+    gap: var(--space-md);
+  }
+
+  @container (min-width: 768px) {
+    .featured-collection__grid {
+      grid-template-columns: repeat(var(--columns), 1fr);
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .featured-collection * {
+      transition: none !important;
+    }
+  }
+{% endstylesheet %}
+```
+
+## Layout Patterns
+
+### CSS Grid for Page Layouts
+
+```css
+.section-content {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: var(--space-lg);
+}
+```
+
+### Flexbox for Component Layouts
+
+```css
+.product-card {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+}
+```
+
+### Page-Width Container
+
+```css
+.page-width {
+  width: min(100%, var(--page-width));
+  margin-inline: auto;
+  padding-inline: var(--space-md);
+}
+```
+
+### Full-Bleed with Content Constraint
+
+```css
+.full-bleed {
+  display: grid;
+  grid-template-columns: var(--space-md) 1fr var(--space-md);
+}
+
+.full-bleed > * {
+  grid-column: 2;
+}
+
+.full-bleed > .full-width {
+  grid-column: 1 / -1;
+}
+```
+
+## Responsive Images
+
+```css
+.image-container {
+  position: relative;
+  aspect-ratio: 4 / 3;
+  overflow: hidden;
+}
+
+.image-container img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+```
+
+## Using :is() for Parent-Child Relationships
+
+```css
+/* Multiple parents, same child */
+:is(.hero, .banner) .heading {
+  font-size: var(--font-size-2xl);
+}
+
+/* Same parent, multiple children */
+.card:is(.card--featured, .card--promoted) {
+  border: 2px solid var(--color-accent);
+}
+```
+
+Don't use `:is()` for simple comma-separated selectors - use regular comma separation instead.
+
+## Variable Override Pattern
+
+Use CSS variables to reduce redundancy across modifiers:
+
+```css
+.button {
+  background: rgb(var(--button-color) / var(--button-opacity, 1));
+  color: rgb(var(--button-text));
+}
+
+.button--secondary {
+  --button-color: var(--color-secondary);
+  --button-text: var(--color-foreground);
+}
+
+.button--outline {
+  --button-color: transparent;
+  --button-text: var(--color-accent);
+  --button-opacity: 0;
+}
+```
+
+## Focus Styles
+
+```css
+:focus-visible {
+  outline: 2px solid rgb(var(--color-focus));
+  outline-offset: 2px;
+}
+
+/* High contrast mode */
+@media (forced-colors: active) {
+  :focus-visible {
+    outline: 3px solid LinkText;
+  }
+}
+```
+
+## Print Styles
+
+```css
+@media print {
+  .no-print,
+  .cart-drawer,
+  .navigation__mobile {
+    display: none !important;
+  }
+
+  a[href^='http']::after {
+    content: ' (' attr(href) ')';
+  }
+
+  .product-card {
+    break-inside: avoid;
+  }
+}
+```
+
+## Animation Patterns
+
+```css
+/* Safe defaults - only animate transform and opacity */
+.product-card {
+  transition: transform 0.2s ease;
+}
+
+.product-card:hover {
+  transform: translateY(-2px);
+}
+
+/* will-change only during animation */
+.product-card:hover {
+  will-change: transform;
+}
+.product-card:not(:hover) {
+  will-change: auto;
+}
+```
+
+## CSS Documentation
+
+```css
+/* =============================================================================
+   Product Card
+   ============================================================================= */
+
+/
+ * Card component for displaying product information.
+ *
+ * @example
+ * <div class="product-card product-card--featured">
+ *   <div class="product-card__image">...</div>
+ *   <div class="product-card__info">...</div>
+ * </div>
+ */
+.product-card { }
+```

--- a/plugins/shopify-liquid/skills/liquid-theme-standards/references/javascript-patterns.md
+++ b/plugins/shopify-liquid/skills/liquid-theme-standards/references/javascript-patterns.md
@@ -1,0 +1,291 @@
+# JavaScript Patterns for Shopify Liquid Themes
+
+## Web Component Lifecycle
+
+```javascript
+class MyComponent extends HTMLElement {
+  #abortController = null;
+
+  connectedCallback() {
+    this.#abortController = new AbortController();
+    this.#setup();
+  }
+
+  disconnectedCallback() {
+    this.#abortController?.abort();
+    // Clean up all resources
+  }
+
+  #setup() {
+    // Initialize refs, bind events
+  }
+}
+
+customElements.define('my-component', MyComponent);
+```
+
+## Event-Driven Architecture
+
+### Custom Events with Typed Details
+
+```javascript
+/
+ * @typedef {Object} CartUpdateDetail
+ * @property {number} itemCount - Total items in cart
+ * @property {number} totalPrice - Cart total in cents
+ */
+
+// Dispatching
+/ @type {CustomEvent<CartUpdateDetail>} */
+const event = new CustomEvent('cart:updated', {
+  detail: { itemCount: 3, totalPrice: 4500 },
+  bubbles: true
+});
+this.dispatchEvent(event);
+
+// Listening
+document.addEventListener('cart:updated', (event) => {
+  const { itemCount, totalPrice } = event.detail;
+  this.#updateDisplay(itemCount, totalPrice);
+});
+```
+
+### Event Naming Convention
+
+Use `namespace:action` format:
+- `cart:item-added`, `cart:updated`, `cart:emptied`
+- `variant:selected`, `variant:unavailable`
+- `filter:applied`, `filter:cleared`
+- `search:submitted`, `search:results-loaded`
+
+## Data Loading Pattern
+
+```javascript
+class ProductLoader extends HTMLElement {
+  #controller = null;
+
+  async load(url) {
+    this.#controller?.abort();
+    this.#controller = new AbortController();
+
+    this.setAttribute('aria-busy', 'true');
+
+    try {
+      const response = await fetch(url, {
+        signal: this.#controller.signal
+      });
+
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+      }
+
+      const html = await response.text();
+      const doc = new DOMParser().parseFromString(html, 'text/html');
+      const newContent = doc.querySelector('.product-grid');
+
+      if (newContent) {
+        this.querySelector('.product-grid')?.replaceWith(newContent);
+      }
+
+      return newContent;
+    } catch (error) {
+      if (error.name === 'AbortError') return null;
+      console.error('Load error:', error);
+      throw error;
+    } finally {
+      this.setAttribute('aria-busy', 'false');
+    }
+  }
+
+  disconnectedCallback() {
+    this.#controller?.abort();
+  }
+}
+```
+
+## URL Manipulation
+
+```javascript
+// Reading URL parameters
+const url = new URL(window.location.href);
+const filter = url.searchParams.get('filter');
+
+// Updating URL parameters
+const updateURL = (params) => {
+  const url = new URL(window.location.href);
+
+  for (const [key, value] of Object.entries(params)) {
+    if (value != null) {
+      url.searchParams.set(key, value);
+    } else {
+      url.searchParams.delete(key);
+    }
+  }
+
+  history.pushState(null, '', url.toString());
+};
+
+// Never do this:
+// let url = window.location.pathname + '?filter=' + value;
+```
+
+## Optimistic UI
+
+```javascript
+async addToCart(variantId) {
+  // 1. Update UI immediately
+  this.#setButtonState('adding');
+  this.#incrementCartCount();
+
+  try {
+    // 2. Make request
+    const formData = new FormData();
+    formData.append('id', variantId);
+    formData.append('quantity', '1');
+
+    const response = await fetch('/cart/add.js', {
+      method: 'POST',
+      body: formData
+    });
+
+    if (!response.ok) throw new Error('Failed');
+
+    // 3. Confirm success
+    this.#setButtonState('added');
+  } catch (error) {
+    // 4. Revert on failure
+    this.#setButtonState('error');
+    this.#decrementCartCount();
+    console.error('Add to cart failed:', error);
+  }
+}
+```
+
+## Debounce Pattern
+
+```javascript
+/
+ * @param {Function} func - Function to debounce
+ * @param {number} wait - Delay in milliseconds
+ * @returns {Function} Debounced function
+ */
+const debounce = (func, wait) => {
+  let timeout;
+  return (...args) => {
+    clearTimeout(timeout);
+    timeout = setTimeout(() => func(...args), wait);
+  };
+};
+
+// Usage: search input (300ms), resize handler (150ms)
+const handleSearch = debounce((query) => {
+  // Perform search
+}, 300);
+```
+
+## Intersection Observer (Lazy Loading)
+
+```javascript
+class LazyLoader extends HTMLElement {
+  #observer;
+
+  connectedCallback() {
+    this.#observer = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (entry.isIntersecting) {
+            this.#loadContent(entry.target);
+            this.#observer.unobserve(entry.target);
+          }
+        }
+      },
+      { rootMargin: '200px' }
+    );
+
+    for (const el of this.querySelectorAll('[data-lazy]')) {
+      this.#observer.observe(el);
+    }
+  }
+
+  disconnectedCallback() {
+    this.#observer?.disconnect();
+  }
+
+  #loadContent(element) {
+    const src = element.dataset.lazy;
+    if (element instanceof HTMLImageElement) {
+      element.src = src;
+    }
+  }
+}
+```
+
+## JSDoc Type Annotations
+
+```javascript
+/
+ * @typedef {Object} ProductData
+ * @property {string} id - Product ID
+ * @property {string} title - Product title
+ * @property {number} price - Price in cents
+ * @property {boolean} available - Whether in stock
+ * @property {string[]} tags - Product tags
+ */
+
+/
+ * Formats a price from cents to display string.
+ * @param {number} cents - Price in cents
+ * @param {string} [currency='USD'] - Currency code
+ * @returns {string} Formatted price
+ */
+const formatPrice = (cents, currency = 'USD') => {
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency
+  }).format(cents / 100);
+};
+```
+
+## Error Handling
+
+```javascript
+// Always wrap fetch in try/catch
+const fetchJSON = async (url, options = {}) => {
+  try {
+    const response = await fetch(url, options);
+
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+    }
+
+    return await response.json();
+  } catch (error) {
+    if (error.name === 'AbortError') return null;
+    console.error(`Fetch error for ${url}:`, error);
+    return null;
+  }
+};
+
+// Validate DOM elements before use
+const getElement = (selector, context = document) => {
+  const element = context.querySelector(selector);
+  if (!element) {
+    console.warn(`Element not found: ${selector}`);
+  }
+  return element;
+};
+```
+
+## File Organization
+
+Group related classes in feature files:
+```javascript
+// cart.js - all cart-related components
+class CartDrawer extends HTMLElement { }
+class CartItem extends HTMLElement { }
+class CartCount extends HTMLElement { }
+
+customElements.define('cart-drawer', CartDrawer);
+customElements.define('cart-item', CartItem);
+customElements.define('cart-count', CartCount);
+```

--- a/plugins/shopify-liquid/skills/shopify-liquid-themes/SKILL.md
+++ b/plugins/shopify-liquid/skills/shopify-liquid-themes/SKILL.md
@@ -1,50 +1,318 @@
 ---
 name: shopify-liquid-themes
-description: Generate or edit Shopify Liquid theme code, including sections, blocks, snippets, schema JSON, LiquidDoc comments, translation keys, filters, objects, and tags. Use when working in .liquid files or Shopify theme structure.
+description: "Generate Shopify Liquid theme code (sections, blocks, snippets) with correct schema JSON, LiquidDoc headers, translation keys, and CSS/JS patterns. Use when creating or editing .liquid files for Shopify themes, working with schema, doc, stylesheet, javascript tags, or Shopify Liquid objects/filters/tags."
 ---
 
 # Shopify Liquid Themes
 
-Use this skill when creating, editing, or reviewing Shopify theme code.
+## Cline Workflow
 
-## Theme Structure
+Use this skill directly when editing Shopify theme files. Cline does not provide a persistent Liquid language-server surface; when diagnostics are useful and the user is working in a trusted local theme workspace, run the plugin's `liquid_theme_diagnostics` tool to execute bounded `shopify theme check` output.
 
-- `sections/`: full-width customizable modules with `{% schema %}`.
-- `blocks/`: nestable editor components with `{% schema %}`.
-- `snippets/`: reusable fragments rendered with `{% render %}`.
-- `layout/`: page wrappers; keep `{{ content_for_header }}` and `{{ content_for_layout }}` intact.
-- `templates/`: JSON templates that select sections for page types.
-- `config/`: global theme settings.
-- `locales/`: translation files.
-- `assets/`: shared CSS, JavaScript, and static files.
+## Theme Architecture
 
-## Liquid Rules
+```
+.
+|- sections/    # Full-width page modules with {% schema %} - hero, product grid, testimonials
+|- blocks/      # Nestable components with {% schema %} - slides, feature items, text blocks
+|- snippets/    # Reusable fragments via {% render %} - buttons, icons, image helpers
+|- layout/      # Page wrappers (must include {{ content_for_header }} and {{ content_for_layout }})
+|- templates/   # JSON files defining which sections appear on each page type
+|- config/      # Global theme settings (settings_schema.json, settings_data.json)
+|- locales/     # Translation files (en.default.json, fr.json, etc.)
+`- assets/      # Static CSS, JS, images (prefer {% stylesheet %}/{% javascript %} instead)
+```
 
-- Use `{{ value }}` for output and `{% tag %}` for logic.
-- Use whitespace trimming deliberately with `{{- value -}}` and `{%- tag -%}`.
-- Liquid has no parentheses in conditions and no ternary operator. Use nested `if` blocks instead.
-- `for` loops are capped at 50 iterations unless pagination is used.
-- `contains` works reliably for strings; avoid assuming object-array containment.
-- Use `{% render 'snippet', arg: value %}` instead of deprecated `include`.
-- Snippets do not inherit arbitrary outer variables. Pass needed values explicitly.
-- `{% stylesheet %}` and `{% javascript %}` do not process Liquid.
+### When to use what
 
-## Sections And Blocks
+| Need | Use | Why |
+|------|-----|-----|
+| Full-width customizable module | Section | Has `{% schema %}`, appears in editor, renders blocks |
+| Small nestable component with editor settings | Block | Has `{% schema %}`, can nest inside sections/blocks |
+| Reusable logic, not editable by merchant | Snippet | No schema, rendered via `{% render %}`, takes params |
+| Logic shared across blocks/snippets | Snippet | Blocks can't `{% render %}` other blocks |
 
-Every section or block schema must be valid JSON inside `{% schema %}`. Use translation keys for merchant-facing names where the theme already follows that pattern.
+## Liquid Syntax
 
-Common setting choices:
+### Delimiters
 
-- `checkbox` for booleans.
-- `text`, `textarea`, or `inline_richtext` for copy.
-- `range` for bounded numbers with `min`, `max`, `step`, and `default`.
-- `select` or `radio` for fixed choices.
-- `image_picker`, `video`, `product`, `collection`, `page`, `blog`, `article`, `url`, `link_list`, and `font_picker` for Shopify editor resources.
+- `{{ ... }}` - Output (prints a value)
+- `{{- ... -}}` - Output with whitespace trimming
+- `{% ... %}` - Logic tag (if, for, assign) - prints nothing
+- `{%- ... -%}` - Logic tag with whitespace trimming
 
-## Output Guidance
+### Operators
 
-- Preserve existing theme naming, translation, and schema conventions.
-- Prefer semantic HTML and Liquid objects already available in the template.
-- Keep schema defaults valid and editor-friendly.
-- Avoid hardcoded merchant copy when the theme uses locales.
-- Run `liquid_theme_diagnostics` after meaningful Liquid or schema changes when Shopify CLI is available.
+Comparison: `==`, `!=`, `>`, `<`, `>=`, `<=`
+Logical: `and`, `or`, `contains`
+
+### Critical Gotchas
+
+1. No parentheses in conditions - use nested `{% if %}` instead
+2. No ternary - always use `{% if cond %}value{% else %}other{% endif %}`
+3. `for` loops max 50 iterations - use `{% paginate %}` for larger arrays
+4. `contains` only works with strings - can't check objects in arrays
+5. `{% stylesheet %}`/`{% javascript %}` don't render Liquid - no Liquid inside them
+6. Snippets can't access outer-scope variables - pass them as render params
+7. `include` is deprecated - always use `{% render 'snippet_name' %}`
+8. `{% liquid %}` tag - multi-line logic without delimiters; use `echo` for output
+
+### Variables
+
+```liquid
+{% assign my_var = 'value' %}
+{% capture my_var %}computed {{ value }}{% endcapture %}
+{% increment counter %}
+{% decrement counter %}
+```
+
+## Filter Quick Reference
+
+Filters are chained with `|`. Output type of one filter feeds input of next.
+
+Array: `compact`, `concat`, `find`, `find_index`, `first`, `has`, `join`, `last`, `map`, `reject`, `reverse`, `size`, `sort`, `sort_natural`, `sum`, `uniq`, `where`
+String: `append`, `capitalize`, `downcase`, `escape`, `handleize`, `lstrip`, `newline_to_br`, `prepend`, `remove`, `replace`, `rstrip`, `slice`, `split`, `strip`, `strip_html`, `truncate`, `truncatewords`, `upcase`, `url_decode`, `url_encode`
+Math: `abs`, `at_least`, `at_most`, `ceil`, `divided_by`, `floor`, `minus`, `modulo`, `plus`, `round`, `times`
+Money: `money`, `money_with_currency`, `money_without_currency`, `money_without_trailing_zeros`
+Color: `color_brightness`, `color_darken`, `color_lighten`, `color_mix`, `color_modify`, `color_saturate`, `color_desaturate`, `color_to_hex`, `color_to_hsl`, `color_to_rgb`
+Media: `image_url`, `image_tag`, `video_tag`, `external_video_tag`, `media_tag`, `model_viewer_tag`
+URL: `asset_url`, `asset_img_url`, `file_url`, `shopify_asset_url`
+HTML: `link_to`, `script_tag`, `stylesheet_tag`, `time_tag`, `placeholder_svg_tag`
+Localization: `t` (translate), `format_address`, `currency_selector`
+Other: `date`, `default`, `json`, `structured_data`, `font_face`, `font_url`, `payment_button`
+
+> Full details: [language filters](references/filters-language.md), [HTML/media filters](references/filters-html-media.md), [commerce filters](references/filters-commerce.md)
+
+## Tags Quick Reference
+
+| Category | Tags |
+|----------|------|
+| Theme | `content_for`, `layout`, `section`, `sections`, `schema`, `stylesheet`, `javascript`, `style` |
+| Control | `if`, `elsif`, `else`, `unless`, `case`, `when` |
+| Iteration | `for`, `break`, `continue`, `cycle`, `tablerow`, `paginate` |
+| Variable | `assign`, `capture`, `increment`, `decrement`, `echo` |
+| HTML | `form`, `render`, `raw`, `comment`, `liquid` |
+| Documentation | `doc` |
+
+> Full details with syntax and parameters: [references/tags.md](references/tags.md)
+
+## Objects Quick Reference
+
+### Global objects (available everywhere)
+
+`cart`, `collections`, `customer`, `localization`, `pages`, `request`, `routes`, `settings`, `shop`, `template`, `theme`, `linklists`, `images`, `blogs`, `articles`, `all_products`, `metaobjects`, `canonical_url`, `content_for_header`, `content_for_layout`, `page_title`, `page_description`, `handle`, `current_page`
+
+### Page-specific objects
+
+| Template | Objects |
+|----------|---------|
+| `/product` | `product`, `remote_product` |
+| `/collection` | `collection`, `current_tags` |
+| `/cart` | `cart` |
+| `/article` | `article`, `blog` |
+| `/blog` | `blog`, `current_tags` |
+| `/page` | `page` |
+| `/search` | `search` |
+| `/customers/*` | `customer`, `order` |
+
+> Full reference: [commerce objects](references/objects-commerce.md), [content objects](references/objects-content.md), [tier 2](references/objects-tier2.md), [tier 3](references/objects-tier3.md)
+
+## Schema Tag
+
+Sections and blocks require `{% schema %}` with a valid JSON object. Sections use `section.settings.*`, blocks use `block.settings.*`.
+
+### Section schema structure
+
+```json
+{
+  "name": "t:sections.hero.name",
+  "tag": "section",
+  "class": "hero-section",
+  "limit": 1,
+  "settings": [],
+  "max_blocks": 16,
+  "blocks": [{ "type": "@theme" }],
+  "presets": [{ "name": "t:sections.hero.name" }],
+  "enabled_on": { "templates": ["index"] },
+  "disabled_on": { "templates": ["password"] }
+}
+```
+
+### Block schema structure
+
+```json
+{
+  "name": "t:blocks.slide.name",
+  "tag": "div",
+  "class": "slide",
+  "settings": [],
+  "blocks": [{ "type": "@theme" }],
+  "presets": [{ "name": "t:blocks.slide.name" }]
+}
+```
+
+### Setting type decision table
+
+| Need | Setting Type | Key Fields |
+|------|-------------|------------|
+| On/off toggle | `checkbox` | `default: true/false` |
+| Short text | `text` | `placeholder` |
+| Long text | `textarea` | `placeholder` |
+| Rich text (with `<p>`) | `richtext` | - |
+| Inline rich text (no `<p>`) | `inline_richtext` | - |
+| Number input | `number` | `placeholder` |
+| Slider | `range` | `min`, `max`, `default` (all required), `step`, `unit` |
+| Dropdown/segmented | `select` | `options: [{value, label}]` |
+| Radio buttons | `radio` | `options: [{value, label}]` |
+| Text alignment | `text_alignment` | `default: "left"/"center"/"right"` |
+| Color picker | `color` | `default: "#000000"` |
+| Image upload | `image_picker` | - |
+| Video upload | `video` | - |
+| External video URL | `video_url` | `accept: ["youtube", "vimeo"]` |
+| Product picker | `product` | - |
+| Collection picker | `collection` | - |
+| Page picker | `page` | - |
+| Blog picker | `blog` | - |
+| Article picker | `article` | - |
+| URL entry | `url` | - |
+| Menu picker | `link_list` | - |
+| Font picker | `font_picker` | `default` (required) |
+| Editor header | `header` | `content` (no `id` needed) |
+| Editor description | `paragraph` | `content` (no `id` needed) |
+
+### `visible_if` pattern
+
+```json
+{
+  "visible_if": "{{ block.settings.layout == 'vertical' }}",
+  "type": "select",
+  "id": "alignment",
+  "label": "t:labels.alignment",
+  "options": [...]
+}
+```
+
+Conditionally shows/hides a setting in the editor based on other setting values.
+
+### Block entry types
+
+- `{ "type": "@theme" }` - Accept any theme block
+- `{ "type": "@app" }` - Accept app blocks
+- `{ "type": "slide" }` - Accept only the `slide` block type
+
+> Full schema details and all 33 setting types: [references/schema-and-settings.md](references/schema-and-settings.md)
+
+## CSS & JavaScript
+
+### Per-component styles and scripts
+
+Use `{% stylesheet %}` and `{% javascript %}` in sections, blocks, and snippets:
+
+```liquid
+{% stylesheet %}
+  .my-component { display: flex; }
+{% endstylesheet %}
+
+{% javascript %}
+  console.log('loaded');
+{% endjavascript %}
+```
+
+- One tag each per file - multiple `{% stylesheet %}` tags will error
+- No Liquid inside - these tags don't process Liquid; use CSS variables or classes instead
+- Only supported in `sections/`, `blocks/`, and `snippets/`
+
+### `{% style %}` tag (Liquid-aware CSS)
+
+For dynamic CSS that needs Liquid (e.g., color settings that live-update in editor):
+
+```liquid
+{% style %}
+  .section-{{ section.id }} {
+    background: {{ section.settings.bg_color }};
+  }
+{% endstyle %}
+```
+
+### CSS patterns for settings
+
+Single CSS property - use CSS variables:
+```liquid
+<div style="--gap: {{ block.settings.gap }}px">
+```
+
+Multiple CSS properties - use CSS classes as select values:
+```liquid
+<div class="{{ block.settings.layout }}">
+```
+
+## LiquidDoc (`{% doc %}`)
+
+Required for: snippets (always), blocks (when statically rendered via `{% content_for 'block' %}`)
+
+```liquid
+{% doc %}
+  Brief description of what this file renders.
+
+  @param {type} name - Description of required parameter
+  @param {type} [name] - Description of optional parameter (brackets = optional)
+
+  @example
+  {% render 'snippet-name', name: value %}
+{% enddoc %}
+```
+
+Param types: `string`, `number`, `boolean`, `image`, `object`, `array`
+
+## Translations
+
+### Every user-facing string must use the `t` filter
+
+```liquid
+<!-- Correct -->
+<h2>{{ 'sections.hero.heading' | t }}</h2>
+<button>{{ 'products.add_to_cart' | t }}</button>
+
+<!-- Wrong - never hardcode strings -->
+<h2>Welcome to our store</h2>
+```
+
+### Variable interpolation
+
+```liquid
+{{ 'products.price_range' | t: min: product.price_min | money, max: product.price_max | money }}
+```
+
+Locale file:
+```json
+{
+  "products": {
+    "price_range": "From {{ min }} to {{ max }}"
+  }
+}
+```
+
+### Locale file structure
+
+```
+locales/
+|- en.default.json          # English translations (required)
+|- en.default.schema.json   # Editor setting translations (required)
+|- fr.json                  # French translations
+`- fr.schema.json           # French editor translations
+```
+
+### Key naming conventions
+
+- Use snake_case and hierarchical keys (max 3 levels)
+- Use sentence case for all text (capitalize first word only)
+- Schema labels use `t:` prefix: `"label": "t:labels.heading"`
+- Group by component: `sections.hero.heading`, `blocks.slide.title`
+
+## References
+
+- Filters: [language](references/filters-language.md) (77), [HTML/media](references/filters-html-media.md) (45), [commerce](references/filters-commerce.md) (30)
+- [Tag reference (30 tags)](references/tags.md)
+- Objects: [commerce](references/objects-commerce.md) (5), [content](references/objects-content.md) (10), [tier 2](references/objects-tier2.md) (69), [tier 3](references/objects-tier3.md) (53)
+- [Schema & settings reference (33 types)](references/schema-and-settings.md)
+- [Complete examples (snippet, block, section)](references/examples.md)

--- a/plugins/shopify-liquid/skills/shopify-liquid-themes/SKILL.md
+++ b/plugins/shopify-liquid/skills/shopify-liquid-themes/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: shopify-liquid-themes
+description: Generate or edit Shopify Liquid theme code, including sections, blocks, snippets, schema JSON, LiquidDoc comments, translation keys, filters, objects, and tags. Use when working in .liquid files or Shopify theme structure.
+---
+
+# Shopify Liquid Themes
+
+Use this skill when creating, editing, or reviewing Shopify theme code.
+
+## Theme Structure
+
+- `sections/`: full-width customizable modules with `{% schema %}`.
+- `blocks/`: nestable editor components with `{% schema %}`.
+- `snippets/`: reusable fragments rendered with `{% render %}`.
+- `layout/`: page wrappers; keep `{{ content_for_header }}` and `{{ content_for_layout }}` intact.
+- `templates/`: JSON templates that select sections for page types.
+- `config/`: global theme settings.
+- `locales/`: translation files.
+- `assets/`: shared CSS, JavaScript, and static files.
+
+## Liquid Rules
+
+- Use `{{ value }}` for output and `{% tag %}` for logic.
+- Use whitespace trimming deliberately with `{{- value -}}` and `{%- tag -%}`.
+- Liquid has no parentheses in conditions and no ternary operator. Use nested `if` blocks instead.
+- `for` loops are capped at 50 iterations unless pagination is used.
+- `contains` works reliably for strings; avoid assuming object-array containment.
+- Use `{% render 'snippet', arg: value %}` instead of deprecated `include`.
+- Snippets do not inherit arbitrary outer variables. Pass needed values explicitly.
+- `{% stylesheet %}` and `{% javascript %}` do not process Liquid.
+
+## Sections And Blocks
+
+Every section or block schema must be valid JSON inside `{% schema %}`. Use translation keys for merchant-facing names where the theme already follows that pattern.
+
+Common setting choices:
+
+- `checkbox` for booleans.
+- `text`, `textarea`, or `inline_richtext` for copy.
+- `range` for bounded numbers with `min`, `max`, `step`, and `default`.
+- `select` or `radio` for fixed choices.
+- `image_picker`, `video`, `product`, `collection`, `page`, `blog`, `article`, `url`, `link_list`, and `font_picker` for Shopify editor resources.
+
+## Output Guidance
+
+- Preserve existing theme naming, translation, and schema conventions.
+- Prefer semantic HTML and Liquid objects already available in the template.
+- Keep schema defaults valid and editor-friendly.
+- Avoid hardcoded merchant copy when the theme uses locales.
+- Run `liquid_theme_diagnostics` after meaningful Liquid or schema changes when Shopify CLI is available.

--- a/plugins/shopify-liquid/skills/shopify-liquid-themes/references/examples.md
+++ b/plugins/shopify-liquid/skills/shopify-liquid-themes/references/examples.md
@@ -1,0 +1,353 @@
+# Complete Examples
+
+Full, production-ready examples for each asset type. Use these as templates when generating Shopify Liquid theme code.
+
+## Snippet Example
+
+Snippets live in `snippets/`, are rendered via `{% render %}`, and use `{% doc %}` for documentation. They have no `{% schema %}` tag.
+
+File: `snippets/image.liquid`
+
+```liquid
+{% doc %}
+  Renders a responsive image that might be wrapped in a link.
+
+  When `width`, `height` and `crop` are provided, the image will be rendered
+  with a fixed aspect ratio.
+
+  @param {image} image - The image to be rendered
+  @param {string} [url] - An optional destination URL for the image
+  @param {string} [css_class] - Optional class to be added to the image wrapper
+  @param {number} [width] - The highest resolution width of the image to be rendered
+  @param {number} [height] - The highest resolution height of the image to be rendered
+  @param {string} [crop] - The crop position of the image
+
+  @example
+  {% render 'image', image: product.featured_image %}
+  {% render 'image', image: product.featured_image, url: product.url %}
+  {% render 'image',
+    css_class: 'product__image',
+    image: product.featured_image,
+    url: product.url,
+    width: 1200,
+    height: 800,
+    crop: 'center',
+  %}
+{% enddoc %}
+
+{% liquid
+  unless height
+    assign width = width | default: image.width
+  endunless
+
+  if url
+    assign wrapper = 'a'
+  else
+    assign wrapper = 'div'
+  endif
+%}
+
+<{{ wrapper }}
+  class="image {{ css_class }}"
+  {% if url %}
+    href="{{ url }}"
+  {% endif %}
+>
+  {{ image | image_url: width: width, height: height, crop: crop | image_tag }}
+</{{ wrapper }}>
+
+{% stylesheet %}
+  .image {
+    display: block;
+    position: relative;
+    overflow: hidden;
+    width: 100%;
+    height: auto;
+  }
+
+  .image > img {
+    width: 100%;
+    height: auto;
+  }
+{% endstylesheet %}
+
+{% javascript %}
+  function doSomething() {
+    // example
+  }
+  doSomething()
+{% endjavascript %}
+```
+
+Key patterns:
+- `{% doc %}` at the top documents params with types, optionality (`[param]`), and examples
+- `{% liquid %}` block for multi-line logic (no delimiters needed per line)
+- CSS variables for single-property settings, classes for multi-property
+- One `{% stylesheet %}` and one `{% javascript %}` tag per file
+
+## Block Example: Text
+
+Blocks live in `blocks/`, have `{% schema %}` for settings, and use `{% doc %}` when statically rendered.
+
+File: `blocks/text.liquid`
+
+```liquid
+{% doc %}
+  Renders a text block.
+
+  @example
+  {% content_for 'block', type: 'text', id: 'text' %}
+{% enddoc %}
+
+<div
+  class="text {{ block.settings.text_style }}"
+  style="--text-align: {{ block.settings.alignment }}"
+  {{ block.shopify_attributes }}
+>
+  {{ block.settings.text }}
+</div>
+
+{% stylesheet %}
+  .text {
+    text-align: var(--text-align);
+  }
+  .text--title {
+    font-size: 2rem;
+    font-weight: 700;
+  }
+  .text--subtitle {
+    font-size: 1.5rem;
+  }
+{% endstylesheet %}
+
+{% schema %}
+{
+  "name": "t:general.text",
+  "settings": [
+    {
+      "type": "text",
+      "id": "text",
+      "label": "t:labels.text",
+      "default": "Text"
+    },
+    {
+      "type": "select",
+      "id": "text_style",
+      "label": "t:labels.text_style",
+      "options": [
+        { "value": "text--title", "label": "t:options.text_style.title" },
+        { "value": "text--subtitle", "label": "t:options.text_style.subtitle" },
+        { "value": "text--normal", "label": "t:options.text_style.normal" }
+      ],
+      "default": "text--title"
+    },
+    {
+      "type": "text_alignment",
+      "id": "alignment",
+      "label": "t:labels.alignment",
+      "default": "left"
+    }
+  ],
+  "presets": [{ "name": "t:general.text" }]
+}
+{% endschema %}
+```
+
+Key patterns:
+- `{{ block.shopify_attributes }}` required on the outermost block element
+- CSS variable `--text-align` for single-property setting
+- CSS class `text--title` for multi-property style variants
+- All labels use `t:` translation keys
+- `select` options use CSS class names as values when controlling multiple styles
+
+## Block Example: Group (Nested Blocks)
+
+Group blocks accept child blocks via `{% content_for 'blocks' %}` and `"blocks": [{ "type": "@theme" }]`.
+
+File: `blocks/group.liquid`
+
+```liquid
+{% doc %}
+  Renders a group of blocks with configurable layout direction, gap and
+  alignment.
+
+  @example
+  {% content_for 'block', type: 'group', id: 'group' %}
+{% enddoc %}
+
+<div
+  class="group {{ block.settings.layout_direction }}"
+  style="
+    --padding: {{ block.settings.padding }}px;
+    --alignment: {{ block.settings.alignment }};
+  "
+  {{ block.shopify_attributes }}
+>
+  {% content_for 'blocks' %}
+</div>
+
+{% stylesheet %}
+  .group {
+    display: flex;
+    flex-wrap: nowrap;
+    overflow: hidden;
+    width: 100%;
+  }
+  .group--horizontal {
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
+    padding: 0 var(--padding);
+  }
+  .group--vertical {
+    flex-direction: column;
+    align-items: var(--alignment);
+    padding: var(--padding) 0;
+  }
+{% endstylesheet %}
+
+{% schema %}
+{
+  "name": "t:general.group",
+  "blocks": [{ "type": "@theme" }],
+  "settings": [
+    {
+      "type": "select",
+      "id": "layout_direction",
+      "label": "t:labels.layout_direction",
+      "default": "group--vertical",
+      "options": [
+        { "value": "group--horizontal", "label": "t:options.direction.horizontal" },
+        { "value": "group--vertical", "label": "t:options.direction.vertical" }
+      ]
+    },
+    {
+      "visible_if": "{{ block.settings.layout_direction == 'group--vertical' }}",
+      "type": "select",
+      "id": "alignment",
+      "label": "t:labels.alignment",
+      "default": "flex-start",
+      "options": [
+        { "value": "flex-start", "label": "t:options.alignment.left" },
+        { "value": "center", "label": "t:options.alignment.center" },
+        { "value": "flex-end", "label": "t:options.alignment.right" }
+      ]
+    },
+    {
+      "type": "range",
+      "id": "padding",
+      "label": "t:labels.padding",
+      "default": 0,
+      "min": 0,
+      "max": 200,
+      "step": 2,
+      "unit": "px"
+    }
+  ],
+  "presets": [
+    {
+      "name": "t:general.column",
+      "category": "t:general.layout",
+      "settings": {
+        "layout_direction": "group--vertical",
+        "alignment": "flex-start",
+        "padding": 0
+      }
+    },
+    {
+      "name": "t:general.row",
+      "category": "t:general.layout",
+      "settings": {
+        "layout_direction": "group--horizontal",
+        "padding": 0
+      }
+    }
+  ]
+}
+{% endschema %}
+```
+
+Key patterns:
+- `"blocks": [{ "type": "@theme" }]` allows any theme block as child
+- `{% content_for 'blocks' %}` renders the nested blocks
+- `visible_if` conditionally shows the alignment setting only when vertical layout is selected
+- Multiple presets (Column and Row) with different default settings
+- `range` setting with required `min`, `max`, `default`, and optional `step`/`unit`
+
+## Section Example
+
+Sections live in `sections/`, always have `{% schema %}`, and use `{% content_for 'blocks' %}` to render their blocks.
+
+File: `sections/custom-section.liquid`
+
+```liquid
+<div class="example-section full-width">
+  {% if section.settings.background_image %}
+    <div class="example-section__background">
+      {{ section.settings.background_image | image_url: width: 2000 | image_tag }}
+    </div>
+  {% endif %}
+
+  <div class="custom-section__content">
+    {% content_for 'blocks' %}
+  </div>
+</div>
+
+{% stylesheet %}
+  .example-section {
+    position: relative;
+    overflow: hidden;
+    width: 100%;
+  }
+  .example-section__background {
+    position: absolute;
+    width: 100%;
+    height: 100%;
+    z-index: -1;
+    overflow: hidden;
+  }
+  .example-section__background img {
+    position: absolute;
+    width: 100%;
+    height: auto;
+    top: 50%;
+    left: 50%;
+    transform: translate(-50%, -50%);
+  }
+  .example-section__content {
+    display: grid;
+    grid-template-columns: var(--content-grid);
+  }
+
+  .example-section__content > * {
+    grid-column: 2;
+  }
+{% endstylesheet %}
+
+{% schema %}
+{
+  "name": "t:general.custom_section",
+  "blocks": [{ "type": "@theme" }],
+  "settings": [
+    {
+      "type": "image_picker",
+      "id": "background_image",
+      "label": "t:labels.background"
+    }
+  ],
+  "presets": [
+    {
+      "name": "t:general.custom_section"
+    }
+  ]
+}
+{% endschema %}
+```
+
+Key patterns:
+- Sections use `section.settings.*` (not `block.settings.*`)
+- No `{% doc %}` tag needed for sections (they are not rendered via `{% render %}`)
+- `image_picker` setting accessed with `| image_url: width: N | image_tag` filter chain
+- `{% content_for 'blocks' %}` renders merchant-configurable blocks
+- Presets are required for sections to appear in "Add section" menu
+- `"blocks": [{ "type": "@theme" }]` makes the section accept any theme block

--- a/plugins/shopify-liquid/skills/shopify-liquid-themes/references/filters-commerce.md
+++ b/plugins/shopify-liquid/skills/shopify-liquid-themes/references/filters-commerce.md
@@ -1,0 +1,394 @@
+# Liquid Filters - Commerce
+
+> 30 filters across 8 categories.
+
+## Cart
+
+### `item_count_for_variant`
+
+- Syntax: `{{ cart | item_count_for_variant: {variant_id} }}`
+- Returns: `number`
+- Returns the total item count for a specified variant in the `cart` object.
+
+```liquid
+{{ cart | item_count_for_variant: 39888235757633 }}
+```
+
+### `line_items_for`
+
+- Syntax: `{{ cart | line_items_for: object }}`
+- Returns: `array`
+- Returns the subset of `cart` line items that include a specified product or variant.
+
+```liquid
+{% assign product = all_products['bloodroot-whole'] %}
+{% assign line_items = cart | line_items_for: product %}
+
+Total cart quantity for product: {{ line_items | sum: 'quantity' }}
+```
+
+## Collection
+
+### `link_to_type`
+
+- Syntax: `{{ string | link_to_type }}`
+- Returns: `string`
+- Generates an HTML `<a>` tag with an `href` attribute linking to a collection page that lists all products of the given
+product type.
+
+```liquid
+{{ 'Health' | link_to_type }}
+```
+
+### `link_to_vendor`
+
+- Syntax: `{{ string | link_to_vendor }}`
+- Returns: `string`
+- Generates an HTML `<a>` tag with an `href` attribute linking to a collection page that lists all products of a given
+product vendor.
+
+```liquid
+{{ "Polina's Potent Potions" | link_to_vendor }}
+```
+
+### `sort_by`
+
+- Syntax: `{{ string | sort_by: string }}`
+- Returns: `string`
+- Generates a collection URL with the provided `sort_by` parameter appended.
+This filter must be applied to the object property `collection.url`.
+
+```liquid
+{{ collection.url | sort_by: 'best-selling' }}
+```
+
+### `url_for_type`
+
+- Syntax: `{{ string | url_for_type }}`
+- Returns: `string`
+- Generates a URL for a collection page that lists all products of the given product type.
+
+```liquid
+{{ 'health' | url_for_type }}
+```
+
+### `url_for_vendor`
+
+- Syntax: `{{ string | url_for_vendor }}`
+- Returns: `string`
+- Generates a URL for a collection page that lists all products from the given product vendor.
+
+```liquid
+{{ "Polina's Potent Potions" | url_for_vendor }}
+```
+
+### `within`
+
+- Syntax: `{{ string | within: collection }}`
+- Returns: `string`
+- Generates a product URL within the context of the provided collection.
+
+```liquid
+{%- assign collection_product = collection.products.first -%}
+
+{{ collection_product.url | within: collection }}
+```
+
+### `highlight_active_tag`
+
+- Syntax: `{{ string | highlight_active_tag }}`
+- Returns: `string`
+- Wraps a given tag within the `collection` object in an HTML `<span>` tag, with a `class` attribute of `active`, if the tag is currently active. Only
+applies to collection tags.
+
+```liquid
+{% for tag in collection.all_tags %}
+  {{- tag | highlight_active_tag | link_to_tag: tag }}
+{% endfor %}
+```
+
+## Customer
+
+### `customer_login_link`
+
+- Syntax: `{{ string | customer_login_link }}`
+- Returns: `string`
+- Generates an HTML link to the customer login page.
+
+```liquid
+{{ 'Log in' | customer_login_link }}
+```
+
+### `customer_logout_link`
+
+- Syntax: `{{ string | customer_logout_link }}`
+- Returns: `string`
+- Generates an HTML link to log the customer out of their account and redirect to the homepage.
+
+```liquid
+{{ 'Log out' | customer_logout_link }}
+```
+
+### `customer_register_link`
+
+- Syntax: `{{ string | customer_register_link }}`
+- Returns: `string`
+- Generates an HTML link to the customer registration page.
+
+```liquid
+{{ 'Create an account' | customer_register_link }}
+```
+
+### `avatar`
+
+- Syntax: `{{ customer | avatar }}`
+- Returns: `string`
+- Generates HTML to render a customer's avatar, if available.
+
+### `login_button`
+
+- Syntax: `{{ shop | login_button }}`
+- Returns: `string`
+- Generates an HTML Button that enables a customer to either sign in to the storefront using their Shop account or follow the shop in the Shop App.
+
+## Localization
+
+### `currency_selector` *(deprecated)*
+
+- Syntax: `{{ form | currency_selector }}`
+- Returns: `string`
+- Generates an HTML `<select>` element with an option for each currency available on the store.
+
+```liquid
+{% form 'currency' %}
+  {{ form | currency_selector }}
+{% endform %}
+```
+
+### `translate`
+
+- Syntax: `{{ string | t }}`
+- Returns: `string`
+- Returns a string of translated text for a given translation key from a locale file.
+
+### `format_address`
+
+- Syntax: `{{ address | format_address }}`
+- Returns: `string`
+- Generates an HTML address display, with each address component ordered according to the address's locale.
+
+```liquid
+{{ shop.address | format_address }}
+```
+
+## Metafield
+
+### `metafield_tag`
+
+- Syntax: `{{ metafield | metafield_tag }}`
+- Returns: `string`
+- Generates an HTML element to host the data from a `metafield` object.
+The type of element that's generated differs depending on the type of metafield.
+
+```liquid
+&lt;!-- boolean --&gt;
+{{ product.metafields.information.seasonal | metafield_tag }}
+
+&lt;!-- collection_reference --&gt;
+{{ product.metafields.information.related_collection | metafield_tag }}
+
+&lt;!-- color --&gt;
+{{ product.metafields.details.potion_color | metafield_tag }}
+
+&lt;!-- date --&gt;
+{{ product.metafields.information.expiry | metafield_tag }}
+
+&lt;!-- date_time --&gt;
+{{ product.metafields.information.brew_date | metafield_tag }}
+
+&lt;!-- json --&gt;
+{{ product.metafields.information.burn_temperature | metafield_tag }}
+
+&lt;!-- money --&gt;
+{{ product.metafields.details.price_per_ml | metafield_tag }}
+
+&lt;!-- multi_line_text_field --&gt;
+{{ product.metafields.information.shipping | metafield_tag }}
+
+&lt;!-- number_decimal --&gt;
+{{ product.metafields.information.salinity | metafield_tag }}
+
+&lt;!-- number_integer --&gt;
+{{ product.metafields.information.doses_per_day | metafield_tag }}
+
+&lt;!-- page_reference --&gt;
+{{ product.metafields.information.dosage | metafield_tag }}
+
+&lt;!-- product_reference --&gt;
+{{ product.metafields.information.related_product | metafield_tag }}
+
+&lt;!-- rating --&gt;
+{{ product.metafields.details.rating | metafield_tag }}
+
+&lt;!-- single_line_text_field --&gt;
+{{ product.metafields.information.directions | metafield_tag }}
+
+&lt;!-- url --&gt;
+{{ product.metafields.information.health | metafield_tag }}
+
+&lt;!-- variant_reference --&gt;
+{{ product.metafields.information.best_seller | metafield_tag }}
+
+&lt;!-- rich_text_field --&gt;
+{{ product.metafields.information.rich_description | metafield_tag }}
+```
+
+### `metafield_text`
+
+- Syntax: `{{ metafield | metafield_text }}`
+- Returns: `string`
+- Generates a text version of the data from a `metafield` object.
+
+```liquid
+{{ product.metafields.information.dosage | metafield_text }}
+```
+
+## Money
+
+### `money`
+
+- Syntax: `{{ number | money }}`
+- Returns: `string`
+- Formats a given price based on the store's HTML without currency setting.
+
+```liquid
+{{ product.price | money }}
+```
+
+### `money_with_currency`
+
+- Syntax: `{{ number | money_with_currency }}`
+- Returns: `string`
+- Formats a given price based on the store's HTML with currency setting.
+
+```liquid
+{{ product.price | money_with_currency }}
+```
+
+### `money_without_currency`
+
+- Syntax: `{{ number | money_without_currency }}`
+- Returns: `string`
+- Formats a given price based on the store's HTML without currency setting, without the currency symbol.
+
+```liquid
+{{ product.price | money_without_currency }}
+```
+
+### `money_without_trailing_zeros`
+
+- Syntax: `{{ number | money_without_trailing_zeros }}`
+- Returns: `string`
+- Formats a given price based on the store's HTML without currency setting, excluding the decimal separator
+(either `.` or `,`) and trailing zeros.
+
+If the price has a non-zero decimal value, then the output is the same as the `money` filter.
+
+```liquid
+{{ product.price | money_without_trailing_zeros }}
+```
+
+## Payment
+
+### `payment_button`
+
+- Syntax: `{{ form | payment_button }}`
+- Returns: `string`
+- Generates an HTML container to host accelerated checkout buttons
+for a product. The `payment_button` filter must be used on the `form` object within a product form.
+
+```liquid
+{% form 'product', product %}
+  {{ form | payment_button }}
+{% endform %}
+```
+
+### `payment_terms`
+
+- Syntax: `{{ form | payment_terms }}`
+- Returns: `string`
+- Generates the HTML for the Shop Pay Installments banner.
+
+### `payment_type_img_url`
+
+- Syntax: `{{ string | payment_type_img_url }}`
+- Returns: `string`
+- Returns the URL for an SVG image of a given payment type.
+
+```liquid
+{% for type in shop.enabled_payment_types %}
+&lt;img src="{{ type | payment_type_img_url }}" width="50" height="50" /&gt;
+{% endfor %}
+```
+
+### `payment_type_svg_tag`
+
+- Syntax: `{{ string | payment_type_svg_tag }}`
+- Returns: `string`
+- Generates an HTML `<svg>` tag for a given payment type.
+
+```liquid
+{% for type in shop.enabled_payment_types -%}
+  {{ type | payment_type_svg_tag }}
+{% endfor %}
+```
+
+## Tag
+
+### `link_to_add_tag`
+
+- Syntax: `{{ string | link_to_add_tag }}`
+- Returns: `string`
+- Generates an HTML `<a>` tag with an `href` attribute linking to the current blog or collection, filtered to show
+only articles or products that have a given tag, as well as any currently active tags.
+
+```liquid
+{% for tag in collection.all_tags %}
+  {%- if current_tags contains tag -%}
+    {{ tag }}
+  {%- else -%}
+    {{ tag | link_to_add_tag: tag }}
+  {%- endif -%}
+{% endfor %}
+```
+
+### `link_to_remove_tag`
+
+- Syntax: `{{ string | link_to_remove_tag }}`
+- Returns: `string`
+- Generates an HTML `<a>` tag with an `href` attribute linking to the current blog or collection, filtered to show
+only articles or products that have any currently active tags, except the provided tag.
+
+```liquid
+{% for tag in collection.all_tags %}
+  {%- if current_tags contains tag -%}
+    {{ tag | link_to_remove_tag: tag }}
+  {%- else -%}
+    {{ tag | link_to_add_tag: tag }}
+  {%- endif -%}
+{% endfor %}
+```
+
+### `link_to_tag`
+
+- Syntax: `{{ string | link_to_tag }}`
+- Returns: `string`
+- Generates an HTML `<a>` tag with an `href` attribute linking to the current blog or collection, filtered to show
+only articles or products that have a given tag.
+
+```liquid
+{% for tag in collection.all_tags %}
+  {{- tag | link_to_tag: tag }}
+{% endfor %}
+```
+

--- a/plugins/shopify-liquid/skills/shopify-liquid-themes/references/filters-html-media.md
+++ b/plugins/shopify-liquid/skills/shopify-liquid-themes/references/filters-html-media.md
@@ -1,0 +1,518 @@
+# Liquid Filters - Html media
+
+> 45 filters across 5 categories.
+
+## Color
+
+### `brightness_difference`
+
+- Syntax: `{{ string | brightness_difference: string }}`
+- Returns: `number`
+- Calculates the perceived brightness difference between two colors.
+
+```liquid
+{{ '#E800B0' | brightness_difference: '#FECEE9' }}
+```
+
+### `color_brightness`
+
+- Syntax: `{{ string | color_brightness }}`
+- Returns: `number`
+- Calculates the perceived brightness of a given color.
+
+```liquid
+{{ '#EA5AB9' | color_brightness }}
+```
+
+### `color_contrast`
+
+- Syntax: `{{ string | color_contrast: string }}`
+- Returns: `number`
+- Calculates the contrast ratio between two colors and returns the ratio's numerator. The ratio's denominator, which isn't
+returned, is always 1. For example, with a contrast ratio of 3.5:1, this filter returns 3.5.
+
+```liquid
+{{ '#E800B0' | color_contrast: '#D9D8FF' }}
+```
+
+### `color_darken`
+
+- Syntax: `{{ string | color_darken: number }}`
+- Returns: `string`
+- Darkens a given color by a specific percentage. The percentage must be between 0 and 100.
+
+```liquid
+{{ '#EA5AB9' | color_darken: 30 }}
+```
+
+### `color_desaturate`
+
+- Syntax: `{{ string | color_desaturate: number }}`
+- Returns: `string`
+- Desaturates a given color by a specific percentage. The percentage must be between 0 and 100.
+
+```liquid
+{{ '#EA5AB9' | color_desaturate: 30 }}
+```
+
+### `color_difference`
+
+- Syntax: `{{ string | color_difference: string }}`
+- Returns: `number`
+- Calculates the color difference between two colors.
+
+```liquid
+{{ '#720955' | color_difference: '#FFF3F9' }}
+```
+
+### `color_extract`
+
+- Syntax: `{{ string | color_extract: string }}`
+- Returns: `number`
+- Extracts a specific color component from a given color.
+
+```liquid
+{{ '#EA5AB9' | color_extract: 'red' }}
+```
+
+### `color_lighten`
+
+- Syntax: `{{ string | color_lighten: number }}`
+- Returns: `string`
+- Lightens a given color by a specific percentage. The percentage must be between 0 and 100.
+
+```liquid
+{{ '#EA5AB9' | color_lighten: 30 }}
+```
+
+### `color_mix`
+
+- Syntax: `{{ string | color_mix: string, number }}`
+- Returns: `string`
+- Blends two colors together by a specific percentage factor. The percentage must be between 0 and 100.
+
+```liquid
+{{ '#E800B0' | color_mix: '#00936F', 50 }}
+```
+
+### `color_modify`
+
+- Syntax: `{{ string | color_modify: string, number }}`
+- Returns: `string`
+- Modifies a specific color component of a given color by a specific amount.
+
+```liquid
+{{ '#EA5AB9' | color_modify: 'red', 255 }}
+```
+
+### `color_saturate`
+
+- Syntax: `{{ string | color_saturate: number }}`
+- Returns: `string`
+- Saturates a given color by a specific percentage. The percentage must be between 0 and 100.
+
+```liquid
+{{ '#EA5AB9' | color_saturate: 30 }}
+```
+
+### `color_to_hex`
+
+- Syntax: `{{ string | color_to_hex }}`
+- Returns: `string`
+- Converts a CSS color string to hexadecimal format (`hex6`).
+
+```liquid
+{{ 'rgb(234, 90, 185)' | color_to_hex }}
+```
+
+### `color_to_hsl`
+
+- Syntax: `{{ string | color_to_hsl }}`
+- Returns: `string`
+- Converts a CSS color string to `HSL` format.
+
+```liquid
+{{ '#EA5AB9' | color_to_hsl }}
+```
+
+### `color_to_oklch`
+
+- Syntax: `{{ string | color_to_oklch }}`
+- Returns: `string`
+- Converts a CSS color string to `OKLCH` format.
+
+```liquid
+{{ '#EA5AB9' | color_to_oklch }}
+```
+
+### `color_to_rgb`
+
+- Syntax: `{{ string | color_to_rgb }}`
+- Returns: `string`
+- Converts a CSS color string to `RGB` format.
+
+```liquid
+{{ '#EA5AB9' | color_to_rgb }}
+```
+
+### `hex_to_rgba` *(deprecated)*
+
+- Syntax: `{{ string | hex_to_rgba }}`
+- Returns: `string`
+- Converts a CSS color string from  hexadecimal format to `RGBA` format. Shorthand hexadecimal formatting (`hex3`) is also accepted.
+
+```liquid
+{{ '#EA5AB9' | hex_to_rgba }}
+```
+
+## Font
+
+### `font_face`
+
+- Syntax: `{{ font | font_face }}`
+- Returns: `string`
+- Generates a CSS `@font_face` declaration to load the provided font.
+
+```liquid
+{{ settings.type_header_font | font_face }}
+```
+
+### `font_modify`
+
+- Syntax: `{{ font | font_modify: string, string }}`
+- Returns: `font`
+- Modifies a specific property of a given font.
+
+```liquid
+{%- assign bold_font = settings.type_body_font | font_modify: 'weight', 'bold' -%}
+
+h2 {
+  font-weight: {{ bold_font.weight }};
+}
+```
+
+### `font_url`
+
+- Syntax: `{{ font | font_url }}`
+- Returns: `string`
+- Returns the CDN URL for the provided font in `woff2` format.
+
+```liquid
+{{ settings.type_header_font | font_url }}
+```
+
+## Hosted file
+
+### `asset_img_url`
+
+- Syntax: `{{ string | asset_img_url }}`
+- Returns: `string`
+- Returns the CDN URL for an image in the
+`assets` directory of a theme.
+
+```liquid
+{{ 'red-and-black-bramble-berries.jpg' | asset_img_url }}
+```
+
+### `asset_url`
+
+- Syntax: `{{ string | asset_url }}`
+- Returns: `string`
+- Returns the CDN URL for a file in the
+`assets` directory of a theme.
+
+```liquid
+{{ 'cart.js' | asset_url }}
+```
+
+### `file_img_url`
+
+- Syntax: `{{ string | file_img_url }}`
+- Returns: `string`
+- Returns the CDN URL for an image from the
+Files page of the Shopify admin.
+
+```liquid
+{{ 'potions-header.png' | file_img_url }}
+```
+
+### `file_url`
+
+- Syntax: `{{ string | file_url }}`
+- Returns: `string`
+- Returns the CDN URL for a file from the
+Files page of the Shopify admin.
+
+```liquid
+{{ 'disclaimer.pdf' | file_url }}
+```
+
+### `global_asset_url`
+
+- Syntax: `{{ string | global_asset_url }}`
+- Returns: `string`
+- Returns the CDN URL for a global asset.
+
+```liquid
+{{ 'lightbox.js' | global_asset_url | script_tag }}
+
+{{ 'lightbox.css' | global_asset_url | stylesheet_tag }}
+```
+
+### `shopify_asset_url`
+
+- Syntax: `{{ string | shopify_asset_url }}`
+- Returns: `string`
+- Returns the CDN URL for a globally accessible Shopify asset.
+
+```liquid
+{{ 'option_selection.js' | shopify_asset_url }}
+```
+
+## Html
+
+### `time_tag`
+
+- Syntax: `{{ string | time_tag: string }}`
+- Returns: `string`
+- Converts a timestamp into an HTML `<time>` tag.
+
+```liquid
+{{ article.created_at | time_tag: '%B %d, %Y' }}
+```
+
+### `inline_asset_content`
+
+- Syntax: `{{ asset_name | inline_asset_content }}`
+- Returns: `string`
+- Outputs the content of an asset inline in the template. The asset must be either a SVG, JS, or CSS file.
+
+```liquid
+{{ 'icon.svg' | inline_asset_content }}
+```
+
+### `highlight`
+
+- Syntax: `{{ string | highlight: string }}`
+- Returns: `string`
+- Wraps all instances of a specific string, within a given string, with an HTML `<strong>` tag with a `class` attribute
+of `highlight`.
+
+```liquid
+{% for item in search.results %}
+  {% if item.object_type == 'product' %}
+    {{ item.description | highlight: search.terms }}
+  {% else %}
+    {{ item.content | highlight: search.terms }}
+  {% endif %}
+{% endfor %}
+```
+
+### `link_to`
+
+- Syntax: `{{ string | link_to: string }}`
+- Returns: `string`
+- Generates an HTML `<a>` tag.
+
+```liquid
+{{ 'Shopify' | link_to: 'https://www.shopify.com' }}
+```
+
+### `placeholder_svg_tag`
+
+- Syntax: `{{ string | placeholder_svg_tag }}`
+- Returns: `string`
+- Generates an HTML `<svg>` tag for a given placeholder name.
+
+```liquid
+{{ 'collection-1' | placeholder_svg_tag }}
+```
+
+### `preload_tag`
+
+- Syntax: `{{ string | preload_tag: as: string }}`
+- Returns: `string`
+- Generates an HTML `<link>` tag with a `rel` attribute of `preload` to prioritize loading a given Shopify-hosted asset.
+The asset URL is also added to the Link header
+with a `rel` attribute of `preload`.
+
+```liquid
+{{ 'cart.js' | asset_url | preload_tag: as: 'script' }}
+```
+
+### `script_tag`
+
+- Syntax: `{{ string | script_tag }}`
+- Returns: `string`
+- Generates an HTML `<script>` tag for a given resource URL. The tag has a `type` attribute of `text/javascript`.
+
+```liquid
+{{ 'cart.js' | asset_url | script_tag }}
+```
+
+### `stylesheet_tag`
+
+- Syntax: `{{ string | stylesheet_tag }}`
+- Returns: `string`
+- Generates an HTML `<link>` tag for a given resource URL. The tag has the following parameters:
+
+| Attribute | Value |
+| --- | --- |
+| `rel` | `stylesheet` |
+| `type` | `text/css` |
+| `media` | `all` |
+
+```liquid
+{{ 'base.css' | asset_url | stylesheet_tag }}
+```
+
+## Media
+
+### `external_video_tag`
+
+- Syntax: `{{ variable | external_video_tag }}`
+- Returns: `string`
+- Generates an HTML `<iframe>` tag containing the player for a given external video. The input for the `external_video_tag`
+filter can be either a `media` object or `external_video_url`.
+
+```liquid
+{% for media in product.media %}
+  {% if media.media_type == 'external_video' %}
+    {% if media.host == 'youtube' %}
+      {{ media | external_video_url: color: 'white' | external_video_tag }}
+    {% elsif media.host == 'vimeo' %}
+      {{ media | external_video_url: loop: '1', muted: '1' | external_video_tag }}
+    {% endif %}
+  {% endif %}
+{% endfor %}
+```
+
+### `external_video_url`
+
+- Syntax: `{{ media | external_video_url: attribute: string }}`
+- Returns: `string`
+- Returns the URL for a given external video. Use this filter to specify parameters for the external video player generated
+by the `external_video_tag` filter.
+
+```liquid
+{% for media in product.media %}
+  {% if media.media_type == 'external_video' %}
+    {% if media.host == 'youtube' %}
+      {{ media | external_video_url: color: 'white' | external_video_tag }}
+    {% elsif media.host == 'vimeo' %}
+      {{ media | external_video_url: loop: '1', muted: '1' | external_video_tag }}
+    {% endif %}
+  {% endif %}
+{% endfor %}
+```
+
+### `image_tag`
+
+- Syntax: `{{ string | image_tag }}`
+- Returns: `string`
+- Generates an HTML `<img>` tag for a given `image_url`.
+
+```liquid
+{{ product | image_url: width: 200 | image_tag }}
+```
+
+### `media_tag`
+
+- Syntax: `{{ media | media_tag }}`
+- Returns: `string`
+- Generates an appropriate HTML tag for a given media object.
+
+```liquid
+{% for media in product.media %}
+  {{- media | media_tag }}
+{% endfor %}
+```
+
+### `model_viewer_tag`
+
+- Syntax: `{{ media | model_viewer_tag }}`
+- Returns: `string`
+- Generates a Google model viewer component for a given 3D model.
+
+```liquid
+{% for media in product.media %}
+  {% if media.media_type == 'model' %}
+    {{ media | model_viewer_tag }}
+  {% endif %}
+{% endfor %}
+```
+
+### `video_tag`
+
+- Syntax: `{{ media | video_tag }}`
+- Returns: `string`
+- Generates an HTML `<video>` tag for a given video.
+
+```liquid
+{% for media in product.media %}
+  {% if media.media_type == 'video' %}
+    {{ media | video_tag }}
+  {% endif %}
+{% endfor %}
+```
+
+### `article_img_url` *(deprecated)*
+
+- Syntax: `{{ variable | article_img_url }}`
+- Returns: `string`
+- Returns the CDN URL for an article's image.
+
+```liquid
+{{ article.image | article_img_url }}
+```
+
+### `collection_img_url` *(deprecated)*
+
+- Syntax: `{{ variable | collection_img_url }}`
+- Returns: `string`
+- Returns the CDN URL for a collection's image.
+
+```liquid
+{{ collection.image | collection_img_url }}
+```
+
+### `image_url`
+
+- Syntax: `{{ variable | image_url: width: number, height: number }}`
+- Returns: `string`
+- Returns the CDN URL for an image.
+
+```liquid
+{{ product | image_url: width: 450 }}
+```
+
+### `img_tag` *(deprecated)*
+
+- Syntax: `{{ string | img_tag }}`
+- Returns: `string`
+- Generates an HTML `<img>` tag for a given image URL.
+
+```liquid
+{{ product | img_tag }}
+```
+
+### `img_url` *(deprecated)*
+
+- Syntax: `{{ variable | img_url }}`
+- Returns: `string`
+- Returns the CDN URL for an image.
+
+```liquid
+{{ product | img_url }}
+```
+
+### `product_img_url` *(deprecated)*
+
+- Syntax: `{{ variable | product_img_url }}`
+- Returns: `string`
+- Returns the CDN URL for a product image.
+
+```liquid
+{{ product.featured_image | product_img_url }}
+```
+

--- a/plugins/shopify-liquid/skills/shopify-liquid-themes/references/filters-language.md
+++ b/plugins/shopify-liquid/skills/shopify-liquid-themes/references/filters-language.md
@@ -1,0 +1,916 @@
+# Liquid Filters - Language
+
+> 77 filters across 6 categories.
+
+## Array
+
+### `compact`
+
+- Syntax: `{{ array | compact }}`
+- Returns: `array`
+- Removes any `nil` items from an array.
+
+```liquid
+{%- assign original_prices = collection.products | map: 'compare_at_price' -%}
+
+Original prices:
+
+{% for price in original_prices -%}
+  - {{ price }}
+{%- endfor %}
+
+{%- assign compacted_original_prices = original_prices | compact -%}
+
+Original prices - compacted:
+
+{% for price in compacted_original_prices -%}
+  - {{ price }}
+{%- endfor %}
+```
+
+### `concat`
+
+- Syntax: `{{ array | concat: array }}`
+- Returns: `array`
+- Concatenates (combines) two arrays.
+
+```liquid
+{%- assign types_and_vendors = collection.all_types | concat: collection.all_vendors -%}
+
+Types and vendors:
+
+{% for item in types_and_vendors -%}
+  {%- if item != blank -%}
+    - {{ item }}
+  {%- endif -%}
+{%- endfor %}
+```
+
+### `find`
+
+- Syntax: `{{ array | find: string, string }}`
+- Returns: `untyped`
+- Returns the first item in an array with a specific property value.
+
+```liquid
+{% assign product = collection.products | find: 'vendor', "Polina's Potent Potions" %}
+
+{{ product.title }}
+```
+
+### `find_index`
+
+- Syntax: `{{ array | find_index: string, string }}`
+- Returns: `number`
+- Returns the index of the first item in an array with a specific property value.
+
+```liquid
+{% assign index = collection.products | find_index: 'vendor', "Polina's Potent Potions" %}
+
+{{ index }}
+```
+
+### `first`
+
+- Syntax: `{{ array | first }}`
+- Returns: `untyped`
+- Returns the first item in an array.
+
+```liquid
+{%- assign first_product = collection.products | first -%}
+
+{{ first_product.title }}
+```
+
+### `has`
+
+- Syntax: `{{ array | has: string, string }}`
+- Returns: `boolean`
+- Tests if any item in an array has a specific property value.
+
+```liquid
+{% assign has_potent_potions = collection.products | has: 'vendor', "Polina's Potent Potions" %}
+
+{{ has_potent_potions }}
+```
+
+### `join`
+
+- Syntax: `{{ array | join }}`
+- Returns: `string`
+- Combines all of the items in an array into a single string, separated by a space.
+
+```liquid
+{{ collection.all_tags | join }}
+```
+
+### `last`
+
+- Syntax: `{{ array | last }}`
+- Returns: `untyped`
+- Returns the last item in an array.
+
+```liquid
+{%- assign last_product = collection.products | last -%}
+
+{{ last_product.title }}
+```
+
+### `map`
+
+- Syntax: `{{ array | map: string }}`
+- Returns: `array`
+- Creates an array of values from a specific property of the items in an array.
+
+```liquid
+{%- assign product_titles = collection.products | map: 'title' -%}
+
+{{ product_titles | join: ', ' }}
+```
+
+### `reject`
+
+- Syntax: `{{ array | reject: string, string }}`
+- Returns: `array`
+- Filters an array to exclude items with a specific property value.
+
+```liquid
+{% assign polina_products = collection.products | reject: 'vendor', "Polina's Potent Potions" %}
+
+Products from other vendors than Polina's Potent Potions:
+
+{% for product in polina_products -%}
+  - {{ product.title }}
+{%- endfor %}
+```
+
+### `reverse`
+
+- Syntax: `{{ array | reverse }}`
+- Returns: `array`
+- Reverses the order of the items in an array.
+
+```liquid
+Original order:
+{{ collection.products | map: 'title' | join: ', ' }}
+
+Reverse order:
+{{ collection.products | reverse | map: 'title' | join: ', ' }}
+```
+
+### `size`
+
+- Syntax: `{{ variable | size }}`
+- Returns: `number`
+- Returns the size of a string or array.
+
+```liquid
+{{ collection.title | size }}
+{{ collection.products | size }}
+```
+
+### `sort`
+
+- Syntax: `{{ array | sort }}`
+- Returns: `array`
+- Sorts the items in an array in case-sensitive alphabetical, or numerical, order.
+
+```liquid
+{% assign tags = collection.all_tags | sort %}
+
+{% for tag in tags -%}
+  {{ tag }}
+{%- endfor %}
+```
+
+### `sort_natural`
+
+- Syntax: `{{ array | sort_natural }}`
+- Returns: `array`
+- Sorts the items in an array in case-insensitive alphabetical order.
+
+```liquid
+{% assign tags = collection.all_tags | sort_natural %}
+
+{% for tag in tags -%}
+  {{ tag }}
+{%- endfor %}
+```
+
+### `sum`
+
+- Syntax: `{{ array | sum }}`
+- Returns: `number`
+- Returns the sum of all elements in an array.
+
+```liquid
+{% assign fibonacci = '0, 1, 1, 2, 3, 5' | split: ', ' %}
+
+{{ fibonacci | sum }}
+```
+
+### `uniq`
+
+- Syntax: `{{ array | uniq }}`
+- Returns: `array`
+- Removes any duplicate items in an array.
+
+```liquid
+{% assign potion_array = 'invisibility, health, love, health, invisibility' | split: ', ' %}
+
+{{ potion_array | uniq | join: ', ' }}
+```
+
+### `where`
+
+- Syntax: `{{ array | where: string, string }}`
+- Returns: `array`
+- Filters an array to include only items with a specific property value.
+
+```liquid
+{% assign polina_products = collection.products | where: 'vendor', "Polina's Potent Potions" %}
+
+Products from Polina's Potent Potions:
+
+{% for product in polina_products -%}
+  - {{ product.title }}
+{%- endfor %}
+```
+
+## Date
+
+### `date`
+
+- Syntax: `{{ date | date: string }}`
+- Returns: `string`
+- Formats a date according to a specified format string.
+
+## Default
+
+### `default_errors`
+
+- Syntax: `{{ string | default_errors }}`
+- Returns: `string`
+- Generates default error messages for each possible value of `form.errors`.
+
+### `default`
+
+- Syntax: `{{ variable | default: variable }}`
+- Returns: `untyped`
+- Sets a default value for any variable whose value is one of the following:
+
+- `empty`
+- `false`
+- `nil`
+
+```liquid
+{{ product.selected_variant.url | default: product.url }}
+```
+
+### `default_pagination`
+
+- Syntax: `{{ paginate | default_pagination }}`
+- Returns: `string`
+- Generates HTML for a set of links for paginated results. Must be applied to the `paginate` object.
+
+```liquid
+{% paginate collection.products by 2 %}
+  {% for product in collection.products %}
+    {{- product.title }}
+  {% endfor %}
+
+  {{- paginate | default_pagination -}}
+{% endpaginate %}
+```
+
+## Format
+
+### `date`
+
+- Syntax: `{{ string | date: string }}`
+- Returns: `string`
+- Converts a timestamp into another date format.
+
+```liquid
+{{ article.created_at | date: '%B %d, %Y' }}
+```
+
+### `json`
+
+- Syntax: `{{ variable | json }}`
+- Returns: `string`
+- Converts a string, or object, into JSON format.
+
+```liquid
+{{ product | json }}
+```
+
+### `structured_data`
+
+- Syntax: `{{ variable | structured_data }}`
+- Returns: `string`
+- Converts an object into a schema.org structured data format.
+
+```liquid
+&lt;script type="application/ld+json"&gt;
+  {{ product | structured_data }}
+&lt;/script&gt;
+```
+
+### `unit_price_with_measurement`
+
+- Syntax: `{{ number | unit_price_with_measurement: unit_price_measurement }}`
+- Returns: `string`
+- Formats a given unit price and measurement based on the store's HTML without currency setting.
+
+```liquid
+{%- assign variant = product.variants.first -%}
+
+{{ variant.unit_price | unit_price_with_measurement: variant.unit_price_measurement }}
+```
+
+### `weight_with_unit`
+
+- Syntax: `{{ number | weight_with_unit }}`
+- Returns: `string`
+- Generates a formatted weight for a `variant` object. The weight unit is
+set in the general settings in the Shopify admin.
+
+```liquid
+{%- assign variant = product.variants.first -%}
+
+{{ variant.weight | weight_with_unit }}
+```
+
+## Math
+
+### `abs`
+
+- Syntax: `{{ number | abs }}`
+- Returns: `number`
+- Returns the absolute value of a number.
+
+```liquid
+{{ -3 | abs }}
+```
+
+### `at_least`
+
+- Syntax: `{{ number | at_least }}`
+- Returns: `number`
+- Limits a number to a minimum value.
+
+```liquid
+{{ 4 | at_least: 5 }}
+{{ 4 | at_least: 3 }}
+```
+
+### `at_most`
+
+- Syntax: `{{ number | at_most }}`
+- Returns: `number`
+- Limits a number to a maximum value.
+
+```liquid
+{{ 6 | at_most: 5 }}
+{{ 4 | at_most: 5 }}
+```
+
+### `ceil`
+
+- Syntax: `{{ number | ceil }}`
+- Returns: `number`
+- Rounds a number up to the nearest integer.
+
+```liquid
+{{ 1.2 | ceil }}
+```
+
+### `divided_by`
+
+- Syntax: `{{ number | divided_by: number }}`
+- Returns: `number`
+- Divides a number by a given number. The `divided_by` filter produces a result of the same type as the divisor. This means if you divide by an integer, the result will be an integer, and if you divide by a float, the result will be a float.
+
+```liquid
+{{ 4 | divided_by: 2 }}
+
+# divisor is an integer
+{{ 20 | divided_by: 7 }}
+
+# divisor is a float 
+{{ 20 | divided_by: 7.0 }}
+```
+
+### `floor`
+
+- Syntax: `{{ number | floor }}`
+- Returns: `number`
+- Rounds a number down to the nearest integer.
+
+```liquid
+{{ 1.2 | floor }}
+```
+
+### `minus`
+
+- Syntax: `{{ number | minus: number }}`
+- Returns: `number`
+- Subtracts a given number from another number.
+
+```liquid
+{{ 4 | minus: 2 }}
+```
+
+### `modulo`
+
+- Syntax: `{{ number | modulo: number }}`
+- Returns: `number`
+- Returns the remainder of dividing a number by a given number.
+
+```liquid
+{{ 12 | modulo: 5 }}
+```
+
+### `plus`
+
+- Syntax: `{{ number | plus: number }}`
+- Returns: `number`
+- Adds two numbers.
+
+```liquid
+{{ 2 | plus: 2 }}
+```
+
+### `round`
+
+- Syntax: `{{ number | round }}`
+- Returns: `number`
+- Rounds a number to the nearest integer.
+
+```liquid
+{{ 2.7 | round }}
+{{ 1.3 | round }}
+```
+
+### `times`
+
+- Syntax: `{{ number | times: number }}`
+- Returns: `number`
+- Multiplies a number by a given number.
+
+```liquid
+{{ 2 | times: 2 }}
+```
+
+## String
+
+### `blake3`
+
+- Syntax: `{{ string | blake3 }}`
+- Returns: `string`
+- Converts a string into a Blake3 hash.
+
+```liquid
+{{ '' | blake3 }}
+```
+
+### `hmac_sha1`
+
+- Syntax: `{{ string | hmac_sha1: string }}`
+- Returns: `string`
+- Converts a string into an SHA-1 hash using a hash message authentication code (HMAC).
+
+```liquid
+{%- assign secret_potion = 'Polyjuice' | hmac_sha1: 'Polina' -%}
+
+My secret potion: {{ secret_potion }}
+```
+
+### `hmac_sha256`
+
+- Syntax: `{{ string | hmac_sha256: string }}`
+- Returns: `string`
+- Converts a string into an SHA-256 hash using a hash message authentication code (HMAC).
+
+```liquid
+{%- assign secret_potion = 'Polyjuice' | hmac_sha256: 'Polina' -%}
+
+My secret potion: {{ secret_potion }}
+```
+
+### `md5`
+
+- Syntax: `{{ string | md5 }}`
+- Returns: `string`
+- Converts a string into an MD5 hash. MD5 is not considered safe anymore. Please use 'blake3' instead for better security and performance.
+
+```liquid
+{{ '' | md5 }}
+```
+
+### `sha1`
+
+- Syntax: `{{ string | sha1: string }}`
+- Returns: `string`
+- Converts a string into an SHA-1 hash. SHA-1 is not considered safe anymore. Please use 'blake3' instead for better security and performance.
+
+```liquid
+{%- assign secret_potion = 'Polyjuice' | sha1 -%}
+
+My secret potion: {{ secret_potion }}
+```
+
+### `sha256`
+
+- Syntax: `{{ string | sha256: string }}`
+- Returns: `string`
+- Converts a string into an SHA-256 hash. Please use 'blake3' instead for better security and performance.
+
+```liquid
+{%- assign secret_potion = 'Polyjuice' | sha256 -%}
+
+My secret potion: {{ secret_potion }}
+```
+
+### `append`
+
+- Syntax: `{{ string | append: string }}`
+- Returns: `string`
+- Adds a given string to the end of a string.
+
+```liquid
+{%-  assign path = product.url -%}
+
+{{ request.origin | append: path }}
+```
+
+### `base64_decode`
+
+- Syntax: `{{ string | base64_decode }}`
+- Returns: `string`
+- Decodes a string in Base64 format.
+
+```liquid
+{{ 'b25lIHR3byB0aHJlZQ==' | base64_decode }}
+```
+
+### `base64_encode`
+
+- Syntax: `{{ string | base64_encode }}`
+- Returns: `string`
+- Encodes a string to Base64 format.
+
+```liquid
+{{ 'one two three' | base64_encode }}
+```
+
+### `base64_url_safe_decode`
+
+- Syntax: `{{ string | base64_url_safe_decode }}`
+- Returns: `string`
+- Decodes a string in URL-safe Base64 format.
+
+```liquid
+{{ 'b25lIHR3byB0aHJlZQ==' | base64_url_safe_decode }}
+```
+
+### `base64_url_safe_encode`
+
+- Syntax: `{{ string | base64_url_safe_encode }}`
+- Returns: `string`
+- Encodes a string to URL-safe Base64 format.
+
+```liquid
+{{ 'one two three' | base64_url_safe_encode }}
+```
+
+### `capitalize`
+
+- Syntax: `{{ string | capitalize }}`
+- Returns: `string`
+- Capitalizes the first word in a string and downcases the remaining characters.
+
+```liquid
+{{ 'this sentence should start with a capitalized word.' | capitalize }}
+```
+
+### `downcase`
+
+- Syntax: `{{ string | downcase }}`
+- Returns: `string`
+- Converts a string to all lowercase characters.
+
+```liquid
+{{ product.title | downcase }}
+```
+
+### `escape`
+
+- Syntax: `{{ string | escape }}`
+- Returns: `string`
+- Escapes special characters in HTML, such as `<>`, `'`, and `&`, and converts characters into escape sequences. The filter doesn't effect characters within the string that don't have a corresponding escape sequence.".
+
+```liquid
+{{ '&lt;p&gt;Text to be escaped.&lt;/p&gt;' | escape }}
+```
+
+### `escape_once`
+
+- Syntax: `{{ string | escape_once }}`
+- Returns: `string`
+- Escapes a string without changing characters that have already been escaped.
+
+```liquid
+# applying the escape filter to already escaped text escapes characters in HTML entities:
+
+{{ "&amp;lt;p&amp;gt;Text to be escaped.&amp;lt;/p&amp;gt;" | escape }}
+
+# applying the escape_once filter to already escaped text skips characters in HTML entities:
+
+{{ "&amp;lt;p&amp;gt;Text to be escaped.&amp;lt;/p&amp;gt;" | escape_once }}
+
+# use escape_once to escape strings where a combination of HTML entities and non-escaped characters might be present:
+
+{{ "&amp;lt;p&amp;gt;Text to be escaped.&amp;lt;/p&amp;gt; &amp; some additional text" | escape_once }}
+```
+
+### `lstrip`
+
+- Syntax: `{{ string | lstrip }}`
+- Returns: `string`
+- Strips all whitespace from the left of a string.
+
+```liquid
+{%- assign text = '  Some potions create whitespace.      ' -%}
+
+"{{ text }}"
+"{{ text | lstrip }}"
+```
+
+### `newline_to_br`
+
+- Syntax: `{{ string | newline_to_br }}`
+- Returns: `string`
+- Converts newlines (`\n`) in a string to HTML line breaks (`<br>`).
+
+```liquid
+{{ product.description | newline_to_br }}
+```
+
+### `prepend`
+
+- Syntax: `{{ string | prepend: string }}`
+- Returns: `string`
+- Adds a given string to the beginning of a string.
+
+```liquid
+{%- assign origin = request.origin -%}
+
+{{ product.url | prepend: origin }}
+```
+
+### `remove`
+
+- Syntax: `{{ string | remove: string }}`
+- Returns: `string`
+- Removes any instance of a substring inside a string.
+
+```liquid
+{{ "I can't do it!" | remove: "'t" }}
+```
+
+### `remove_first`
+
+- Syntax: `{{ string | remove_first: string }}`
+- Returns: `string`
+- Removes the first instance of a substring inside a string.
+
+```liquid
+{{ "I hate it when I accidentally spill my duplication potion accidentally!" | remove_first: ' accidentally' }}
+```
+
+### `remove_last`
+
+- Syntax: `{{ string | remove_last: string }}`
+- Returns: `string`
+- Removes the last instance of a substring inside a string.
+
+```liquid
+{{ "I hate it when I accidentally spill my duplication potion accidentally!" | remove_last: ' accidentally' }}
+```
+
+### `replace`
+
+- Syntax: `{{ string | replace: string, string }}`
+- Returns: `string`
+- Replaces any instance of a substring inside a string with a given string.
+
+```liquid
+{{ product.handle | replace: '-', ' ' }}
+```
+
+### `replace_first`
+
+- Syntax: `{{ string | replace_first: string, string }}`
+- Returns: `string`
+- Replaces the first instance of a substring inside a string with a given string.
+
+```liquid
+{{ product.handle | replace_first: '-', ' ' }}
+```
+
+### `replace_last`
+
+- Syntax: `{{ string | replace_last: string, string }}`
+- Returns: `string`
+- Replaces the last instance of a substring inside a string with a given string.
+
+```liquid
+{{ product.handle | replace_last: '-', ' ' }}
+```
+
+### `rstrip`
+
+- Syntax: `{{ string | rstrip }}`
+- Returns: `string`
+- Strips all whitespace from the right of a string.
+
+```liquid
+{%- assign text = '  Some potions create whitespace.      ' -%}
+
+"{{ text }}"
+"{{ text | rstrip }}"
+```
+
+### `slice`
+
+- Syntax: `{{ string | slice }}`
+- Returns: `string`
+- Returns a substring or series of array items, starting at a given 0-based index.
+
+```liquid
+{{ collection.title | slice: 0 }}
+{{ collection.title | slice: 0, 5 }}
+
+{{ collection.all_tags | slice: 1, 2 | join: ', ' }}
+```
+
+### `split`
+
+- Syntax: `{{ string | split: string }}`
+- Returns: `array`
+- Splits a string into an array of substrings based on a given separator.
+
+```liquid
+{%- assign title_words = product.handle | split: '-' -%}
+
+{% for word in title_words -%}
+  {{ word }}
+{%- endfor %}
+```
+
+### `strip`
+
+- Syntax: `{{ string | strip }}`
+- Returns: `string`
+- Strips all whitespace from the left and right of a string.
+
+```liquid
+{%- assign text = '  Some potions create whitespace.      ' -%}
+
+"{{ text }}"
+"{{ text | strip }}"
+```
+
+### `strip_html`
+
+- Syntax: `{{ string | strip_html }}`
+- Returns: `string`
+- Strips all HTML tags from a string.
+
+```liquid
+&lt;!-- With HTML --&gt;
+{{ product.description }}
+
+&lt;!-- HTML stripped --&gt;
+{{ product.description | strip_html }}
+```
+
+### `strip_newlines`
+
+- Syntax: `{{ string | strip_newlines }}`
+- Returns: `string`
+- Strips all newline characters (line breaks) from a string.
+
+```liquid
+&lt;!-- With newlines --&gt;
+{{ product.description }}
+
+&lt;!-- Newlines stripped --&gt;
+{{ product.description | strip_newlines }}
+```
+
+### `truncate`
+
+- Syntax: `{{ string | truncate: number }}`
+- Returns: `string`
+- Truncates a string down to a given number of characters.
+
+```liquid
+{{ article.title | truncate: 15 }}
+```
+
+### `truncatewords`
+
+- Syntax: `{{ string | truncatewords: number }}`
+- Returns: `string`
+- Truncates a string down to a given number of words.
+
+```liquid
+{{ article.content | strip_html | truncatewords: 15 }}
+```
+
+### `upcase`
+
+- Syntax: `{{ string | upcase }}`
+- Returns: `string`
+- Converts a string to all uppercase characters.
+
+```liquid
+{{ product.title | upcase }}
+```
+
+### `url_decode`
+
+- Syntax: `{{ string | url_decode }}`
+- Returns: `string`
+- Decodes any percent-encoded characters
+in a string.
+
+```liquid
+{{ 'test%40test.com' | url_decode }}
+```
+
+### `url_encode`
+
+- Syntax: `{{ string | url_encode }}`
+- Returns: `string`
+- Converts any URL-unsafe characters in a string to the
+percent-encoded equivalent.
+
+```liquid
+{{ 'test@test.com' | url_encode }}
+```
+
+### `camelize`
+
+- Syntax: `{{ string | camelize }}`
+- Returns: `string`
+- Converts a string to CamelCase.
+
+```liquid
+{{ 'variable-name' | camelize }}
+```
+
+### `handleize`
+
+- Syntax: `{{ string | handleize }}`
+- Returns: `string`
+- Converts a string into a handle.
+
+```liquid
+{{ product.title | handleize }}
+{{ product.title | handle }}
+```
+
+### `url_escape`
+
+- Syntax: `{{ string | url_escape }}`
+- Returns: `string`
+- Escapes any URL-unsafe characters in a string.
+
+```liquid
+{{ '&lt;p&gt;Health &amp; Love potions&lt;/p&gt;' | url_escape }}
+```
+
+### `url_param_escape`
+
+- Syntax: `{{ string | url_param_escape }}`
+- Returns: `string`
+- Escapes any characters in a string that are unsafe for URL parameters.
+
+```liquid
+{{ '&lt;p&gt;Health &amp; Love potions&lt;/p&gt;' | url_param_escape }}
+```
+
+### `pluralize`
+
+- Syntax: `{{ number | pluralize: string, string }}`
+- Returns: `string`
+- Outputs the singular or plural version of a string based on a given number.
+
+```liquid
+Cart item count: {{ cart.item_count }} {{ cart.item_count | pluralize: 'item', 'items' }}
+```
+

--- a/plugins/shopify-liquid/skills/shopify-liquid-themes/references/objects-commerce.md
+++ b/plugins/shopify-liquid/skills/shopify-liquid-themes/references/objects-commerce.md
@@ -1,0 +1,236 @@
+# Liquid Objects - Commerce
+
+> Core commerce objects with full property tables.
+
+## `cart`
+
+A customer's cart.
+
+Access: Global
+
+Properties:
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `requires_shipping` | `boolean` | Returns `true` if any of the products in the cart require shipping. Returns `false` if not. |
+| `note` | `string` | Additional information captured with the cart. |
+| `item_count` | `number` | The number of items in the cart. |
+| `total_price` | `number` | The total price of all of the items in the cart in the currency's subunit, after discounts have been applied. |
+| `checkout_charge_amount` | `number` | The amount that the customer will be charged at checkout in the currency's subunit. |
+| `original_total_price` | `number` | The total price of all of the items in the cart in the currency's subunit, before discounts have been applied. |
+| `items_subtotal_price` | `number` | The total price of all of the items in the cart in the currency's subunit, after any line item discounts. This doesn't include taxes (unless taxes are included in the prices), cart discounts, or shipping costs. |
+| `total_discount` | `number` | The total amount of all discounts (the amount saved) for the cart in the currency's subunit. |
+| `items` | `array` | The line items in the cart. |
+| `empty?` | `boolean` | Returns `true` if there are no items in the cart. Return's `false` if there are. |
+| `currency` | `` | The currency of the cart. |
+| `total_weight` | `number` | The total weight of all of the items in the cart in grams. |
+| `discount_applications` | `array` | The discount applications for the cart. |
+| `attributes` | `untyped` | Additional attributes entered by the customer with the cart. |
+| `cart_level_discount_applications` | `array` | The cart-specific discount applications for the cart. |
+| `taxes_included` | `boolean` | Returns `true` if taxes are included in the prices of products in the cart. Returns `false` if not. |
+| `duties_included` | `boolean` | Returns `true` if duties are included in the prices of products in the cart. Returns `false` if not. |
+
+## `line_item`
+
+A line in a cart, checkout, or order. Each line item represents a product variant.
+
+Access: `cart.line_items`, `checkout.line_items`, `order.line_items`, `parent_relationship.parent`
+
+Properties:
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `id` | `number` | The ID of the line item. |
+| `quantity` | `number` | The quantity of the line item. |
+| `discount_allocations` | `array` | The discount allocations that apply to the line item. |
+| `final_price` | `number` | The price of the line item in the currency's subunit. This includes any line-level discounts. |
+| `final_line_price` | `number` | The combined price, in the currency's subunit, of all of the items in the line item. This includes any line-level discounts. |
+| `variant_id` | `number` | The ID of the line item's variant. |
+| `product_id` | `number` | The ID of the line item's product. |
+| `product` | `product` | The product associated with the line item. May be a regular product or a remote product. |
+| `variant` | `variant` | The variant associated with the line item. |
+| `tax_lines` | `array` | The tax lines for the line item. |
+| `fulfillment` | `fulfillment` | The fulfillment of the line item. |
+| `successfully_fulfilled_quantity` | `number` | The number of items from the line item that have been successfully fulfilled. |
+| `fulfillment_service` | `string` | The fulfillment service for the vartiant associated with the line item. If there's no fulfillment service, then `manual` is returned. |
+| `properties` | `array` | The properties of the line item. |
+| `unit_price_measurement` | `unit_price_measurement` | The unit price measurement of the line item. |
+| `unit_price` | `number` | The unit price  of the line item in the currency's subunit. |
+| `sku` | `string` | The sku of the variant associated with the line item. |
+| `message` | `string` | Information about the discounts that have affected the line item. |
+| `vendor` | `string` | The vendor of the variant associated with the line item. |
+| `title` | `string` | The title of the line item. The title is a combination of `line_item.product.title` and `line_item.variant.title`, separated by a hyphen. |
+| `taxable` | `boolean` | Returns `true` if taxes should be charged on the line item. Returns `false` if not. |
+| `original_price` | `number` | The price of the line item in the currency's subunit, before discounts have been applied. |
+| `original_line_price` | `number` | The combined price of all of the items in a line item in the currency's subunit, before any discounts have been applied. |
+| `line_level_total_discount` | `number` | The total amount of any discounts applied to the line item in the currency's subunit. |
+| `line_level_discount_allocations` | `array` | The discount allocations that apply directly to the line item. |
+| `gift_card` | `boolean` | Returns `true` if the product associated with the line item is a gift card. Returns `false` if not. |
+| `requires_shipping` | `boolean` | Returns `true` if the variant associated with the line item requires shipping. Returns `false` if not. |
+| `options_with_values` | `array` | The name and value pairs for each option of the variant associated with the line item. |
+| `key` | `string` | The key of the line item. |
+| `grams` | `number` | The weight of the line item in the store's default weight unit. |
+| `url` | `string` | The relative URL of the variant associated with the line item. |
+| `url_to_remove` | `string` | A URL to remove the line item from the cart. |
+| `image` | `image` | The image of the line item. |
+| `selling_plan_allocation` | `selling_plan_allocation` | The selling plan allocation of the line item. If the line item doesn't have a selling plan allocation, then `nil` is returned. |
+| `item_components` | `array` | The components of a line item. |
+| `instructions` | `instructions` | Instructions define behaviours and operations that can be performed on the nested cart line. |
+| `parent_relationship` | `parent_relationship` | The parent relationship for a nested line item. |
+| `error_message` | `string` | An informational error message about the status of the line item in the buyer's chosen language. |
+
+## `order`
+
+An order.
+
+Access: `checkout.order`, `customer.last_order`, `customer.orders`
+
+Properties:
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `attributes` | `untyped` | The attributes on the order. |
+| `cancel_reason` | `string` | The reason that the order was cancelled. |
+| `cancel_reason_label` | `string` | The localized version of the cancellation reason for the order. |
+| `cancelled` | `boolean` | Returns `true` if the order was cancelled. Returns `false` if not. |
+| `cancelled_at` | `string` | A timestamp for when the order was cancelled. |
+| `cart_level_discount_applications` | `array` | The discount applications that apply at the order level. |
+| `created_at` | `string` | A timestamp for when the order was created. |
+| `total_duties` | `number` | The sum of all duties applied to the line items in the order in the currency's subunit. |
+| `customer_url` | `string` | The URL for the customer to view the order in their account. |
+| `customer` | `customer` | The customer that placed the order. |
+| `discount_applications` | `array` | All of the discount applications for the order and its line items. |
+| `total_discounts` | `number` | The total amount of all discounts applied to the order in the currency's subunit. |
+| `total_net_amount` | `number` | The net amount of the order in the currency's subunit. |
+| `tax_price` | `number` | The total amount of taxes applied to the order in the currency's subunit. |
+| `total_refunded_amount` | `number` | The total amount that's been refunded from the order in the currency's subunit. |
+| `email` | `string` | The email that's associated with the order. |
+| `financial_status` | `string` | The order's financial status. |
+| `financial_status_label` | `` | The localized version of the financial status of the order. |
+| `fulfillment_status` | `string` | The fulfillment status of the order. |
+| `fulfillment_status_label` | `string` | The localized version of the fulfillment status of the order. |
+| `id` | `number` | The ID of the order. |
+| `metafields` | `untyped` | The metafields applied to the order. |
+| `name` | `string` | The name of the order. |
+| `note` | `string` | The note on the order. |
+| `confirmation_number` | `string` | A randomly generated alpha-numeric identifier for the order that may be shown to the customer instead of the sequential order name. For example, "XPAV284CT", "R50KELTJP" or "35PKUN0UJ". This value isn't guaranteed to be unique. |
+| `order_number` | `number` | The integer representation of the order name. |
+| `order_status_url` | `string` | The URL for the Order status page for the order. |
+| `customer_order_url` | `string` | The URL for the new order details page. |
+| `phone` | `string` | The phone number associated with the order. |
+| `shipping_address` | `address` | The shipping address of the order. |
+| `billing_address` | `address` | The billing address of the order. |
+| `tags` | `array` | The tags on the order. |
+| `tax_lines` | `array` | The tax lines on the order. |
+| `transactions` | `array` | The transactions of the order. |
+| `line_items` | `array` | The line items in the order. |
+| `subtotal_line_items` | `array` | The non-tip line items in the order. |
+| `item_count` | `number` | The number of items in the order. |
+| `shipping_methods` | `array` | The shipping methods for the order. |
+| `line_items_subtotal_price` | `number` | The sum of the prices of all of the line items in the order in the currency's subunit, after any line item discounts have been applied. |
+| `subtotal_price` | `number` | The sum of the prices of the subtotal line items in the currency's subunit, after any line item or cart discounts have been applied. |
+| `total_price` | `number` | The total price of the order in the currency's subunit. |
+| `shipping_price` | `number` | The shipping price of the order in the currency's subunit. |
+| `pickup_in_store?` | `boolean` | Returns `true` if the order is a store pickup order. |
+
+## `product`
+
+A product in the store.
+
+Access: `all_products.`, `collection.products`, `line_item.product`, `link.object`, `metafield.value`, `recommendations.products`, `search.results`, `variant.product`
+
+Properties:
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `selling_plan_groups` | `array` | The selling plan groups that the variants of the product are included in. |
+| `metafields` | `untyped` | The metafields applied to the product. |
+| `options_with_values` | `array` | The options on the product. |
+| `category` | `taxonomy_category` | The taxonomy category for the product |
+| `variants` | `array` | The variants of the product. |
+| `variants_count` | `number` | The total number of variants for the product. |
+| `id` | `number` | The ID of the product. |
+| `title` | `string` | The title of the product. |
+| `handle` | `string` | The handle of the product. |
+| `template_suffix` | `string` | The name of the custom template of the product. |
+| `vendor` | `string` | The vendor of the product. |
+| `description` | `string` | The description of the product. |
+| `content` | `string` | The description of the product. |
+| `featured_image` | `image` | The first (featured) image attached to the product. |
+| `featured_media` | `media` | The first (featured) media attached to the product. |
+| `media` | `array` | The media attached to the product, sorted by the date it was added to the product. |
+| `images` | `array` | The images attached to the product. |
+| `price_min` | `number` | The lowest price of any variants of the product in the currency's subunit. |
+| `price` | `number` | The lowest price of any variants of the product in the currency's subunit. |
+| `price_max` | `number` | The highest price of any variants of the product in the currency's subunit. |
+| `price_varies` | `boolean` | Returns `true` if the product's variant prices vary. Returns `false` if not. |
+| `selected_or_first_available_variant` | `variant` | The currently selected or first available variant of the product. |
+| `collections` | `array` | The collections that the product belongs to. |
+| `selected_variant` | `variant` | The currently selected variant of the product. |
+| `first_available_variant` | `variant` | The first available variant of the product. |
+| `available` | `boolean` | Returns `true` if at least one of the variants of the product is available. Returns `false` if not. |
+| `options` | `array` | The option names of the product. |
+| `type` | `string` | The type of the product. |
+| `compare_at_price_min` | `number` | The lowest compare at price of any variants of the product in the currency's subunit. This is the same as `product.compare_at_price`. |
+| `compare_at_price_max` | `number` | The highest compare at price of any variants of the product in the currency's subunit. |
+| `compare_at_price` | `number` | The lowest compare at price of any variants of the product in the currency's subunit. |
+| `compare_at_price_varies` | `boolean` | Returns `true` if the variant compare at prices of the product vary. Returns `false` if not. |
+| `url` | `string` | The relative URL of the product. |
+| `tags` | `array` | The tags of the product. |
+| `published_at` | `string` | A timestamp for when the product was published. |
+| `created_at` | `string` | A timestamp for when the product was created. |
+| `options_by_name` | `untyped` | Allows you to access a specific product option by its name. |
+| `has_only_default_variant` | `boolean` | Returns `true` if the product doesn't have any options. Returns `false` if not. |
+| `quantity_price_breaks_configured?` | `boolean` | Returns `true` if the product has at least one variant with quantity price breaks in the current customer context. Returns `false` if not. |
+| `requires_selling_plan` | `boolean` | Returns `true` if all of the variants of the product require a selling plan. Returns `false` if not. |
+| `selected_selling_plan` | `selling_plan` | The currently selected selling plan. |
+| `selected_selling_plan_allocation` | `selling_plan_allocation` | The currently selected selling plan allocation for the currently selected variant. |
+| `selected_or_first_available_selling_plan_allocation` | `selling_plan_allocation` | The currently selected, or first available, selling plan allocation. |
+| `gift_card?` | `boolean` | Returns `true` if the product is a gift card. Returns `false` if not. |
+
+## `variant`
+
+A product variant.
+
+Access: `line_item.variant`, `product.first_available_variant`, `product.selected_or_first_available_variant`, `product.variants`, `product.selected_variant`, `product_option_value.variant`, `remote_product.selected_or_first_available_variant`, `remote_product.selected_variant`, `remote_product.first_available_variant`
+
+Properties:
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `metafields` | `untyped` | The metafields applied to the variant. |
+| `product` | `product` | The parent product of the variant. |
+| `selected` | `boolean` | Returns `true` if the variant is currently selected. Returns `false` if it's not. |
+| `matched` | `boolean` | Returns `true` if the variant has been matched by a storefront filter or no filters are applied. Returns `false` if it hasn't. |
+| `id` | `number` | The ID of the variant. |
+| `title` | `string` | A concatenation of each variant option, separated by a `/`. |
+| `quantity_rule` | `quantity_rule` | The quantity rule for the variant. |
+| `quantity_price_breaks` | `array` | Returns `quantity_price_break` objects for the variant in the current customer context. |
+| `quantity_price_breaks_configured?` | `boolean` | Returns `true` if the variant has any quantity price breaks available in the current customer context. Returns `false` if it doesn't. |
+| `price` | `number` | The price of the variant in the currency's subunit. |
+| `compare_at_price` | `number` | The compare at price of the variant in the currency's subunit. |
+| `selected_selling_plan_allocation` | `selling_plan_allocation` | The selected `selling_plan_allocation`. |
+| `selling_plan_allocations` | `array` | The `selling_plan_allocation` objects for the variant. |
+| `sku` | `string` | The SKU of the variant. |
+| `barcode` | `string` | The barcode of the variant. |
+| `available` | `boolean` | Returns `true` if the variant is available. Returns `false` if not. |
+| `options` | `product_option_value` | The values of the variant for each product option. |
+| `url` | `string` | The URL of the variant. |
+| `weight_unit` | `string` | The unit for the weight of the variant. |
+| `weight_in_unit` | `number` | The weight of the variant in the unit specified by `variant.weight_unit`. |
+| `weight` | `number` | The weight of the variant in grams. |
+| `unit_price_measurement` | `unit_price_measurement` | The unit price measurement of the variant. |
+| `unit_price` | `number` | The unit price of the variant in the currency's subunit. |
+| `inventory_quantity` | `number` | The inventory quantity of the variant. |
+| `inventory_management` | `string` | The inventory management service of the variant. |
+| `inventory_policy` | `string` | Whether the variant should continue to be sold when it's out of stock. |
+| `requires_shipping` | `boolean` | Returns `true` if the variant requires shipping. Returns `false` if it doesn't. |
+| `taxable` | `boolean` | Returns `true` if taxes should be charged on the variant. Returns `false` if not. |
+| `featured_image` | `image` | The image attached to the variant. |
+| `image` | `image` | The image attached to the variant. |
+| `featured_media` | `media` | The first media object attached to the variant. |
+| `incoming` | `boolean` | Returns `true` if the variant has incoming inventory. Returns `false` if not. |
+| `next_incoming_date` | `string` | The arrival date for the next incoming inventory of the variant. |
+| `store_availabilities` | `array` | The store availabilities for the variant. |
+| `requires_selling_plan` | `boolean` | Returns `true` if the variant's product is set to require a `selling_plan` when being added to the cart. Returns `false` if not. |
+

--- a/plugins/shopify-liquid/skills/shopify-liquid-themes/references/objects-content.md
+++ b/plugins/shopify-liquid/skills/shopify-liquid-themes/references/objects-content.md
@@ -1,0 +1,279 @@
+# Liquid Objects - Content & Theme
+
+> Content and theme objects with full property tables.
+
+## `article`
+
+An article, or blog post, in a blog.
+
+Access: `articles.`, `blog.articles`
+
+Properties:
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `image` | `image` | The featured image for the article. |
+| `author` | `string` | The full name of the author of the article. |
+| `metafields` | `untyped` | The metafields applied to the article. |
+| `handle` | `string` | The handle of the article. |
+| `id` | `string` | The ID of the article. |
+| `title` | `string` | The title of the article. |
+| `url` | `string` | The relative URL of the article. |
+| `template_suffix` | `string` | The name of the custom template assigned to the article. |
+| `created_at` | `string` | A timestamp for when the article was created. |
+| `published_at` | `string` | A timestamp for when the article was published. |
+| `updated_at` | `string` | A timestamp for when the article was updated. |
+| `moderated?` | `boolean` | Returns `true` if the blog that the article belongs to is set to moderate comments. Returns `false` if not. |
+| `comments` | `array` | The published comments for the article. |
+| `comments_count` | `number` | The number of published comments for the article. |
+| `comments_enabled?` | `boolean` | Returns `true` if comments are enabled. Returns `false` if not. |
+| `comment_post_url` | `string` | The relative URL where POST requests are sent when creating new comments. |
+| `content` | `string` | The content of the article. |
+| `excerpt` | `string` | The excerpt of the article. |
+| `excerpt_or_content` | `string` | Returns the article excerpt if it exists. Returns the article content if no excerpt exists. |
+| `tags` | `array` | The tags applied to the article. |
+| `user` | `user` | The user associated with the author of the article. |
+
+## `block`
+
+The content and settings of a section block.
+
+Access: `section.blocks`
+
+Properties:
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `id` | `string` | The ID of the block. |
+| `settings` | `untyped` | The settings of the block. |
+| `type` | `string` | The type of the block. |
+| `shopify_attributes` | `string` | The data attributes for the block for use in the theme editor. |
+
+## `blog`
+
+Information about a specific blog in the store.
+
+Access: Templates: blog, article
+
+Properties:
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `id` | `number` | The ID of the blog. |
+| `title` | `string` | The title of the blog. |
+| `handle` | `string` | The handle of the blog. |
+| `articles` | `array` | The articles in the blog. |
+| `articles_count` | `number` | The total number of articles in the blog. This total doesn't include hidden articles. |
+| `metafields` | `array` | The metafields applied to the blog. |
+| `url` | `string` | The relative URL of the blog. |
+| `template_suffix` | `string` | The name of the custom template assigned to the blog. |
+| `all_tags` | `array` | All of the tags on the articles in the blog. |
+| `tags` | `array` | A list of all of the tags on all of the articles in the blog.  Unlike `blog.all_tags`, this property only returns tags of articles that are in the filtered view. |
+| `comments_enabled?` | `boolean` | Returns `true` if comments are enabled for the blog. Returns `false` if not. |
+| `moderated?` | `boolean` | Returns `true` if the blog is set to moderate comments. Returns `false` if not. |
+| `next_article` | `article` | The next (older) article in the blog. |
+| `previous_article` | `article` | The previous (newer) article in the blog. |
+
+## `collection`
+
+A collection in a store.
+
+Access: `collections.`
+
+Properties:
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `metafields` | `array` | The metafields applied to the collection. |
+| `id` | `number` | The ID of the collection. |
+| `handle` | `string` | The handle of the collection. |
+| `title` | `string` | The title of the collection. |
+| `description` | `string` | The description of the collection. |
+| `template_suffix` | `string` | The name of the custom template assigned to the collection. |
+| `current_vendor` | `string` | The vendor name on a vendor collection page. |
+| `current_type` | `string` | The product type on a product type collection page. |
+| `url` | `string` | The relative URL of the collection. |
+| `published_at` | `string` | A timestamp for when the collection was published. |
+| `image` | `image` | The image for the collection. |
+| `sort_options` | `array` | The available sorting options for the collection. |
+| `sort_by` | `string` | The sort order applied to the collection by the `sort_by` URL parameter. |
+| `default_sort_by` | `string` | The default sort order of the collection. |
+| `next_product` | `product` | The next product in the collection. Returns `nil` if there's no next product. |
+| `previous_product` | `product` | The previous product in the collection. Returns `nil` if there's no previous product. |
+| `products_count` | `number` | The total number of products in the current view of the collection. |
+| `products` | `array` | All of the products in the collection. |
+| `all_products_count` | `number` | The total number of products in a collection. |
+| `all_tags` | `array` | All of the tags applied to the products in the collection. |
+| `tags` | `array` | The tags that are currently applied to the collection. |
+| `all_types` | `array` | All of the product types in a collection. |
+| `all_vendors` | `array` | All of the product vendors in a collection. |
+| `filters` | `array` | The storefront filters that have been set up on the collection. |
+| `featured_image` | `image` | The featured image for the collection. |
+
+## `customer`
+
+A customer of the store.
+
+Access: Global
+
+Properties:
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `first_name` | `string` | The first name of the customer. |
+| `last_name` | `string` | The last name of the customer. |
+| `orders_count` | `number` | The total number of orders that the customer has placed. |
+| `total_spent` | `number` | The total amount that the customer has spent on all orders in the currency's subunit. |
+| `orders` | `array` | All of the orders placed by the customer. |
+| `last_order` | `order` | The last order placed by the customer, not including test orders. |
+| `name` | `string` | The full name of the customer. |
+| `email` | `string` | The email of the customer. |
+| `phone` | `string` | The phone number of the customer. |
+| `has_account` | `boolean` | Returns `true` if the email associated with the customer is tied to a customer account. Returns `false` if not. |
+| `accepts_marketing` | `boolean` | Returns `true` if the customer accepts marketing. Returns `false` if not. |
+| `id` | `number` | The ID of the customer. |
+| `tags` | `array` | The tags associated with the customer. |
+| `default_address` | `address` | The default address of the customer. |
+| `addresses` | `array` | All of the addresses associated with the customer. |
+| `addresses_count` | `number` | The number of addresses associated with the customer. |
+| `tax_exempt` | `boolean` | Returns `true` if the customer is exempt from taxes. Returns `false` if not. |
+| `payment_methods` | `array` | The customer's saved payment methods. |
+| `b2b?` | `boolean` | Returns `true` if the customer is a B2B customer. Returns `false` if not. |
+| `company_available_locations` | `array` | The company locations that the customer has access to, or can interact with. |
+| `company_available_locations_count` | `number` | The number of company locations associated with the customer. |
+| `current_location` | `company_location` | The currently selected company location. |
+| `current_company` | `company` | The company that the customer is purchasing for. |
+| `has_avatar?` | `boolean` | Returns `true` if an avatar is associated with a customer. Returns `false` if not. |
+| `store_credit_account` | `store_credit_account` | The store credit account associated with the customer. |
+
+## `form`
+
+Information about a form created by a `form` tag.
+
+Properties:
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `errors` | `form_errors` | Any errors from the form. |
+| `address1` | `string` | The first address line associated with the address. |
+| `address2` | `string` | The second address line associated with the address. |
+| `author` | `string` | The name of the author of the article comment. |
+| `body` | `string` | The content of the contact submission or article comment. |
+| `city` | `string` | The city associated with the address. |
+| `company` | `string` | The company associated with the address. |
+| `country` | `string` | The country associated with the address. |
+| `email` | `string` | The email associated with the form. |
+| `first_name` | `string` | The first name associated with the customer or address. |
+| `id` | `string` | The ID of the form. |
+| `last_name` | `string` | The last name associated with the customer or address. |
+| `password_needed` | `boolean` | Returns `true`. |
+| `phone` | `string` | The phone number associated with the address. |
+| `posted_successfully?` | `boolean` | Returns `true` if the form was submitted successfully. Returns `false` if there were errors. |
+| `province` | `string` | The province associated with the address. |
+| `set_as_default_checkbox` | `string` | Renders an HTML checkbox that can submit the address as the customer's default address. |
+| `name` | `string` | The nickname of the gift card recipient. |
+| `message` | `string` | The personalized message intended for the recipient. |
+| `zip` | `string` | The zip or postal code associated with the address. |
+
+## `image`
+
+An image, such as a product or collection image.
+
+Access: `article.image`, `blog.image`, `collection.image`, `generic_file.preview_image`, `line_item.image`, `media.preview_image`, `model.preview_image`, `product.featured_image`, `product.media`, `product.images`, `variant.image`, `video.preview_image`, `brand.favicon_url`, `brand.cover_image`, `brand.logo`, `brand.square_logo`, `collection.featured_image`, `external_video.preview_image`, `filter_value.image`, `image.preview_image`, `swatch.image`, `variant.featured_image`, `remote_product.featured_image`, `user.image`, `page_image.`
+
+Properties:
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `presentation` | `image_presentation` | The presentation settings for the image. |
+| `src` | `string` | The relative URL of the image. |
+| `width` | `number` | The width of the image in pixels. |
+| `height` | `number` | The height of the image in pixels. |
+| `aspect_ratio` | `number` | The aspect ratio of the image as a decimal. |
+| `alt` | `string` | The alt text of the image. |
+| `attached_to_variant?` | `boolean` | Returns `true` if the image is associated with a variant. Returns `false` if not. |
+| `id` | `number` | The ID of the image. |
+| `media_type` | `string` | The media type of the image. Always returns `image`. |
+| `position` | `number` | The position of the image in the `product.images` or `product.media` array. |
+| `preview_image` | `image` | A preview image for the image. |
+| `product_id` | `number` | The ID of the product that the image is associated with. |
+| `variants` | `array` | The product variants that the image is associated with. |
+
+## `page`
+
+A page on a store.
+
+Access: `pages.`, `metafield.value`
+
+Properties:
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `id` | `number` | The ID of the page. |
+| `author` | `string` | The author of the page. |
+| `handle` | `string` | The handle of the page. |
+| `title` | `string` | The title of the page. |
+| `template_suffix` | `string` | The name of the custom template assigned to the page. |
+| `content` | `string` | The content of the page. |
+| `url` | `string` | The relative URL of the page. |
+| `metafields` | `untyped` | The metafields applied to the page. |
+| `published_at` | `string` | A timestamp for when the page was published. |
+
+## `section`
+
+The properties and settings of a section.
+
+Properties:
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `id` | `string` | The ID of the section. |
+| `settings` | `untyped` | The settings of the section. |
+| `index` | `number` | The 1-based index of the current section within its location. |
+| `index0` | `number` | The 0-based index of the current section within its location. |
+| `location` | `string` | The scope or context of the section (template, section group, or global). |
+| `blocks` | `array` | The blocks of the section. |
+
+## `shop`
+
+Information about the store, such as the store address, the total number of products, and various settings.
+
+Access: Global
+
+Properties:
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `id` | `string` | The ID of the store. |
+| `name` | `string` | The name of the store. |
+| `description` | `string` | The description of the store. |
+| `enabled_currencies` | `array` | The currencies that the store accepts. |
+| `published_locales` | `array` | The locales (languages) that are published on the store. |
+| `url` | `string` | The full URL of the store. |
+| `email` | `string` | The sender email of the store. |
+| `secure_url` | `string` | The full URL of the store, with an `https` protocol. |
+| `domain` | `string` | The primary domain of the store. |
+| `permanent_domain` | `string` | The `.myshopify.com` domain of the store. |
+| `phone` | `string` | The phone number of the store. |
+| `password_message` | `string` | The password page message of the store. |
+| `address` | `address` | The address of the store. |
+| `customer_accounts_enabled` | `boolean` | Returns `true` if the store shows a login link. Returns `false` if not. |
+| `customer_accounts_optional` | `boolean` | Returns `true` if customer accounts are optional to complete checkout. Returns `false` if not. |
+| `currency` | `string` | The currency of the store. |
+| `money_format` | `currency` | The money format of the store. |
+| `money_with_currency_format` | `currency` | The money format of the store with the currency included. |
+| `metafields` | `` | The metafields applied to the store. |
+| `enabled_payment_types` | `array` | The accepted payment types on the store. |
+| `refund_policy` | `policy` | The refund policy for the store. |
+| `shipping_policy` | `policy` | The shipping policy for the store. |
+| `privacy_policy` | `policy` | The privacy policy for the store. |
+| `terms_of_service` | `policy` | The terms of service for the store. |
+| `subscription_policy` | `policy` | The subscription policy for the store. |
+| `policies` | `array` | The policies for the store. |
+| `vendors` | `array` | All of the product vendors for the store. |
+| `types` | `array` | All of the product types in the store. |
+| `products_count` | `number` | The number of products in the store. |
+| `collections_count` | `number` | The number of collections in the store. |
+| `accepts_gift_cards` | `boolean` | Returns `true` if the store accepts gift cards. Returns `false` if not. |
+| `brand` | `brand` | The brand assets for the store. |
+

--- a/plugins/shopify-liquid/skills/shopify-liquid-themes/references/objects-tier2.md
+++ b/plugins/shopify-liquid/skills/shopify-liquid-themes/references/objects-tier2.md
@@ -1,0 +1,559 @@
+# Liquid Objects - Tier 2
+
+> 69 objects with property names listed.
+
+### `address`
+
+An address, such as a customer address or order shipping address.
+
+Access: `checkout.billing_address`, `checkout.shipping_address`, `customer.addresses`, `customer.default_address`, `location.address`, `order.billing_address`, `order.shipping_address`, `shop.address`
+
+Properties: `company`, `phone`, `first_name`, `last_name`, `name`, `url`, `summary`, `id`, `address1`, `address2`, `city`, `zip`, `country_code`, `province_code`, `country`, `street`, `province`
+
+### `brand`
+
+The brand assets for the store.
+
+Access: `remote_shop.brand`, `shop.brand`
+
+Properties: `slogan`, `short_description`, `favicon_url`, `cover_image`, `logo`, `square_logo`, `colors`, `metafields`
+
+### `checkout`
+
+A customer's checkout.
+
+Access: Templates: checkout
+
+Properties: `applied_gift_cards`, `attributes`, `billing_address`, `buyer_accepts_marketing`, `cart_level_discount_applications`, `currency`, `customer`, `discount_applications`, `discounts_amount`, `discounts_savings`, `email`, `gift_cards_amount`, `id`, `line_items`, `line_items_subtotal_price`, `name`, `note`, `order`, `order_id`, `order_name`, `order_number`, `requires_shipping`, `shipping_address`, `shipping_method`, `shipping_price`, `tax_lines`, `tax_price`, `total_price`, `transactions`, `item_count`
+
+### `closest`
+
+A drop that holds resources of different types that are the closest to the current context
+
+Access: Global
+
+Properties: `product`, `collection`, `article`, `blog`, `page`, `metaobject`
+
+### `color`
+
+A color from a `color` setting.
+
+Access: `swatch.color`
+
+Properties: `red`, `green`, `blue`, `rgb`, `rgba`, `oklch`, `oklcha`, `hue`, `saturation`, `lightness`, `alpha`, `chroma`, `color_space`
+
+### `comment`
+
+An article comment.
+
+Access: `article.comments`
+
+Properties: `author`, `content`, `created_at`, `email`, `id`, `status`, `updated_at`, `url`
+
+### `company`
+
+A company that a customer is purchasing for.
+
+Access: `company_location.company`, `customer.current_company`
+
+Properties: `id`, `name`, `external_id`, `available_locations`, `available_locations_count`, `metafields`
+
+### `company_address`
+
+The address of a company location.
+
+Access: `company_location.shipping_address`
+
+Properties: `attention`, `id`, `address1`, `address2`, `first_name`, `last_name`, `city`, `zip`, `country_code`, `province_code`, `country`, `street`, `province`
+
+### `company_location`
+
+A location of the company that a customer is purchasing for.
+
+Access: `company.available_locations`, `customer.company_available_locations`, `customer.current_location`
+
+Properties: `id`, `name`, `external_id`, `url_to_set_as_current`, `current?`, `company`, `shipping_address`, `tax_registration_id`, `metafields`, `store_credit_account`
+
+### `country`
+
+A country supported by the store's localization options.
+
+Access: `localization.available_countries`, `localization.country`, `address.country`, `company_address.country`
+
+Properties: `name`, `iso_code`, `unit_system`, `currency`, `market`, `popular?`, `continent`, `available_languages`
+
+### `currency`
+
+Information about a currency, like the ISO code and symbol.
+
+Access: `cart.currency`, `country.currency`, `shop.enabled_currencies`, `money.currency`, `shop.money_format`, `shop.money_with_currency_format`
+
+Properties: `iso_code`, `symbol`, `name`
+
+### `discount` *(deprecated)*
+
+A discount applied to a cart, line item, or order.
+
+Access: `cart.discounts`, `line_item.discounts`, `order.discounts`, `checkout.discount`
+
+Properties: `amount`, `total_amount`, `code`, `title`, `type`, `savings`, `total_savings`
+
+### `discount_application`
+
+Information about the intent of a discount.
+
+Access: `cart.discount_applications`, `order.discount_applications`, `discount_allocation.discount_application`
+
+Properties: `total_allocated_amount`, `title`, `value`, `target_selection`, `type`, `value_type`, `target_type`
+
+### `external_video`
+
+Information about an external video from YouTube or Vimeo.
+
+Access: `product.media`
+
+Properties: `external_id`, `aspect_ratio`, `host`, `alt`, `id`, `media_type`, `position`, `preview_image`
+
+### `filter`
+
+A storefront filter.
+
+Access: `collection.filters`, `search.filters`
+
+Properties: `param_name`, `label`, `operator`, `type`, `active_values`, `inactive_values`, `values`, `false_value`, `true_value`, `max_value`, `min_value`, `range_max`, `url_to_remove`, `presentation`
+
+### `filter_value`
+
+A specific value of a filter.
+
+Access: `filter.`, `filter.false_value`, `filter.true_value`, `filter.max_value`, `filter.min_value`
+
+Properties: `param_name`, `value`, `active`, `count`, `label`, `url_to_add`, `url_to_remove`, `swatch`, `image`
+
+### `font`
+
+A font from a `font_picker` setting.
+
+Properties: `family`, `fallback_families`, `baseline_ratio`, `weight`, `style`, `variants`, `system?`
+
+### `forloop`
+
+Information about a parent `for` loop.
+
+Access: `forloop.parentloop`
+
+Properties: `length`, `parentloop`, `index`, `index0`, `rindex`, `rindex0`, `first`, `last`
+
+### `fulfillment`
+
+An order fulfillment, which includes information like the line items
+being fulfilled and shipment tracking.
+
+Access: `line_item.fulfillment`
+
+Properties: `created_at`, `item_count`, `fulfillment_line_items`, `tracking_company`, `tracking_numbers`, `tracking_number`, `tracking_url`
+
+### `generic_file`
+
+A file from a `file_reference` type metafield that is neither an image or video.
+
+Access: `metafield.value`
+
+Properties: `url`, `id`, `media_type`, `preview_image`, `position`, `alt`
+
+### `gift_card`
+
+A gift card that's been issued to a customer or a recipient.
+
+Access: Templates: gift_card.liquid
+
+Properties: `balance`, `code`, `currency`, `customer`, `recipient`, `message`, `send_on`, `enabled`, `expired`, `expires_on`, `initial_value`, `url`, `template_suffix`, `properties`, `qr_identifier`, `pass_url`, `product`, `last_four_characters`
+
+### `group`
+
+A group of rules for the `robots.txt` file.
+
+Access: `robots.default_groups`
+
+Properties: `user_agent`, `rules`, `sitemap`
+
+### `link`
+
+A link in a menu.
+
+Access: `linklist.links`
+
+Properties: `active`, `current`, `child_active`, `child_current`, `handle`, `links`, `object`, `title`, `type`, `levels`, `url`
+
+### `linklist`
+
+A menu in a store.
+
+Access: `linklists.`
+
+Properties: `links`, `handle`, `levels`, `title`
+
+### `localization`
+
+Information about the countries and languages that are available on a store.
+
+Access: Global
+
+Properties: `available_countries`, `available_languages`, `market`, `country`, `language`
+
+### `location`
+
+A store location.
+
+Access: `store_availability.location`
+
+Properties: `id`, `name`, `address`, `latitude`, `longitude`, `metafields`
+
+### `market`
+
+A group of one or more regions of the world that a merchant is targeting for sales.
+
+Access: `localization.market`, `country.market`
+
+Properties: `id`, `handle`, `metafields`
+
+### `measurement`
+
+A measurement from one of the following metafield types:
+
+- `dimension`
+- `volume`
+- `weight`
+
+Access: `metafield.value`
+
+Properties: `type`, `value`, `unit`
+
+### `media`
+
+An abstract media object that can represent the following object types:
+
+- `image`
+- `model`
+- `video`
+- `external_video`
+
+Access: `product.media`, `product.featured_media`, `variant.featured_media`, `remote_product.featured_media`
+
+Properties: `id`, `position`, `media_type`, `preview_image`, `alt`
+
+### `metafield`
+
+A metafield attached to a parent object.
+
+Access: `app.metafields`, `article.metafields`, `blog.metafields`, `collection.metafields`, `customer.metafields`, `location.metafields`, `order.metafields`, `page.metafields`, `product.metafields`, `shop.metafields`, `variant.metafields`
+
+Properties: `value`, `type`, `list?`
+
+### `metaobject_system`
+
+Basic information about a `metaobject`. These properties are grouped under the `system` object to avoid collisions between system property names and user-defined metaobject fields.
+
+Access: `metaobject.system`
+
+Properties: `type`, `handle`, `id`, `url`
+
+### `model`
+
+A 3D model uploaded as product media.
+
+Access: `product.media`
+
+Properties: `sources`, `alt`, `id`, `media_type`, `position`, `preview_image`
+
+### `model_source`
+
+A model source file.
+
+Access: `model.`
+
+Properties: `format`, `mime_type`, `url`
+
+### `paginate`
+
+Information about the pagination inside a set of `paginate` tags.
+
+Properties: `page_size`, `current_offset`, `current_page`, `items`, `parts`, `next`, `previous`, `pages`, `page_param`
+
+### `part`
+
+A part in the navigation for pagination.
+
+Access: `paginate.parts`, `paginate.next`, `paginate.previous`
+
+Properties: `is_link`, `title`, `url`
+
+### `policy`
+
+A store policy, such as a privacy or return policy.
+
+Access: `shop.policies`, `remote_shop.shipping_policy`, `remote_shop.refund_policy`, `shop.refund_policy`, `shop.shipping_policy`, `shop.privacy_policy`, `shop.terms_of_service`, `shop.subscription_policy`
+
+Properties: `id`, `body`, `url`, `title`
+
+### `predictive_search`
+
+Information about the results from a predictive search query through the
+Predictive Search API.
+
+Properties: `performed`, `resources`, `terms`, `types`
+
+### `predictive_search_resources`
+
+Contains arrays of objects for each resource type that can be returned by a predictive search query.
+
+Access: `predictive_search.resources`
+
+Properties: `articles`, `collections`, `pages`, `products`
+
+### `product_option`
+
+A product option, such as size or color.
+
+Access: `product.options_with_values`
+
+Properties: `name`, `position`, `values`, `selected_value`
+
+### `product_option_value`
+
+A product option value, such as "red" for the option "color".
+
+Access: `product_option.values`, `variant.options`
+
+Properties: `id`, `name`, `swatch`, `selected`, `available`, `variant`, `product_url`
+
+### `quantity_rule`
+
+A variant order quantity rule.
+
+Access: `variant.quantity_rule`
+
+Properties: `min`, `max`, `increment`
+
+### `rating`
+
+Information for a `rating` type metafield.
+
+Access: `metafield.value`
+
+Properties: `rating`, `scale_min`, `scale_max`
+
+### `recipient`
+
+A recipient that is associated with a gift card.
+
+Access: `gift_card.recipient`
+
+Properties: `nickname`, `email`, `name`
+
+### `recommendations`
+
+Product recommendations for a specific product based on sales data, product descriptions, and collection relationships.
+
+Properties: `performed?`, `products`, `products_count`, `intent`
+
+### `remote_product`
+
+A product that comes from a remote source, inheriting all product functionality and also providing additional context about the remote source.
+
+Access: `collection.products`, `line_item.product`, `search.results`, `variant.product`
+
+Properties: `title`, `remote_details`, `featured_media`, `media`, `template_suffix`, `metafields`, `description`, `selling_plan_groups`, `options_with_values`, `category`, `variants`, `variants_count`, `id`, `vendor`, `content`, `featured_image`, `images`, `price_min`, `price`, `price_max`, `price_varies`, `selected_or_first_available_variant`, `selected_variant`, `first_available_variant`, `available`, `options`, `type`, `compare_at_price_min`, `compare_at_price_max`, `compare_at_price`, `compare_at_price_varies`, `url`, `published_at`, `created_at`, `options_by_name`, `has_only_default_variant`, `quantity_price_breaks_configured?`, `requires_selling_plan`, `selected_selling_plan`, `selected_selling_plan_allocation`, `selected_or_first_available_selling_plan_allocation`, `gift_card?`
+
+### `remote_shop`
+
+Information about a remote store.
+
+Access: `remote_product.remote_details`, `remote_details.shop`
+
+Properties: `name`, `brand`, `shipping_policy`, `refund_policy`, `policies`
+
+### `request`
+
+Information about the current URL and the associated page.
+
+Access: Global
+
+Properties: `design_mode`, `visual_preview_mode`, `page_type`, `host`, `origin`, `path`, `locale`
+
+### `routes`
+
+Allows you to generate standard URLs for the storefront.
+
+Access: Global
+
+Properties: `root_url`, `account_url`, `account_login_url`, `account_logout_url`, `account_recover_url`, `account_register_url`, `account_addresses_url`, `account_profile_url`, `collections_url`, `all_products_collection_url`, `search_url`, `predictive_search_url`, `cart_url`, `cart_add_url`, `cart_change_url`, `cart_clear_url`, `cart_update_url`, `product_recommendations_url`, `storefront_login_url`
+
+### `search`
+
+Information about a storefront search query.
+
+Access: Templates: search
+
+Properties: `terms`, `filters`, `performed`, `results`, `results_count`, `sort_options`, `sort_by`, `default_sort_by`, `types`
+
+### `selling_plan`
+
+Information about the intent of how a specific selling plan affects a line item.
+
+Access: `line_item.selling_plan_allocation`, `variant.selling_plan_allocations`, `product.selected_selling_plan`, `remote_product.selected_selling_plan`, `selling_plan_allocation.selling_plan`
+
+Properties: `id`, `name`, `description`, `group_id`, `recurring_deliveries`, `options`, `price_adjustments`, `selected`, `checkout_charge`
+
+### `selling_plan_allocation`
+
+Information about how a specific selling plan affects a line item.
+
+Access: `line_item.selling_plan_allocation`, `variant.selling_plan_allocations`, `product.selected_selling_plan_allocation`, `product.selected_or_first_available_selling_plan_allocation`, `variant.selected_selling_plan_allocation`, `remote_product.selected_selling_plan_allocation`, `remote_product.selected_or_first_available_selling_plan_allocation`
+
+Properties: `price`, `compare_at_price`, `price_adjustments`, `unit_price`, `per_delivery_price`, `selling_plan`, `selling_plan_group_id`, `checkout_charge_amount`, `remaining_balance_charge_amount`
+
+### `selling_plan_group`
+
+Information about a specific group of selling plans that include any of a
+product's variants.
+
+Access: `product.`
+
+Properties: `selling_plans`, `id`, `name`, `app_id`, `options`, `selling_plan_selected`
+
+### `selling_plan_group_option`
+
+Information about a specific option in a selling plan group.
+
+Access: `selling_plan_group.`
+
+Properties: `name`, `position`, `values`, `selected_value`
+
+### `selling_plan_option`
+
+Information about a selling plan's value for a specific `selling_plan_group_option`.
+
+Access: `selling_plan.options`
+
+Properties: `name`, `position`, `value`
+
+### `selling_plan_price_adjustment`
+
+Information about how a selling plan changes the price of a variant for a given period of time.
+
+Access: `selling_plan_allocation.price_adjustments`
+
+Properties: `order_count`, `position`, `value_type`, `value`
+
+### `shipping_method`
+
+Information about the shipping method for an order.
+
+Access: `checkout.shipping_method`, `order.shipping_method`
+
+Properties: `title`, `original_price`, `price_with_discounts`, `handle`, `id`, `tax_lines`, `discount_allocations`
+
+### `shop_locale`
+
+A language in a store.
+
+Access: `localization.available_languages`, `localization.language`, `request.locale`, `shop.published_locales`, `shop.locale`
+
+Properties: `name`, `endonym_name`, `iso_code`, `primary`, `root_url`
+
+### `store_availability`
+
+A variant's inventory information for a physical store location.
+
+Access: `variant.store_availabilities`
+
+Properties: `available`, `pick_up_enabled`, `pick_up_time`, `location`
+
+### `tablerowloop`
+
+Information about a parent `tablerow` loop.
+
+Properties: `length`, `col`, `row`, `index`, `index0`, `col0`, `rindex`, `rindex0`, `first`, `last`, `col_first`, `col_last`
+
+### `tax_line`
+
+Information about a tax line of a checkout or order.
+
+Access: `checkout.tax_lines`, `order.tax_lines`
+
+Properties: `title`, `price`, `rate`, `rate_percentage`
+
+### `taxonomy_category`
+
+The taxonomy category for a product
+
+Access: `product.category`, `remote_product.category`
+
+Properties: `gid`, `id`, `name`, `ancestors`
+
+### `template`
+
+Information about the current template.
+
+Access: Global
+
+Properties: `name`, `suffix`, `directory`
+
+### `theme` *(deprecated)*
+
+Information about the current theme.
+
+Access: Global
+
+Properties: `id`, `name`, `role`
+
+### `transaction`
+
+A transaction associated with a checkout or order.
+
+Access: `checkout.transactions`, `order.transactions`
+
+Properties: `id`, `name`, `status`, `created_at`, `receipt`, `kind`, `gateway`, `status_label`, `payment_details`, `amount`, `gateway_display_name`, `show_buyer_pending_payment_instructions?`, `buyer_pending_payment_notice`, `buyer_pending_payment_instructions`
+
+### `transaction_payment_details`
+
+Information about the payment methods used for a transaction.
+
+Access: `transaction.payment_details`
+
+Properties: `credit_card_company`, `credit_card_last_four_digits`, `credit_card_number`, `gift_card`
+
+### `unit_price_measurement`
+
+Information about how units of a product variant are measured. It's used to calculate
+unit prices.
+
+Access: `line_item.unit_price_measurement`, `variant.unit_price_measurement`
+
+Properties: `measured_type`, `quantity_value`, `quantity_unit`, `reference_value`, `reference_unit`
+
+### `user`
+
+The author of a blog article.
+
+Access: `article.user`
+
+Properties: `account_owner`, `bio`, `email`, `first_name`, `homepage`, `image`, `last_name`, `name`
+
+### `video`
+
+Information about a video uploaded as product media or a `file_reference` metafield.
+
+Access: `metafield.value`, `product.media`
+
+Properties: `sources`, `duration`, `aspect_ratio`, `alt`, `id`, `media_type`, `position`, `preview_image`
+
+### `video_source`
+
+Information about the source files for a video.
+
+Access: `video.sources`
+
+Properties: `width`, `format`, `height`, `mime_type`, `url`
+

--- a/plugins/shopify-liquid/skills/shopify-liquid-themes/references/objects-tier3.md
+++ b/plugins/shopify-liquid/skills/shopify-liquid-themes/references/objects-tier3.md
@@ -1,0 +1,110 @@
+# Liquid Objects - Tier 3
+
+> 53 simple objects with access paths.
+
+`additional_checkout_buttons` (global) - Returns `true` if a store has any payment providers with offsite checkouts, such as PayPal Express C
+
+`all_country_option_tags` (global) - Creates an `<option>` tag for each country.
+
+`all_products` (global) - All of the products on a store.
+
+`app` - An app. This object is usually used to access app-specific information for use with theme app extens
+
+`articles` (global) - All of the articles across the blogs in the store.
+
+`blogs` (global) - All of the blogs in the store.
+
+`brand_color` (brand.colors) - The colors defined as part of a store's brand assets.
+
+`canonical_url` (global) - The canonical URL for the current page.
+
+`collections` (global) - All of the collections on a store.
+
+`color_scheme` - A color_scheme from a `color_scheme` setting.
+
+`color_scheme_group` - A color_scheme_group from a `color_scheme_group` setting.
+
+`content_for_additional_checkout_buttons` (global) - Returns checkout buttons for any active payment providers with offsite checkouts.
+
+`content_for_header` (global) - Dynamically returns all scripts required by Shopify.
+
+`content_for_index` (global) - Dynamically returns the content of sections to be rendered on the home page.
+
+`content_for_layout` (global) - Dynamically returns content based on the current template.
+
+`country_option_tags` (global) - Creates an `<option>` tag for each country and region that's included in a shipping zone on the Ship
+
+`current_page` (global) - The current page number.
+
+`current_tags` (blog, collection) - The currently applied tags.
+
+`customer_payment_method` (customer.payment_methods) - A customer's saved payment method.
+
+`discount_allocation` (line_item.discount_allocations, shipping_method.discount_allocations) - Information about how a discount affects an item.
+
+`filter_value_display` *(deprecated)* (filter_value.display) - The visual representation of a filter value.
+
+`focal_point` (image_presentation.focal_point) - The focal point for an image.
+
+`form_errors` (form.errors) - The error category strings for errors from a form created by a `form` tag.
+
+`handle` (global) - The handle of the resource associated with the current template.
+
+`image_presentation` (image.presentation) - The presentation settings for an image.
+
+`images` (global) - All of the images that have been uploaded to a store.
+
+`instructions` (line_item.instructions) - The instructions for a nested cart line item.
+
+`linklists` (global) - All of the menus in a store.
+
+`metaobject` (metaobjects.) - A metaobject entry, which includes the values for a set of fields. The set is defined by the parent 
+
+`metaobject_definition` - A `metaobject_definition` defines the structure of a metaobject type for the store, which consists o
+
+`metaobjects` (global) - All of the metaobjects of the store.
+
+`money` (metafield.value, store_credit_account.balance) - A money value, in the the customer's local (presentment) currency.
+
+`page_description` (global) - The meta description of the current page.
+
+`page_image` (global) - An image to be shown in search engine listings and social media previews for the current page.
+
+`page_title` (global) - The page title of the current page.
+
+`pages` (global) - All of the pages on a store.
+
+`parent_relationship` (line_item.parent_relationship) - Information about the parent relationship for a nested cart line item.
+
+`pending_payment_instruction_input` (transaction.buyer_pending_payment_instructions) - Header-value pairs that make up the list of payment information specific to the payment method. This
+
+`powered_by_link` (global) - Creates an HTML link element that links to a localized version of `shopify.com`, based on the locale
+
+`quantity_price_break` (variant.quantity_price_breaks) - The per-unit price of a variant when purchasing the minimum quantity or more.
+
+`remote_details` (remote_product., remote_product.remote_details) - Information about the remote source from which the object came from.
+
+`robots` (robots.txt.liquid) - The default rule groups for the `robots.txt` file.
+
+`rule` (group.rules) - A rule for the `robots.txt` file, which tells crawlers which pages can, or can't, be accessed.
+
+`script` (scripts.cart_calculate_line_items) - Information about a Shopify Script. > Caution: > Shopify Scripts will be sunset on August 28, 2025. 
+
+`scripts` (global) - The active scripts, of each script type, on the store. > Caution: > Shopify Scripts will be sunset o
+
+`selling_plan_allocation_price_adjustment` (selling_plan_allocation.price_adjustments) - The resulting price from the intent of the associated `selling_plan_price_adjustment`.
+
+`selling_plan_checkout_charge` (line_item.selling_plan_allocation, variant.selling_plan_allocations, selling_plan.checkout_charge) - Information about how a specific selling plan affects the amount that a customer needs to pay for a 
+
+`settings` (global) - Allows you to access all of the theme's settings from the `settings_schema.json` file.
+
+`sitemap` (group.sitemap) - The sitemap for a specific group in the `robots.txt` file.
+
+`sort_option` (collection.sort_options, search.sort_options) - A sort option for a collection or search results page.
+
+`store_credit_account` (customer.store_credit_account, company_location.store_credit_account) - A store credit account owned by a customer.
+
+`swatch` (product_option_value.swatch, filter_value.swatch) - Color and image for visual representation. Available for product option values and filter values.
+
+`user_agent` (group.user_agent) - The user-agent, which is the name of the crawler, for a specific group in the `robots.txt` file.
+

--- a/plugins/shopify-liquid/skills/shopify-liquid-themes/references/schema-and-settings.md
+++ b/plugins/shopify-liquid/skills/shopify-liquid-themes/references/schema-and-settings.md
@@ -1,0 +1,220 @@
+# Schema & Settings Reference
+
+## Section Schema Structure
+
+The `{% schema %}` tag in sections accepts a JSON object with these top-level keys:
+
+```json
+{
+  "name": "t:sections.my_section.name",
+  "tag": "section",
+  "class": "my-section",
+  "limit": 1,
+  "settings": [],
+  "max_blocks": 16,
+  "blocks": [{ "type": "@theme" }],
+  "presets": [{ "name": "t:sections.my_section.name" }],
+  "enabled_on": { "templates": ["product"], "groups": ["header"] },
+  "disabled_on": { "templates": ["password"] },
+  "default": { "settings": {}, "blocks": [] },
+  "locales": {}
+}
+```
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `name` | string | Section title in theme editor (use `t:` prefix for translations) |
+| `tag` | string | HTML wrapper element. Values: `article`, `aside`, `div`, `footer`, `header`, `section` |
+| `class` | string | Additional CSS class on wrapper |
+| `limit` | integer (1-2) | Max times section can be added to a template |
+| `settings` | array | Array of setting objects (see Setting Types below) |
+| `max_blocks` | integer (1-50) | Max blocks allowed in section (default 50) |
+| `blocks` | array | Block type entries: `@theme`, `@app`, or custom types |
+| `presets` | array | Default configurations for adding via theme editor |
+| `enabled_on` | object | Restrict to specific templates/groups |
+| `disabled_on` | object | Prevent on specific templates/groups |
+| `default` | object | Default settings/blocks for static sections |
+| `locales` | object | Inline translations (for portable sections) |
+
+Template values for `enabled_on`/`disabled_on`: `*`, `404`, `article`, `blog`, `captcha`, `cart`, `collection`, `customers/account`, `customers/activate_account`, `customers/addresses`, `customers/login`, `customers/order`, `customers/register`, `customers/reset_password`, `gift_card`, `index`, `list-collections`, `metaobject`, `page`, `password`, `policy`, `product`, `search`
+
+## Block Schema Structure
+
+The `{% schema %}` tag in theme blocks (`.liquid` files in `blocks/`):
+
+```json
+{
+  "name": "t:blocks.my_block.name",
+  "tag": "div",
+  "class": "my-block",
+  "settings": [],
+  "blocks": [{ "type": "@theme" }],
+  "presets": [{ "name": "t:blocks.my_block.name" }]
+}
+```
+
+| Key | Type | Description |
+|-----|------|-------------|
+| `name` | string | Block title in theme editor |
+| `tag` | string/null | HTML wrapper (any string up to 50 chars, or `null` for no wrapper) |
+| `class` | string | Additional CSS class (appended to `shopify-block`) |
+| `settings` | array | Array of setting objects |
+| `blocks` | array | Nested block entries: `@theme`, `@app`, or specific type names |
+| `presets` | array | Default configurations for theme editor |
+
+## Block Entry Types
+
+In the `blocks` array of a section or block schema:
+
+| Type | Description | Example |
+|------|-------------|---------|
+| `@theme` | Accept any theme block | `{ "type": "@theme" }` |
+| `@app` | Accept app blocks | `{ "type": "@app" }` |
+| Custom name | Accept a specific block file | `{ "type": "slide" }` |
+
+## Setting Types (33 types)
+
+### Sidebar Settings (no `id` required)
+
+These organize the editor UI - they don't produce values:
+
+| Type | Required Fields | Description |
+|------|----------------|-------------|
+| `header` | `type`, `content` | Section header in editor. Optional: `info`, `visible_if` |
+| `paragraph` | `type`, `content` | Descriptive text in editor. Optional: `visible_if` |
+
+### Input Settings (require `id` and `label`)
+
+All input settings share these standard attributes:
+
+| Attribute | Required | Description |
+|-----------|----------|-------------|
+| `type` | Yes | The setting type |
+| `id` | Yes | Unique identifier, used to access value: `section.settings.{id}` or `block.settings.{id}` |
+| `label` | Yes | Display label in editor (use `t:` prefix) |
+| `default` | No | Default value |
+| `info` | No | Helper text shown below the field |
+| `visible_if` | No | Liquid expression controlling visibility |
+
+### Resource Pickers
+
+| Type | Returns | Extra Fields | Liquid Access |
+|------|---------|--------------|---------------|
+| `article` | article object | - | `section.settings.article.title` |
+| `article_list` | array of articles | `limit` (max 50) | `{% for a in section.settings.articles %}` |
+| `blog` | blog object | - | `section.settings.blog.title` |
+| `collection` | collection object | - | `section.settings.collection.products` |
+| `collection_list` | array of collections | `limit` (max 50) | `{% for c in section.settings.collections %}` |
+| `metaobject` | metaobject entry | `metaobject_type` (required) | `section.settings.my_meta.field_name` |
+| `metaobject_list` | array of metaobjects | `metaobject_type` (required), `limit` | `{% for m in section.settings.my_metas %}` |
+| `page` | page object | - | `section.settings.page.content` |
+| `product` | product object | - | `section.settings.product.title` |
+| `product_list` | array of products | `limit` (max 50) | `{% for p in section.settings.products %}` |
+
+### Text Inputs
+
+| Type | Returns | Extra Fields | Notes |
+|------|---------|--------------|-------|
+| `text` | string | `placeholder` | Single-line text |
+| `textarea` | string | `placeholder` | Multi-line text |
+| `inline_richtext` | HTML string | - | Bold, italic, link (no `<p>` wrapping) |
+| `richtext` | HTML string | - | Bold, italic, underline, link, paragraph, list |
+| `html` | HTML string | `placeholder` | Raw HTML input |
+| `liquid` | HTML string | - | HTML + limited Liquid markup |
+
+### Number & Range
+
+| Type | Returns | Extra Fields | Notes |
+|------|---------|--------------|-------|
+| `number` | number | `placeholder` | Single number input |
+| `range` | number | `min` (required), `max` (required), `default` (required), `step`, `unit` | Slider with value |
+
+### Boolean
+
+| Type | Returns | Extra Fields | Notes |
+|------|---------|--------------|-------|
+| `checkbox` | boolean | `default` (boolean) | Toggle on/off |
+
+### Selection
+
+| Type | Returns | Extra Fields | Notes |
+|------|---------|--------------|-------|
+| `select` | string | `options` (required): array of `{value, label, group?}` | Dropdown / segmented control |
+| `radio` | string | `options` (required): array of `{value, label}` | Radio buttons |
+| `text_alignment` | string | `default`: `"left"`, `"center"`, or `"right"` | Segmented control with alignment icons |
+
+### Media
+
+| Type | Returns | Extra Fields | Notes |
+|------|---------|--------------|-------|
+| `image_picker` | image object | - | `section.settings.image \| image_url: width: 800 \| image_tag` |
+| `video` | video object | - | `section.settings.video \| video_tag` |
+| `video_url` | string (URL) | `accept` (required): `["youtube"]`, `["vimeo"]`, or both | External video URL |
+
+### Color & Style
+
+| Type | Returns | Extra Fields | Notes |
+|------|---------|--------------|-------|
+| `color` | color string | `alpha` (boolean, default true) | Color picker |
+| `color_background` | CSS background string | - | Full CSS background value |
+| `color_scheme` | color scheme ID | - | Theme color scheme picker |
+| `color_scheme_group` | color scheme group | `definition` (required), `role` (required) | Advanced: defines color scheme sets |
+| `font_picker` | font object | `default` (required) | Font from Shopify font library |
+
+### Navigation
+
+| Type | Returns | Extra Fields | Notes |
+|------|---------|--------------|-------|
+| `link_list` | linklist object | - | Menu picker |
+| `url` | string | - | URL entry with resource picker |
+
+## Conditional Visibility (`visible_if`)
+
+Most input settings support `visible_if` - a Liquid expression that controls whether the setting is shown in the theme editor:
+
+```json
+{
+  "type": "select",
+  "id": "alignment",
+  "label": "Alignment",
+  "visible_if": "{{ block.settings.layout == 'vertical' }}",
+  "options": [
+    { "value": "left", "label": "Left" },
+    { "value": "center", "label": "Center" }
+  ]
+}
+```
+
+The expression is evaluated against the current section/block settings. The setting is hidden (not removed) when the expression evaluates to false.
+
+Not supported on: `article`, `article_list`, `blog`, `collection`, `collection_list`, `metaobject`, `metaobject_list`, `page`, `product`, `product_list`, `color_scheme_group`
+
+## Presets
+
+Presets define default configurations that appear in the theme editor's "Add section/block" menu:
+
+```json
+"presets": [
+  {
+    "name": "t:sections.hero.presets.default",
+    "category": "t:categories.banner",
+    "settings": {
+      "heading": "Welcome",
+      "height": 500
+    },
+    "blocks": [
+      {
+        "type": "text",
+        "settings": { "text": "Hello" }
+      }
+    ]
+  }
+]
+```
+
+| Key | Required | Description |
+|-----|----------|-------------|
+| `name` | Yes | Preset name in editor (use `t:` prefix) |
+| `category` | No | Groups preset under a category in editor |
+| `settings` | No | Default setting values |
+| `blocks` | No | Default blocks with their settings |

--- a/plugins/shopify-liquid/skills/shopify-liquid-themes/references/tags.md
+++ b/plugins/shopify-liquid/skills/shopify-liquid-themes/references/tags.md
@@ -1,0 +1,813 @@
+# Liquid Tags Reference
+
+> 30 tags organized by category. Each entry shows syntax, description, and examples.
+
+## Conditional
+
+### `case`
+
+Renders a specific expression depending on the value of a specific variable.
+
+Syntax:
+```liquid
+{% case variable %}
+  {% when first_value %}
+    first_expression
+  {% when second_value %}
+    second_expression
+  {% else %}
+    third_expression
+{% endcase %}
+```
+
+Keywords:
+- `variable`: The name of the variable you want to base your case statement on.
+- `first_value`: A specific value to check for.
+- `second_value`: A specific value to check for.
+- `first_expression`: An expression to be rendered when the variable's value matches `first_value`.
+- `second_expression`: An expression to be rendered when the variable's value matches `second_value`.
+- `third_expression`: An expression to be rendered when the variable's value has no match.
+
+```liquid
+{% case product.type %}
+  {% when 'Health' %}
+    This is a health potion.
+  {% when 'Love' %}
+    This is a love potion.
+  {% else %}
+    This is a potion.
+{% endcase %}
+```
+
+### `if`
+
+Renders an expression if a specific condition is `true`.
+
+Syntax:
+```liquid
+{% if condition %}
+  expression
+{% endif %}
+```
+
+Keywords:
+- `condition`: The condition to evaluate.
+- `expression`: The expression to render if the condition is met.
+
+```liquid
+{% if product.compare_at_price &gt; product.price %}
+  This product is on sale!
+{% endif %}
+```
+
+### `unless`
+
+Renders an expression unless a specific condition is `true`.
+
+Syntax:
+```liquid
+{% unless condition %}
+  expression
+{% endunless %}
+```
+
+> Tip:
+> Similar to the `if` tag, you can use `elsif` to add more conditions to an `unless` tag.
+
+Keywords:
+- `condition`: The condition to evaluate.
+- `expression`: The expression to render unless the condition is met.
+
+```liquid
+{% unless product.has_only_default_variant %}
+  // Variant selection functionality
+{% endunless %}
+```
+
+### `else`
+
+Allows you to specify a default expression to execute when no other condition is met.
+
+Syntax:
+```liquid
+{% else %}
+  expression
+```
+
+You can use the `else` tag with the following tags:
+
+- `case`
+- `if`
+- `unless`
+
+Keywords:
+- `expression`: The expression to render if no other condition is met.
+
+```liquid
+{% if product.available %}
+  This product is available!
+{% else %}
+  This product is sold out!
+{% endif %}
+```
+
+## Html
+
+### `form`
+
+Generates an HTML `<form>` tag, including any required `<input>` tags to submit the form to a specific endpoint.
+
+Syntax:
+```liquid
+{% form 'form_type' %}
+  content
+{% endform %}
+```
+
+Because there are many different form types available in Shopify themes, the `form` tag requires a type. Depending on the
+form type, an additional parameter might be required. You can specify the following form types:
+
+- `activate_customer_password`
+- `cart`
+- `contact`
+- `create_customer`
+- `currency`
+- `customer`
+- `customer_address`
+- `customer_login`
+- `guest_login`
+- `localization`
+- `new_comment`
+- `product`
+- `recover_customer_password`
+- `reset_customer_password`
+- `storefront_password`
+
+Keywords:
+- `form_type`: The name of the desired form type
+- `content`: The form contents
+
+Parameters:
+- `return_to` (optional): The desired URL to redirect to when the form submits.
+
+Example: activate_customer_password
+```liquid
+{% form 'activate_customer_password', article %}
+  form_content
+{% endform %}
+
+```
+
+### `style`
+
+Generates an HTML `<style>` tag with an attribute of `data-shopify`.
+
+Syntax:
+```liquid
+{% style %}
+  CSS_rules
+{% endstyle %}
+```
+
+> Note:
+> If you reference color settings inside `style` tags, then
+> the associated CSS rules will update as the setting is changed in the theme editor, without a page refresh.
+
+Keywords:
+- `CSS_rules`: The desired CSS rules for the `&lt;style&gt;` tag.
+
+```liquid
+{% style %}
+  .h1 {
+    color: {{ settings.colors_accent_1 }};
+  }
+{% endstyle %}
+```
+
+## Iteration
+
+### `break`
+
+Stops a `for` loop from iterating.
+
+Syntax:
+```liquid
+{% break %}
+```
+
+```liquid
+{% for i in (1..5) -%}
+  {%- if i == 4 -%}
+    {% break %}
+  {%- else -%}
+    {{ i }}
+  {%- endif -%}
+{%- endfor %}
+```
+
+### `continue`
+
+Causes a `for` loop to skip to the next iteration.
+
+Syntax:
+```liquid
+{% continue %}
+```
+
+```liquid
+{% for i in (1..5) -%}
+  {%- if i == 4 -%}
+    {% continue %}
+  {%- else -%}
+    {{ i }}
+  {%- endif -%}
+{%- endfor %}
+```
+
+### `cycle`
+
+Loops through a group of strings and outputs them one at a time for each iteration of a `for` loop.
+
+Syntax:
+```liquid
+{% cycle string, string, ... %}
+```
+
+The `cycle` tag must be used inside a `for` loop.
+
+> Tip:
+> Use the `cycle` tag to output text in a predictable pattern. For example, to apply odd/even classes to rows in a table.
+
+```liquid
+{% for i in (1..4) -%}
+  {% cycle 'one', 'two', 'three' %}
+{%- endfor %}
+```
+
+### `for`
+
+Renders an expression for every item in an array.
+
+Syntax:
+```liquid
+{% for variable in array %}
+  expression
+{% endfor %}
+```
+
+You can do a maximum of 50 iterations with a `for` loop. If you need to iterate over more than 50 items, then use the
+`paginate` tag to split the items over multiple pages.
+
+> Tip:
+> Every `for` loop has an associated `forloop` object with information about the loop.
+
+Keywords:
+- `variable`: The current item in the array.
+- `array`: The array to iterate over.
+- `expression`: The expression to render for each iteration.
+
+Parameters:
+- `limit` (optional): The number of iterations to perform.
+- `offset` (optional): The 1-based index to start iterating at.
+- `range` (optional): A custom numeric range to iterate over.
+- `reversed` (optional): Iterate in reverse order.
+
+```liquid
+{% for product in collection.products -%}
+  {{ product.title }}
+{%- endfor %}
+```
+
+### `tablerow`
+
+Generates HTML table rows for every item in an array.
+
+Syntax:
+```liquid
+{% tablerow variable in array %}
+  expression
+{% endtablerow %}
+```
+
+The `tablerow` tag must be wrapped in HTML `<table>` and `</table>` tags.
+
+> Tip:
+> Every `tablerow` loop has an associated `tablerowloop` object with information about the loop.
+
+Keywords:
+- `variable`: The current item in the array.
+- `array`: The array to iterate over.
+- `expression`: The expression to render.
+
+Parameters:
+- `cols` (optional): The number of columns that the table should have.
+- `limit` (optional): The number of iterations to perform.
+- `offset` (optional): The 1-based index to start iterating at.
+- `range` (optional): A custom numeric range to iterate over.
+
+```liquid
+&lt;table&gt;
+  {% tablerow product in collection.products %}
+    {{ product.title }}
+  {% endtablerow %}
+&lt;/table&gt;
+```
+
+### `paginate`
+
+Splits an array's items across multiple pages.
+
+Syntax:
+```liquid
+{% paginate array by page_size %}
+  {% for item in array %}
+    forloop_content
+  {% endfor %}
+{% endpaginate %}
+```
+
+Because `for` loops are limited to 50 iterations per page, you need to use the `paginate` tag to
+iterate over an array that has more than 50 items. The following arrays can be paginated:
+
+- `article.comments`
+- `blog.articles`
+- `collections`
+- `collection.products`
+- `customer.addresses`
+- `customer.orders`
+- `metaobject_definition.values`
+- `pages`
+- `product.variants`
+- `search.results`
+- `article_list` settings
+- `collection_list` settings
+- `product_list` settings
+
+Within the `paginate` tag, you have access to the `paginate` object. You can use this
+object, or the `default_pagination` filter, to build page navigation.
+
+> Note:
+> The `paginate` tag allows the user to paginate to the 25,000th item in the array and no further. To reach items further in
+> the array the array should be filtered further before paginating. See
+> Pagination Limits for more information.
+
+Keywords:
+- `array`: The array to be looped over.
+- `page_size`: The number of array items to include per page, between 1 and 250.
+- `item`: An item in the array being looped.
+- `forloop_content`: Content for each loop iteration.
+
+Parameters:
+- `window_size` (optional): The number of pages to display in the pagination.
+
+```liquid
+{% paginate collection.products by 5 %}
+  {% for product in collection.products -%}
+    {{ product.title }}
+  {%- endfor %}
+
+  {{- paginate | default_pagination }}
+{% endpaginate %}
+```
+
+### `else`
+
+Allows you to specify a default expression to execute when a `for` loop has zero length.
+
+Syntax:
+```liquid
+{% for variable in array %}
+  first_expression
+{% else %}
+  second_expression
+{% endfor %}
+```
+
+Keywords:
+- `variable`: The current item in the array.
+- `array`: The array to iterate over.
+- `first_expression`: The expression to render for each iteration.
+- `second_expression`: The expression to render if the loop has zero length.
+
+```liquid
+{% for product in collection.products %}
+  {{ product.title }}&lt;br&gt;
+{% else %}
+  There are no products in this collection.
+{% endfor %}
+```
+
+## Syntax
+
+### `comment`
+
+Prevents an expression from being rendered or output.
+
+Syntax:
+```liquid
+{% comment %}
+  content
+{% endcomment %}
+```
+
+Any text inside `comment` tags won't be output, and any Liquid code will be parsed, but not executed.
+
+Keywords:
+- `content`: The content of the comment.
+
+Example: Inline comments
+```liquid
+{% # content %}
+```
+
+### `doc`
+
+Documents template elements with annotations.
+
+Syntax:
+```liquid
+{% doc %}
+  Renders a message.
+
+  @param {string} foo - A string value.
+  @param {string} [bar] - An optional string value.
+
+  @example
+  {% render 'message', foo: 'Hello', bar: 'World' %}
+{% enddoc %}
+```
+
+The `doc` tag allows developers to include documentation within Liquid
+templates. Any content inside `doc` tags is not rendered or outputted.
+Liquid code inside will be parsed but not executed. This facilitates
+tooling support for features like code completion, linting, and inline
+documentation.
+
+For detailed documentation syntax and examples, see the
+`LiquidDoc` reference.
+
+### `echo`
+
+Outputs an expression.
+
+Syntax:
+```liquid
+{% liquid
+  echo expression
+%}
+```
+
+Using the `echo` tag is the same as wrapping an expression in curly brackets (`{{` and `}}`). However, unlike the curly
+bracket method, you can use the `echo` tag inside `liquid` tags.
+
+> Tip:
+> You can use filters on expressions inside `echo` tags.
+
+Keywords:
+- `expression`: The expression to be output.
+
+```liquid
+{% echo product.title %}
+
+{% liquid
+  echo product.price | money
+%}
+```
+
+### `raw`
+
+Outputs any Liquid code as text instead of rendering it.
+
+Syntax:
+```liquid
+{% raw %}
+  expression
+{% endraw %}
+```
+
+Keywords:
+- `expression`: The expression to be output without being rendered.
+
+```liquid
+{% raw %}
+{{ 2 | plus: 2 }} equals 4.
+{% endraw %}
+```
+
+### `liquid`
+
+Allows you to have a block of Liquid without delimeters on each tag.
+
+Syntax:
+```liquid
+{% liquid
+  expression
+%}
+```
+
+Because the tags don't have delimeters, each tag needs to be on its own line.
+
+> Tip:
+> Use the `echo` tag to output an expression inside `liquid` tags.
+
+Keywords:
+- `expression`: The expression to be rendered inside the `liquid` tag.
+
+```liquid
+{% liquid
+  # Show a message that's customized to the product type
+
+  assign product_type = product.type | downcase
+  assign message = ''
+
+  case product_type
+    when 'health'
+      assign message = 'This is a health potion!'
+    when 'love'
+      assign message = 'This is a love potion!'
+    else
+      assign message = 'This is a potion!'
+  endcase
+
+  echo message
+%}
+```
+
+## Theme
+
+### `content_for`
+
+Creates a designated area in your theme where blocks can be rendered.
+
+Syntax:
+```liquid
+{% content_for 'blocks' %}
+{% content_for 'block', type: "slide", id: "slide-1" %}
+```
+
+The `content_for` tag requires a type parameter to differentiate between rendering a number of theme blocks (`'blocks'`) and a single static block (`'block'`).
+
+Example: blocks
+```liquid
+{% content_for "blocks" %}
+```
+
+### `layout`
+
+Specify which layout to use.
+
+Syntax:
+```liquid
+{% layout name %}
+```
+
+Keywords:
+- `name`: The name of the layout file you want to use, wrapped in quotes, or `none` for no layout.
+
+
+### `include` *(deprecated)*
+
+Renders a snippet.
+
+Syntax:
+```liquid
+{% include 'filename' %}
+```
+
+Inside the snippet, you can access and alter variables that are created outside of the
+snippet.
+
+Keywords:
+- `filename`: The name of the snippet to render, without the `.liquid` extension.
+
+### `render`
+
+Renders a snippet or app block.
+
+Syntax:
+```liquid
+{% render 'filename' %}
+```
+
+Inside snippets and app blocks, you can't directly access variables that are created outside
+of the snippet or app block. However, you can specify variables as parameters
+to pass outside variables to snippets.
+
+While you can't directly access created variables, you can access global objects, as well as any objects that are
+directly accessible outside the snippet or app block. For example, a snippet or app block inside the product template
+can access the `product` object, and a snippet or app block inside a section
+can access the `section` object.
+
+Outside a snippet or app block, you can't access variables created inside the snippet or app block.
+
+> Note:
+> When you render a snippet using the `render` tag, you can't use the `include` tag
+> inside the snippet.
+
+Keywords:
+- `filename`: The name of the snippet to render, without the `.liquid` extension.
+
+Example: for
+```liquid
+{% render 'filename' for array as item %}
+```
+
+### `javascript`
+
+JavaScript code included in section, block and snippet files.
+
+Syntax:
+```liquid
+{% javascript %}
+  javascript_code
+{% endjavascript %}
+```
+
+Each section, block or snippet can have only one `{% javascript %}` tag.
+
+To learn more about how JavaScript that's defined between the `javascript` tags is loaded and run, refer to the documentation for javascript tags.
+> Caution:
+> Liquid isn't rendered inside of `{% javascript %}` tags. Including Liquid code can cause syntax errors.
+
+Keywords:
+- `javascript_code`: The JavaScript code for the section, block or snippet.
+
+### `section`
+
+Renders a section.
+
+Syntax:
+```liquid
+{% section 'name' %}
+```
+
+Rendering a section with the `section` tag renders a section statically. To learn more about sections and how to use
+them in your theme, refer to Render a section.
+
+Keywords:
+- `name`: The name of the section file you want to render.
+
+```liquid
+{% section 'header' %}
+```
+
+### `stylesheet`
+
+CSS styles included in section, block, and snippet files.
+
+Syntax:
+```liquid
+{% stylesheet %}
+  css_styles
+{% endstylesheet %}
+```
+
+Each section, block or snippet can have only one `{% stylesheet %}` tag.
+
+To learn more about how CSS that's defined between the `stylesheet` tags is loaded and run, refer to the documentation for stylesheet tags.
+> Caution:
+> Liquid isn't rendered inside of `{% stylesheet %}` tags. Including Liquid code can cause syntax errors.
+
+Keywords:
+- `css_styles`: The CSS styles for the section, block or snippet.
+
+### `sections`
+
+Renders a section group.
+
+Syntax:
+```liquid
+{% sections 'name' %}
+```
+
+Use this tag to render section groups as part of the theme's layout content. Place the `sections` tag where you want to render it in the layout.
+
+To learn more about section groups and how to use them in your theme, refer to Section groups.
+
+Keywords:
+- `name`: The name of the section group file you want to render.
+
+## Variable
+
+### `assign`
+
+Creates a new variable.
+
+Syntax:
+```liquid
+{% assign variable_name = value %}
+```
+
+You can create variables of any basic type, object, or object property.
+
+> Caution:
+> Predefined Liquid objects can be overridden by variables with the same name.
+> To make sure that you can access all Liquid objects, make sure that your variable name doesn't match a predefined object's name.
+
+Keywords:
+- `variable_name`: The name of the variable being created.
+- `value`: The value you want to assign to the variable.
+
+```liquid
+{%- assign product_title = product.title | upcase -%}
+
+{{ product_title }}
+```
+
+### `capture`
+
+Creates a new variable with a string value.
+
+Syntax:
+```liquid
+{% capture variable %}
+  value
+{% endcapture %}
+```
+
+You can create complex strings with Liquid logic and variables.
+
+> Caution:
+> Predefined Liquid objects can be overridden by variables with the same name.
+> To make sure that you can access all Liquid objects, make sure that your variable name doesn't match a predefined object's name.
+
+Keywords:
+- `variable`: The name of the variable being created.
+- `value`: The value you want to assign to the variable.
+
+```liquid
+{%- assign up_title = product.title | upcase -%}
+{%- assign down_title = product.title | downcase -%}
+{%- assign show_up_title = true -%}
+
+{%- capture title -%}
+  {% if show_up_title -%}
+    Upcase title: {{ up_title }}
+  {%- else -%}
+    Downcase title: {{ down_title }}
+  {%- endif %}
+{%- endcapture %}
+
+{{ title }}
+```
+
+### `decrement`
+
+Creates a new variable, with a default value of -1, that's decreased by 1 with each subsequent call.
+
+> Caution:
+> Predefined Liquid objects can be overridden by variables with the same name.
+> To make sure that you can access all Liquid objects, make sure that your variable name doesn't match a predefined object's name.
+
+Syntax:
+```liquid
+{% decrement variable_name %}
+```
+
+Variables that are declared with `decrement` are unique to the layout, template,
+or section file that they're created in. However, the variable is shared across
+snippets included in the file.
+
+Similarly, variables that are created with `decrement` are independent from those created with `assign`
+and `capture`. However, `decrement` and `increment` share
+variables.
+
+Keywords:
+- `variable_name`: The name of the variable being decremented.
+
+```liquid
+{% decrement variable %}
+{% decrement variable %}
+{% decrement variable %}
+```
+
+### `increment`
+
+Creates a new variable, with a default value of 0, that's increased by 1 with each subsequent call.
+
+> Caution:
+> Predefined Liquid objects can be overridden by variables with the same name.
+> To make sure that you can access all Liquid objects, make sure that your variable name doesn't match a predefined object's name.
+
+Syntax:
+```liquid
+{% increment variable_name %}
+```
+
+Variables that are declared with `increment` are unique to the layout, template,
+or section file that they're created in. However, the variable is shared across
+snippets included in the file.
+
+Similarly, variables that are created with `increment` are independent from those created with `assign`
+and `capture`. However, `increment` and `decrement` share
+variables.
+
+Keywords:
+- `variable_name`: The name of the variable being incremented.
+
+```liquid
+{% increment variable %}
+{% increment variable %}
+{% increment variable %}
+```
+


### PR DESCRIPTION
# Shopify Liquid

Adds a Cline plugin for Shopify Liquid theme development. The plugin combines detailed Liquid theme guidance with a bounded diagnostics tool so users install one useful Liquid plugin instead of separate language-server and skill fragments.

## Cline Primitives

- Tool: `liquid_theme_diagnostics` runs `shopify theme check` in the active workspace or a workspace subdirectory and returns bounded diagnostics output. This is the Cline-native adaptation of Liquid language-server support: Cline does not expose a persistent LSP plugin surface yet, but it can use local theme diagnostics before and after theme edits.
- Skill: `shopify-liquid-themes` covers Liquid syntax, theme architecture, sections, blocks, snippets, schema JSON, settings, filters, objects, tags, translations, and full reference tables/examples.
- Skill: `liquid-theme-standards` covers CSS, JavaScript, and HTML standards for Shopify themes, including design tokens, BEM naming, progressive enhancement, component-scoped behavior, and bundled CSS/JS pattern references.
- Skill: `liquid-theme-a11y` covers accessible product cards, carousels, cart drawers, modals, forms, filters, focus management, keyboard behavior, ARIA usage, and bundled component/focus references.

## Requirements and Trust Boundaries

Users need a Shopify Liquid theme workspace. The bundled skills do not require a Shopify account, API key, or network access.

The diagnostics tool requires Shopify CLI on `PATH` and runs local `shopify theme check` in the selected workspace directory. Users should only run it in theme workspaces they trust. The plugin does not register MCP servers or send theme files to external services by itself.

The bundled Liquid skill material is MIT-licensed by Shopify and included with license/notice files.