### PR TITLE
feat: add mcp-apps plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Each plugin lives in `plugins/<slug>`. The directory name is the install keyword
 | `intercom-support-triage-slack` | Intercom conversation triage tools for support workflows. |
 | `linear` | Linear SDK scripting skill for issue, project, team, cycle, and comment workflows. |
 | `mac-notify` | macOS notifications when a Cline run completes. |
+| `mcp-apps` | Skills for building interactive MCP Apps and migrating OpenAI Apps SDK UIs. |
 | `nanobanana` | Image generation through OpenRouter and Gemini image models. |
 | `speak` | Speaks completed Cline replies with ElevenLabs text to speech. |
 | `typescript-lsp` | TypeScript language service `goto_definition` support. |

--- a/plugins/mcp-apps/README.md
+++ b/plugins/mcp-apps/README.md
@@ -1,0 +1,36 @@
+# mcp-apps
+
+Adds Cline skills for building MCP Apps: MCP tools that return interactive UI resources for hosts that support app rendering.
+
+## What It Does
+
+The plugin bundles four skills:
+
+- `create-mcp-app` for starting a new MCP App server and UI.
+- `add-app-to-server` for adding an interactive UI resource to an existing MCP server tool.
+- `convert-web-app` for making an existing web app work both standalone and as an MCP App.
+- `migrate-oai-app` for migrating OpenAI Apps SDK patterns to MCP Apps.
+
+These skills focus on the practical architecture: tool plus HTML resource, CSP and CORS boundaries, text fallbacks for non-UI hosts, build outputs, and runtime testing with an MCP Apps-capable host.
+
+## Install
+
+```bash
+cline plugin install mcp-apps
+```
+
+For local development from this repository:
+
+```bash
+cline plugin install ./plugins/mcp-apps --cwd .
+```
+
+## Requirements
+
+The plugin itself has no runtime services, MCP servers, or API keys.
+
+Projects built with these skills usually need Node.js, an MCP server framework, `@modelcontextprotocol/ext-apps`, `@modelcontextprotocol/sdk`, a bundler such as Vite, and any app framework the project already uses. When adding dependencies, let the package manager resolve current versions instead of guessing version numbers.
+
+## Trust Boundary
+
+The skills may guide Cline to add dependencies, run builds, and start local app or MCP servers when that is central to the user's task. Do not clone reference repositories, start demo hosts, expose tunnels, or connect to external APIs unless the user asked for that workflow or approved it during the session.

--- a/plugins/mcp-apps/index.ts
+++ b/plugins/mcp-apps/index.ts
@@ -1,0 +1,10 @@
+import type { AgentPlugin } from "@cline/sdk"
+
+const plugin: AgentPlugin = {
+	name: "mcp-apps",
+	manifest: {
+		capabilities: ["skills"],
+	},
+}
+
+export default plugin

--- a/plugins/mcp-apps/package.json
+++ b/plugins/mcp-apps/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "mcp-apps",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Cline plugin that bundles skills for building interactive MCP Apps.",
+  "cline": {
+    "plugins": [
+      {
+        "paths": [
+          "./index.ts"
+        ],
+        "capabilities": [
+          "skills"
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/mcp-apps/skills/add-app-to-server/SKILL.md
+++ b/plugins/mcp-apps/skills/add-app-to-server/SKILL.md
@@ -1,0 +1,57 @@
+---
+name: add-app-to-server
+description: Add an MCP App UI resource to an existing MCP server tool without breaking text-only MCP clients.
+---
+
+# Add App To Server
+
+Use this skill when the user already has an MCP server and wants to add an interactive UI to one or more existing tools.
+
+Preserve the existing tool contract first. The UI is an enhancement, not a replacement for the model-readable tool result.
+
+## Analyze The Server
+
+1. Find the MCP server entrypoint and the tool registration APIs it uses.
+2. List the existing tools, their input schemas, output shapes, and side effects.
+3. Identify which tool result needs a UI and what data the UI needs to render.
+4. Check whether the UI should be read-only, interactive through app-only helper tools, or capable of calling existing tools.
+5. Identify current build tooling and package manager.
+
+## Add The UI
+
+1. Add `@modelcontextprotocol/ext-apps` only if the project does not already use it.
+2. Configure the existing bundler, or add Vite with `vite-plugin-singlefile`, to emit a self-contained HTML file.
+3. Create a UI entrypoint such as `mcp-app.html` plus framework code under the project's existing source layout.
+4. Register a resource URI for the built HTML.
+5. Update the target tool to return:
+   - `content` with a useful text fallback.
+   - UI metadata pointing to the resource URI and initial data.
+6. Keep model-facing tools model-facing. Use app-only helper tools only for interactions the model should not call directly.
+
+## UI Data Flow
+
+Prefer a simple data model:
+
+- Initial tool result contains enough data for the first render.
+- The UI calls app-only helper tools for refreshes, mutations, or large data.
+- Server validates app-originated input just like model-originated input.
+- Errors are visible both in the UI and in model-readable text where relevant.
+
+## CSP And Assets
+
+Declare every external boundary:
+
+- `connectDomains` for APIs, WebSockets, and fetch calls.
+- `resourceDomains` for images, fonts, styles, and scripts.
+- `frameDomains` for embedded iframes.
+
+Avoid adding broad wildcards. If the project has tenant-specific domains, document how the server derives them.
+
+## Review Checklist
+
+- Existing non-UI tool behavior still works.
+- UI-capable hosts get a resource that exists at runtime.
+- Text-only clients receive enough information to continue.
+- Helper tools have the narrowest useful visibility.
+- Build artifacts are ignored or committed according to the repository's normal practice.
+- The user explicitly approved any new external service, tunnel, or hosted dependency needed for testing.

--- a/plugins/mcp-apps/skills/convert-web-app/SKILL.md
+++ b/plugins/mcp-apps/skills/convert-web-app/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: convert-web-app
+description: Convert an existing web application into a hybrid app that can run standalone and as an MCP App.
+---
+
+# Convert Web App
+
+Use this skill when the user wants an existing web app, SPA, iframe embed, dashboard, or visualization to also run as an MCP App.
+
+Keep one codebase. Add MCP-mode entry points and host integration without breaking the standalone browser experience.
+
+## Map The Existing App
+
+Inspect:
+
+- Framework and bundler.
+- Routing and app entrypoints.
+- Data sources: URL parameters, local files, API calls, WebSocket connections, localStorage, or server-rendered props.
+- External resources: fonts, images, CDNs, scripts, iframes, analytics, and API domains.
+- Authentication and user data flow.
+- Existing build and test commands.
+
+## Hybrid Architecture
+
+Use a small adapter layer:
+
+- Standalone mode reads from the existing browser inputs.
+- MCP mode reads initialization data from the host context.
+- Shared rendering components remain framework-native.
+- Server-side MCP tools provide data or mutations that should not happen directly from the browser.
+- The MCP App HTML build is a single-file artifact served as an MCP resource.
+
+Avoid forking the entire app into separate standalone and MCP implementations.
+
+## Server Work
+
+1. Add or extend an MCP server entrypoint.
+2. Register a resource for the MCP App HTML.
+3. Register a tool that returns text fallback content plus UI metadata.
+4. Add helper tools only when the UI needs refreshes, pagination, mutations, or server-only API access.
+5. Validate all inputs regardless of whether they came from the model or the UI.
+
+## Client Work
+
+1. Add MCP-mode detection.
+2. Initialize the host app object only when embedded as an MCP App.
+3. Map existing props, URL params, or API inputs to host-provided initialization data.
+4. Respect host theme and sizing where available.
+5. Keep direct external API calls only when CSP and auth boundaries are intentional. Otherwise route them through MCP server tools.
+
+## Build Work
+
+1. Keep the existing web build intact.
+2. Add a second build target for the MCP App HTML when necessary.
+3. Inline assets for the MCP resource when practical.
+4. Ensure the server reads the built file from a stable path.
+
+## Before Finishing
+
+Verify both modes:
+
+- Standalone app still runs with the existing command.
+- MCP App build emits the expected single HTML file.
+- The MCP tool gives useful text output without UI rendering.
+- The embedded UI can render initial data and call helper tools if any were added.
+- CSP metadata matches the app's actual network and resource usage.

--- a/plugins/mcp-apps/skills/create-mcp-app/SKILL.md
+++ b/plugins/mcp-apps/skills/create-mcp-app/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: create-mcp-app
+description: Build a new MCP App with an MCP tool, an interactive UI resource, a single-file HTML build, host styling, CSP, and text fallback behavior.
+---
+
+# Create MCP App
+
+Use this skill when the user asks to create an MCP App, add an interactive MCP view, scaffold a UI-backed MCP tool, or learn MCP Apps SDK patterns.
+
+An MCP App is an MCP tool plus a UI resource. The tool returns normal text content for the model and non-UI clients, and also returns metadata that points a UI-capable host at an HTML resource.
+
+## First Decisions
+
+1. Identify the server runtime already present in the workspace. Prefer extending it over creating a second server.
+2. Choose the UI framework based on the project:
+   - Existing React app: use React and `useApp` patterns.
+   - Existing Preact, Solid, or vanilla app: keep the current stack.
+   - No existing UI stack: choose the smallest stack that can express the requested UI.
+3. Decide whether the UI needs live updates, host-to-app calls, app-only helper tools, or a static render.
+4. Decide where the built HTML will live. Prefer one single-file HTML artifact per app view.
+
+## Implementation Shape
+
+Use the package manager to add dependencies instead of hardcoding versions from memory. Typical projects need:
+
+```bash
+npm install @modelcontextprotocol/ext-apps @modelcontextprotocol/sdk zod
+npm install -D vite vite-plugin-singlefile typescript tsx
+```
+
+Adapt commands to the workspace's package manager and existing scripts.
+
+The minimal architecture is:
+
+- Server entrypoint registers the MCP tool and a resource handler for the UI HTML.
+- UI entrypoint initializes against the MCP Apps host context when embedded.
+- Build script emits one self-contained HTML file.
+- Tool response includes text fallback content and UI metadata.
+- Resource metadata declares CSP for every external domain the UI loads or connects to.
+
+## Build Steps
+
+1. Add or extend the MCP server entrypoint.
+2. Register the UI resource before any tool returns it.
+3. Add a tool whose result includes both:
+   - `content` with useful text fallback.
+   - UI metadata that points to the resource URI.
+4. Add the UI entrypoint and keep host-specific code behind MCP-mode detection.
+5. Configure Vite or the existing bundler to produce a single HTML artifact.
+6. Add scripts for build, dev, and server start that match the repository's conventions.
+7. Run the existing formatter, typecheck, and build commands.
+
+## Host Behavior
+
+Design for graceful degradation:
+
+- Non-UI clients must still get a meaningful text response.
+- UI-capable hosts should receive the HTML resource and any initialization data.
+- The UI should respect host theme, font, and safe-area values when available.
+- Direct network calls, images, fonts, scripts, iframes, and APIs must be reflected in CSP metadata.
+- Long-running or animated UI should pause when hidden if the host exposes visibility state.
+
+## Common Mistakes
+
+- Returning only the UI metadata and no useful text fallback.
+- Registering the resource after the tool tries to reference it.
+- Loading external assets without CSP entries.
+- Treating localStorage as shared across host views without checking the app view identity.
+- Assuming every MCP client can render the UI.
+- Starting a copied demo host instead of testing the actual server or host the user is targeting.
+
+## Before Finishing
+
+Verify:
+
+- The app builds into the resource path the server reads.
+- The MCP tool still returns useful text in a non-UI client.
+- The UI resource can load without missing asset or CSP errors.
+- Server-to-UI and UI-to-server calls are documented in the code where future maintainers will look.
+- Any external APIs, tokens, or user data flows are explicit and not hidden in example code.

--- a/plugins/mcp-apps/skills/migrate-oai-app/SKILL.md
+++ b/plugins/mcp-apps/skills/migrate-oai-app/SKILL.md
@@ -1,0 +1,65 @@
+---
+name: migrate-oai-app
+description: Migrate an OpenAI Apps SDK app, skybridge integration, or window.openai UI to MCP Apps SDK patterns.
+---
+
+# Migrate OpenAI App To MCP
+
+Use this skill when the user asks to migrate from OpenAI Apps SDK, convert an OpenAI App to MCP, port from `window.openai`, move away from skybridge, or translate `openai/outputTemplate` patterns.
+
+Treat this as an architecture migration, not a search-and-replace.
+
+## Inventory First
+
+Find and record:
+
+- Server-side tool registration and result metadata.
+- Client references to `window.openai`, skybridge APIs, or OpenAI-specific globals.
+- Output template HTML or iframe entrypoints.
+- CSP declarations and external domains.
+- Authentication assumptions.
+- Existing tests, build commands, and local run commands.
+
+## Concept Mapping
+
+Use these mappings as a starting point:
+
+- OpenAI output template becomes an MCP resource URI that serves the app HTML.
+- OpenAI-specific metadata becomes MCP Apps UI metadata.
+- `window.openai` host calls become MCP Apps SDK host/app APIs.
+- Tool result text remains model-readable MCP `content`.
+- App-only interactions become helper tools hidden from normal model use when appropriate.
+- OpenAI CSP fields become MCP Apps CSP metadata with resource, connect, and frame domains.
+
+Do not preserve OpenAI naming in new public APIs unless compatibility requires it.
+
+## Migration Steps
+
+1. Add MCP Apps dependencies with the package manager.
+2. Create an MCP resource for the app HTML.
+3. Update server tool results to include MCP Apps UI metadata and text fallback content.
+4. Replace OpenAI host globals in client code with MCP Apps SDK host/app access.
+5. Move server-only work out of the browser and into MCP tools.
+6. Update CSP declarations to match the new app resource.
+7. Remove dead OpenAI-specific code after the MCP path works.
+8. Run formatter, typecheck, build, and any existing app tests.
+
+## Gaps To Call Out
+
+Some OpenAI Apps SDK behavior may not have a direct MCP Apps equivalent. If you find one:
+
+- Explain the gap plainly.
+- Preserve the closest useful behavior.
+- Avoid pretending a host feature exists when the target MCP host does not expose it.
+- Keep the standalone or old app path only when the user needs compatibility.
+
+## Before Finishing
+
+Check each item explicitly:
+
+- No remaining `window.openai` or skybridge calls in the MCP path.
+- Text fallback still works for non-UI MCP clients.
+- UI resource loads from the MCP server.
+- CSP metadata covers actual domains and is not broader than necessary.
+- Authentication and user data assumptions are documented.
+- Existing standalone behavior is either preserved or intentionally removed.


### PR DESCRIPTION
# mcp-apps

Adds a skills-only plugin for building MCP Apps: MCP tools that return interactive UI resources while still preserving model-readable text output for non-UI clients.

## Cline Primitives

The plugin bundles four skills:

- `create-mcp-app` for starting a new MCP App server and UI.
- `add-app-to-server` for adding an interactive UI resource to an existing MCP server tool without breaking text-only clients.
- `convert-web-app` for making an existing web app work both standalone and as an MCP App.
- `migrate-oai-app` for migrating OpenAI Apps SDK patterns such as `window.openai`, skybridge, and output templates to MCP Apps SDK patterns.

The skills focus on the parts that usually cause implementation drift: tool plus resource architecture, text fallbacks, app-only helper tools, CSP/CORS boundaries, build outputs, host styling, and keeping standalone web behavior intact when needed.

## Requirements

The plugin itself has no runtime service, MCP server registration, API key, or local CLI requirement.

Projects built with the skills will usually need Node.js, an MCP server framework, `@modelcontextprotocol/ext-apps`, `@modelcontextprotocol/sdk`, a bundler such as Vite, and whatever UI framework the target project already uses. The skills direct Cline to let the package manager resolve current dependency versions instead of guessing versions from memory.

## Trust Boundary

The plugin does not start services or clone reference repositories at install time. The bundled skills may guide Cline to add dependencies, run builds, and start local app or MCP servers only when that work is central to the user's requested implementation.

Reference repositories, demo hosts, tunnels, external APIs, and hosted dependencies are treated as explicit workflow choices rather than automatic setup.
