### PR TITLE
feat: add math-olympiad plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Each plugin lives in `plugins/<slug>`. The directory name is the install keyword
 | `intercom-support-triage-slack` | Intercom conversation triage tools for support workflows. |
 | `linear` | Linear SDK scripting skill for issue, project, team, cycle, and comment workflows. |
 | `mac-notify` | macOS notifications when a Cline run completes. |
+| `math-olympiad` | Competition math solving and adversarial proof verification. |
 | `nanobanana` | Image generation through OpenRouter and Gemini image models. |
 | `speak` | Speaks completed Cline replies with ElevenLabs text to speech. |
 | `typescript-lsp` | TypeScript language service `goto_definition` support. |

--- a/plugins/math-olympiad/README.md
+++ b/plugins/math-olympiad/README.md
@@ -1,0 +1,37 @@
+# math-olympiad
+
+Adds a competition math skill for solving and checking IMO, Putnam, USAMO, AIME, and similar problems with adversarial proof verification.
+
+## What It Does
+
+The plugin bundles the `math-olympiad` skill. It guides Cline through:
+
+- Interpreting the problem before solving.
+- Trying multiple proof angles instead of locking onto the first idea.
+- Writing a clean proof separate from exploratory reasoning.
+- Running adversarial verification passes that look for specific proof failures.
+- Returning partial progress or `no confident solution` when a proof does not survive review.
+
+It also adds a prompt rule that blocks external solution lookup as the default behavior for competition math tasks.
+
+## Install
+
+```bash
+cline plugin install math-olympiad
+```
+
+For local development from this repository:
+
+```bash
+cline plugin install ./plugins/math-olympiad --cwd .
+```
+
+## Requirements
+
+No accounts, API keys, MCP servers, or local CLIs are required.
+
+The workflow is pure reasoning by default. Local computation may be useful for tiny exploratory checks or arithmetic, but it is not a proof and should not replace a rigorous argument.
+
+## Trust Boundary
+
+Do not use web search, published-solution lookup, or problem database lookup unless the user explicitly asks for research instead of solving. When the proof is incomplete, say so directly and keep partial results separate from verified claims.

--- a/plugins/math-olympiad/index.ts
+++ b/plugins/math-olympiad/index.ts
@@ -1,0 +1,19 @@
+import type { AgentPlugin } from "@cline/sdk"
+
+const plugin: AgentPlugin = {
+	name: "math-olympiad",
+	manifest: {
+		capabilities: ["rules", "skills"],
+	},
+
+	setup(api) {
+		api.registerRule({
+			id: "math-olympiad-proof-integrity",
+			source: "math-olympiad",
+			content:
+				"For olympiad and competition math tasks, do not use web lookup or external solution search unless the user explicitly asks for research instead of solving. Prefer pure reasoning, separate discovery from proof verification, state gaps plainly, and say no confident solution rather than presenting a bluff.",
+		})
+	},
+}
+
+export default plugin

--- a/plugins/math-olympiad/package.json
+++ b/plugins/math-olympiad/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "math-olympiad",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Cline plugin for competition math solving and adversarial proof verification.",
+  "cline": {
+    "plugins": [
+      {
+        "paths": [
+          "./index.ts"
+        ],
+        "capabilities": [
+          "rules",
+          "skills"
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/math-olympiad/skills/math-olympiad/SKILL.md
+++ b/plugins/math-olympiad/skills/math-olympiad/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: math-olympiad
+description: Solve or verify competition math problems with rigorous proof construction, adversarial checking, and calibrated abstention.
+---
+
+# Math Olympiad
+
+Use this skill for IMO, Putnam, USAMO, AIME, olympiad, contest proof, inequality, number theory, combinatorics, geometry, functional equation, and "is this proof correct?" tasks.
+
+Do not use web search or external solution lookup unless the user explicitly asks for research instead of solving. The default workflow is pure reasoning. Use local computation only for small exploratory checks or arithmetic when it helps find a pattern; never present computation as proof.
+
+## Workflow
+
+1. Restate the problem precisely.
+2. Identify possible interpretations. If one reading is trivial and another is hard, solve the intended hard reading and say why.
+3. Classify the task:
+   - Numeric answer: solve, then verify by independent checks.
+   - Proof problem: build a complete argument.
+   - Proof verification: skip solving and attack the submitted proof.
+4. Generate several approaches before committing:
+   - Small cases past the first degenerate case.
+   - Invariant or monovariant.
+   - Extremal element.
+   - Induction.
+   - Symmetry and valid WLOG reductions.
+   - Work backwards from the desired claim.
+   - Drop or weaken a condition to find where the hypothesis is used.
+   - Generalize if the broader statement has more structure.
+5. Choose the strongest approach and write a clean proof. Remove false starts, private exploration, and unsupported leaps.
+6. Run adversarial verification on the clean proof only.
+7. If a gap is found, either repair the proof and verify again, or report partial progress.
+8. Final answer must be one of:
+   - Verified solution.
+   - Partial result with exact unproved step.
+   - No confident solution.
+
+## Adversarial Verification
+
+Attack the proof with these checks:
+
+- Step does not follow: the conclusion is not implied by the premises.
+- Hypothesis mismatch: a cited theorem needs a condition that was not verified.
+- Small-case failure: a claimed identity or bound fails at the first nontrivial case.
+- Tautology: the remaining "gap" is just the original claim in disguise.
+- Proves too much: the argument would also prove a known false or open statement.
+- Wrong interpretation: the proof solves an easier reading of the problem.
+- WLOG failure: the reduction discards a hard case or changes the problem.
+- Hidden regularization: a divergent sum or limiting argument is treated as bounded.
+- Hand wave at the crux: "standard", "routine", or "clearly" appears exactly where the main work is.
+
+For each check, quote the exact proof line being tested and decide whether it holds.
+
+## Verification Output
+
+For proof verification tasks, use:
+
+```text
+Verdict: correct | incorrect | gap | unclear
+Confidence: high | medium | low
+Issue:
+Repair:
+```
+
+For solving tasks, use:
+
+```text
+Method:
+Proof:
+Adversarial checks:
+Answer:
+Confidence:
+```
+
+## Guardrails
+
+- A correct final answer from flawed reasoning is still a failure.
+- Do not hide gaps behind polished language.
+- Do not cite a theorem without checking its hypotheses.
+- Do not infer a pattern from only degenerate small cases.
+- For full problem sets, solve and verify one problem at a time; do not blend proof states across problems.
+- If the user wants a polished write-up, produce LaTeX after verification passes.


### PR DESCRIPTION
# math-olympiad

Adds a competition math plugin for solving and verifying olympiad-style problems with calibrated rigor. The plugin is designed for IMO, Putnam, USAMO, AIME, contest proof, inequality, number theory, combinatorics, geometry, functional equation, and proof-review tasks.

## Cline Primitives

- Bundles the `math-olympiad` skill for structured problem interpretation, approach selection, clean proof writing, and adversarial verification.
- Adds the `math-olympiad-proof-integrity` rule so competition math tasks default to pure reasoning instead of external solution lookup.

The skill asks Cline to separate exploration from the final proof, attack the final proof with specific checks, and return `no confident solution` or exact partial progress when a proof does not survive review.

## Requirements

No accounts, API keys, MCP servers, or local CLIs are required.

The default workflow is pure reasoning. Small local computation can still be useful for arithmetic or pattern exploration, but the plugin treats computation as evidence, not proof.

## Trust Boundary

The plugin blocks web search, published-solution lookup, and problem database lookup by default. If a user explicitly asks for research instead of solving, that opt-in request is allowed, but the plugin still keeps verified claims separate from unverified or externally sourced material.
