### PR TITLE
feat: add mcp-tunnels plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Each plugin lives in `plugins/<slug>`. The directory name is the install keyword
 | `intercom-support-triage-slack` | Intercom conversation triage tools for support workflows. |
 | `linear` | Linear SDK scripting skill for issue, project, team, cycle, and comment workflows. |
 | `mac-notify` | macOS notifications when a Cline run completes. |
+| `mcp-tunnels` | Slash command for guided Anthropic MCP Tunnel Docker Compose setup. |
 | `nanobanana` | Image generation through OpenRouter and Gemini image models. |
 | `speak` | Speaks completed Cline replies with ElevenLabs text to speech. |
 | `typescript-lsp` | TypeScript language service `goto_definition` support. |

--- a/plugins/mcp-tunnels/README.md
+++ b/plugins/mcp-tunnels/README.md
@@ -1,0 +1,41 @@
+# mcp-tunnels
+
+Adds a Cline slash command for setting up Anthropic MCP Tunnels with Docker Compose.
+
+## What It Does
+
+The plugin registers `/create-docker-mcp-tunnel [deployment-dir]`.
+
+The command submits a guided setup prompt for the manual-credentials Docker Compose flow:
+
+- Preflight Docker, Docker Compose, OpenSSL, and outbound connectivity.
+- Guide the user through Anthropic Console actions they must do themselves.
+- Generate local certificates and proxy configuration only after approval.
+- Keep tunnel tokens out of chat by using a gitignored `.env` placeholder or user-exported environment variable.
+- Route either an existing private MCP server or a tiny sample streamable HTTP server.
+- Verify cloudflared registration, proxy logs, and the final tunnel URL.
+
+## Install
+
+```bash
+cline plugin install mcp-tunnels
+```
+
+For local development from this repository:
+
+```bash
+cline plugin install ./plugins/mcp-tunnels --cwd .
+```
+
+## Requirements
+
+- Docker and Docker Compose on the machine that will run the tunnel stack.
+- OpenSSL for local CA and server certificate generation.
+- Anthropic Console access with permission to manage MCP tunnels.
+- Outbound access to the Anthropic API and tunnel edge. The flow does not require inbound ports on the origin.
+
+## Trust Boundary
+
+This plugin does not create tunnels, run Docker, generate certificates, or call external APIs at install time. The slash command is a runbook prompt; the actual setup happens only after the user asks for it and approves the relevant local actions.
+
+Tunnel tokens, `.env` files, private keys, and generated certificate data should never be pasted into chat or committed to git.

--- a/plugins/mcp-tunnels/index.ts
+++ b/plugins/mcp-tunnels/index.ts
@@ -1,0 +1,48 @@
+import type { AgentPlugin } from "@cline/sdk"
+
+const DEFAULT_DEPLOYMENT_DIR = "./mcp-tunnel"
+
+function formatTunnelPrompt(input: string): string {
+	const requestedDir = input.trim().replace(/\s+/g, " ") || DEFAULT_DEPLOYMENT_DIR
+	const deploymentDir = JSON.stringify(requestedDir)
+
+	return `Guide me through creating an Anthropic MCP Tunnel Docker Compose setup.
+
+Deployment directory: ${deploymentDir}
+
+Operate carefully:
+
+1. Explain that Anthropic MCP Tunnels are a research-preview way to expose a private MCP server through an outbound-only tunnel that depends on Cloudflare transport. Do not position this as a production hardening guide.
+2. Do not ask me to paste the tunnel token into chat. The token is a live secret. If a token is needed, create a gitignored .env placeholder or ask me to export it in my shell, then verify only by checking that it is present without printing it.
+3. Ask before creating files, generating certificates, running Docker, starting services, exposing a tunnel, deploying anything, or calling an external API.
+4. Preflight Docker, Docker Compose, OpenSSL, and outbound connectivity requirements before writing files.
+5. Tell me which Anthropic Console actions I must do myself: create the tunnel, copy the non-secret domain, keep the token secret, and upload the CA certificate.
+6. Generate only local development artifacts in the deployment directory unless I explicitly ask for production or Kubernetes guidance.
+7. If I already have an MCP server, route to that private upstream only after confirming its scheme, host, port, and path. If I do not, offer a tiny sample streamable HTTP MCP server for verification.
+8. Keep private keys, .env files, generated cert data, and tunnel credentials out of git and out of chat.
+9. Verify each stage before moving on: cert generation, CA registration, Compose config, cloudflared registration, proxy logs, and final reachable URL.
+10. End with the deployment directory, configured route, tunnel domain, exact URL path, secret locations, and cleanup/rotation notes.
+
+Use Cline's normal command and file tools only after the relevant approval is clear.`
+}
+
+const plugin: AgentPlugin = {
+	name: "mcp-tunnels",
+	manifest: {
+		capabilities: ["commands"],
+	},
+
+	setup(api) {
+		api.registerCommand({
+			name: "create-docker-mcp-tunnel",
+			description:
+				"Guide Anthropic MCP Tunnel setup with Docker Compose, certificates, cloudflared, and a private MCP upstream.",
+			handler: (input) => ({
+				reply: "Starting a guided Anthropic MCP Tunnel Docker Compose setup.",
+				submitPrompt: formatTunnelPrompt(input),
+			}),
+		})
+	},
+}
+
+export default plugin


### PR DESCRIPTION
# mcp-tunnels

Adds a single slash-command plugin for guiding Anthropic MCP Tunnel setup from Cline.

## Cline Primitives

The plugin registers `/create-docker-mcp-tunnel [deployment-dir]`.

The command submits a careful runbook prompt for the manual-credentials Docker Compose tunnel flow. It asks Cline to preflight Docker, Docker Compose, OpenSSL, and outbound connectivity; guide the user through Anthropic Console actions; generate local cert/proxy artifacts only after approval; route either an existing private MCP server or a tiny sample streamable HTTP server; and verify cloudflared, proxy logs, and the final tunnel URL.

## Requirements

The plugin itself has no install-time dependencies, MCP registration, API key, Docker service, or background process.

Using the command requires Docker, Docker Compose, OpenSSL, Anthropic Console access with permission to manage MCP tunnels, and outbound access to the Anthropic API and tunnel edge.

## Trust Boundary

This is intentionally a guided slash command rather than an automatic tool. Installing the plugin does not create tunnels, generate certificates, run Docker, call external APIs, or write tunnel credentials.

The command prompt explicitly keeps tunnel tokens out of chat, uses a gitignored `.env` placeholder or user-exported environment variable, and asks before file creation, certificate generation, Docker startup, tunnel exposure, deployment, or external API calls.
