### PR TITLE
feat: add mercadopago plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Each plugin lives in `plugins/<slug>`. The directory name is the install keyword
 | `intercom-support-triage-slack` | Intercom conversation triage tools for support workflows. |
 | `linear` | Linear SDK scripting skill for issue, project, team, cycle, and comment workflows. |
 | `mac-notify` | macOS notifications when a Cline run completes. |
+| `mercadopago` | Mercado Pago OAuth MCP plus payment integration, webhook, test-user, and review workflows. |
 | `nanobanana` | Image generation through OpenRouter and Gemini image models. |
 | `speak` | Speaks completed Cline replies with ElevenLabs text to speech. |
 | `typescript-lsp` | TypeScript language service `goto_definition` support. |

--- a/plugins/mercadopago/README.md
+++ b/plugins/mercadopago/README.md
@@ -13,7 +13,7 @@ It also bundles four skills:
 - `mp-test-setup` for creating Mercado Pago test users, loading test-user funds, and finding current test-card guidance.
 - `mp-review` for reviewing an integration against the MCP-backed quality checklist and a fixed security floor.
 
-The plugin registers three slash commands: `/mp-connect`, `/mp-integrate`, and `/mp-review`.
+The plugin registers `/mp-connect` for MCP OAuth/status checks. The integration and review workflows are directly slash-invokable through their bundled skill names, such as `mp-integrate`, `mp-webhooks`, `mp-test-setup`, and `mp-review`.
 
 It also adds a payment-safety rule and a lightweight runtime hook that blocks Mercado Pago credential patterns from tool inputs and blocks `.env` reads in Mercado Pago workspaces.
 

--- a/plugins/mercadopago/README.md
+++ b/plugins/mercadopago/README.md
@@ -1,0 +1,42 @@
+# mercadopago
+
+Adds Mercado Pago integration workflows backed by the official Mercado Pago MCP server.
+
+## What It Does
+
+The plugin registers the `mercadopago` remote MCP server at `https://mcp.mercadopago.com/mcp`.
+
+It also bundles four skills:
+
+- `mp-integrate` for building Checkout Pro, Checkout API, Bricks, QR, Point, subscriptions, marketplace, wallet, money-out, and related integration flows from MCP-backed documentation.
+- `mp-webhooks` for adding signed webhook receivers, configuring webhook URLs, simulating notifications, and diagnosing missed deliveries.
+- `mp-test-setup` for creating Mercado Pago test users, loading test-user funds, and finding current test-card guidance.
+- `mp-review` for reviewing an integration against the MCP-backed quality checklist and a fixed security floor.
+
+The plugin registers three slash commands: `/mp-connect`, `/mp-integrate`, and `/mp-review`.
+
+It also adds a payment-safety rule and a lightweight runtime hook that blocks Mercado Pago credential patterns from tool inputs and blocks `.env` reads in Mercado Pago workspaces.
+
+## Install
+
+```bash
+cline plugin install mercadopago
+```
+
+For local development from this repository:
+
+```bash
+cline plugin install ./plugins/mercadopago --cwd .
+```
+
+## Requirements
+
+OAuth with a Mercado Pago account is required before MCP data tools can return account-specific results. Run `/mp-connect` or use any workflow that triggers MCP auth, then open the authorization URL in the browser.
+
+The plugin does not require access-token headers or local CLIs at install time. Project work may require installing the relevant Mercado Pago SDK for the app's language or framework.
+
+## Trust Boundary
+
+Payment integrations can create real financial effects. The skills ask before writing files, installing SDKs, creating test users, loading test funds, configuring webhook URLs, or making payment-affecting calls.
+
+Never paste Mercado Pago access tokens, OAuth callback URLs, webhook secrets, client secrets, or `.env` contents into chat. Use `.env.example` for variable names and keep actual values in user-managed environment variables or a secret manager.

--- a/plugins/mercadopago/README.md
+++ b/plugins/mercadopago/README.md
@@ -13,7 +13,7 @@ It also bundles four skills:
 - `mp-test-setup` for creating Mercado Pago test users, loading test-user funds, and finding current test-card guidance.
 - `mp-review` for reviewing an integration against the MCP-backed quality checklist and a fixed security floor.
 
-The plugin registers `/mp-connect` for MCP OAuth/status checks. The integration and review workflows are directly slash-invokable through their bundled skill names, such as `mp-integrate`, `mp-webhooks`, `mp-test-setup`, and `mp-review`.
+The plugin registers `/mp-connect` for MCP OAuth and status checks. The integration and review workflows are directly slash-invokable through their bundled skill names, such as `mp-integrate`, `mp-webhooks`, `mp-test-setup`, and `mp-review`.
 
 It also adds a payment-safety rule and a lightweight runtime hook that blocks Mercado Pago credential patterns from tool inputs and blocks `.env` reads in Mercado Pago workspaces.
 

--- a/plugins/mercadopago/index.ts
+++ b/plugins/mercadopago/index.ts
@@ -1,0 +1,195 @@
+import { existsSync, readFileSync } from "node:fs"
+import { dirname, join, parse } from "node:path"
+import type { AgentPlugin } from "@cline/sdk"
+
+const PLUGIN_NAME = "mercadopago"
+const MERCADOPAGO_MCP_URL = "https://mcp.mercadopago.com/mcp"
+const MANIFEST_FILES = [
+	"package.json",
+	"composer.json",
+	"requirements.txt",
+	"Pipfile",
+	"pyproject.toml",
+	"Gemfile",
+	"pom.xml",
+	"build.gradle",
+	"build.gradle.kts",
+	"go.mod",
+]
+
+const credentialPatterns = [
+	/\b(?:TEST|APP_USR)-\d{12,}-\d{6}-[a-f0-9]{32}-U\d+\b/i,
+	/Bearer\s+(?:TEST|APP_USR)-[^\s'"]+/i,
+	/["']client_secret["']\s*[:=]\s*["'][a-f0-9]{32,}["']/i,
+	/["']?(?:x-signature|webhook.?secret)["']?\s*[:=]\s*["'][a-zA-Z0-9+/]{20,}["']/i,
+]
+
+let workspaceRoot: string | undefined
+
+function mpConnectPrompt(): string {
+	return `Verify the Mercado Pago MCP connection.
+
+Use the plugin-owned Cline MCP server named "mercadopago".
+
+1. Check whether a real data tool such as mercadopago__application_list is available and returns an application payload. Do not rely on resource listing as the status check.
+2. If only bootstrap auth tools are visible, call mercadopago__authenticate and show the returned authorization URL as a clickable link.
+3. Tell me: "When you see Authentication Successful in the browser, come back and say anything."
+4. When I respond, call mercadopago__application_list directly. Do not ask me to paste the callback URL because it contains a sensitive OAuth code.
+5. If the connection still fails, explain the exact failure and suggest disabling/re-enabling the plugin or restarting the Cline session.`
+}
+
+function mpIntegratePrompt(input: string): string {
+	const args = input.trim()
+	return `Run the Mercado Pago integration workflow${args ? ` with these arguments: ${JSON.stringify(args)}` : ""}.
+
+Use the bundled mp-integrate skill unless the first argument is "webhook" or "test-setup":
+
+- "webhook": use the mp-webhooks skill.
+- "test-setup": use the mp-test-setup skill.
+- anything else: use mp-integrate.
+
+The Mercado Pago MCP server named "mercadopago" is the source of truth for current documentation and product constraints. If it is not authenticated, start the OAuth flow with mercadopago__authenticate and never ask me to paste a callback URL.
+
+Do not hardcode access tokens, public keys, webhook secrets, or payment IDs. Do not create or overwrite .env. Use .env.example for placeholders and ask before writing files, installing SDKs, creating test users, loading test funds, configuring webhooks, or making any payment-affecting API call.`
+}
+
+function mpReviewPrompt(input: string): string {
+	const scope = input.trim() || "full"
+	return `Review this project's Mercado Pago integration with scope ${JSON.stringify(scope)}.
+
+Use the bundled mp-review skill. Pull the official quality checklist from the Mercado Pago MCP server named "mercadopago"; there is no offline substitute for the official checklist.
+
+Also perform the fixed security floor: credentials are environment-backed, HTTPS is used, webhook signatures are validated, post-payment status is verified server-side, idempotency keys are sent on create calls, and test-user credentials are not committed to production deployment. Do not mutate Mercado Pago state during the review.`
+}
+
+function hasMercadoPagoManifestSignal(root: string): boolean {
+	let current = root
+	const stop = parse(current).root
+	for (let depth = 0; depth < 32; depth++) {
+		for (const name of MANIFEST_FILES) {
+			const file = join(current, name)
+			if (!existsSync(file)) {
+				continue
+			}
+			try {
+				if (readFileSync(file, "utf8").toLowerCase().includes("mercadopago")) {
+					return true
+				}
+			} catch {
+				// Ignore unreadable manifests.
+			}
+		}
+		if (existsSync(join(current, ".git")) || current === stop) {
+			break
+		}
+		current = dirname(current)
+	}
+	return false
+}
+
+function inputText(input: unknown): string {
+	try {
+		return JSON.stringify(input) ?? ""
+	} catch {
+		return String(input ?? "")
+	}
+}
+
+function isEnvRead(toolName: string, text: string): boolean {
+	const envPathPattern =
+		/(^|[\s"'=:[\]{},;&|<>])((?:\.\/)?(?:[^"'`\s;&|<>]*\/)?\.env(?:\.[A-Za-z0-9_-]+)?)(?=$|[\s"'.,;:)\]}&|<>])/g
+	const referencesProtectedEnvFile = [...text.matchAll(envPathPattern)].some(
+		(match) => {
+			const path = match[2] ?? ""
+			return !/(^|[/\\])\.env\.example$/.test(path)
+		},
+	)
+	if (!referencesProtectedEnvFile) {
+		return false
+	}
+	if (/read/i.test(toolName)) {
+		return true
+	}
+	return /(bash|command|terminal|shell|run)/i.test(toolName)
+}
+
+const plugin: AgentPlugin = {
+	name: PLUGIN_NAME,
+	manifest: {
+		capabilities: ["commands", "hooks", "mcp", "rules", "skills"],
+	},
+
+	setup(api, ctx) {
+		workspaceRoot = ctx.workspaceInfo?.rootPath
+
+		api.registerMcpServer({
+			name: "mercadopago",
+			transport: {
+				type: "streamableHttp",
+				url: MERCADOPAGO_MCP_URL,
+				headers: {
+					"X-Invocation-Context": "cline-plugin",
+				},
+			},
+		})
+
+		api.registerCommand({
+			name: "mp-connect",
+			description: "Verify or start Mercado Pago MCP OAuth authentication.",
+			handler: () => ({
+				reply: "Starting Mercado Pago MCP connection check.",
+				submitPrompt: mpConnectPrompt(),
+			}),
+		})
+
+		api.registerCommand({
+			name: "mp-integrate",
+			description: "Run the Mercado Pago integration wizard, webhook flow, or test-user setup.",
+			handler: (input) => ({
+				reply: "Starting Mercado Pago integration workflow.",
+				submitPrompt: mpIntegratePrompt(input),
+			}),
+		})
+
+		api.registerCommand({
+			name: "mp-review",
+			description: "Review a Mercado Pago integration against MCP-backed quality and security checks.",
+			handler: (input) => ({
+				reply: "Starting Mercado Pago integration review.",
+				submitPrompt: mpReviewPrompt(input),
+			}),
+		})
+
+		api.registerRule({
+			id: "mercadopago-payment-safety",
+			source: PLUGIN_NAME,
+			content:
+				"For Mercado Pago work, use the mercadopago MCP server as the source of truth, keep credentials out of chat and source files, never create or overwrite .env files, ask before writes or payment-affecting actions, use idempotency keys on create calls, validate webhook signatures, and verify payment status server-side after redirects or notifications.",
+		})
+	},
+
+	hooks: {
+		beforeTool({ toolCall, input }) {
+			const toolName = String(toolCall.toolName ?? "")
+			const text = inputText(input)
+			if (credentialPatterns.some((pattern) => pattern.test(text))) {
+				return {
+					stop: true,
+					reason:
+						"Blocked Mercado Pago credential exposure. Put tokens and webhook secrets in user-managed environment variables or a secret manager, not in chat, source files, commands, or tool inputs.",
+				}
+			}
+			const root = workspaceRoot ?? process.cwd()
+			if (isEnvRead(toolName, text) && hasMercadoPagoManifestSignal(root)) {
+				return {
+					stop: true,
+					reason:
+						"Blocked .env read in a Mercado Pago workspace. Read .env.example or ask the user which variable names exist without exposing secret values.",
+				}
+			}
+			return undefined
+		},
+	},
+}
+
+export default plugin

--- a/plugins/mercadopago/index.ts
+++ b/plugins/mercadopago/index.ts
@@ -38,30 +38,6 @@ Use the plugin-owned Cline MCP server named "mercadopago".
 5. If the connection still fails, explain the exact failure and suggest disabling/re-enabling the plugin or restarting the Cline session.`
 }
 
-function mpIntegratePrompt(input: string): string {
-	const args = input.trim()
-	return `Run the Mercado Pago integration workflow${args ? ` with these arguments: ${JSON.stringify(args)}` : ""}.
-
-Use the bundled mp-integrate skill unless the first argument is "webhook" or "test-setup":
-
-- "webhook": use the mp-webhooks skill.
-- "test-setup": use the mp-test-setup skill.
-- anything else: use mp-integrate.
-
-The Mercado Pago MCP server named "mercadopago" is the source of truth for current documentation and product constraints. If it is not authenticated, start the OAuth flow with mercadopago__authenticate and never ask me to paste a callback URL.
-
-Do not hardcode access tokens, public keys, webhook secrets, or payment IDs. Do not create or overwrite .env. Use .env.example for placeholders and ask before writing files, installing SDKs, creating test users, loading test funds, configuring webhooks, or making any payment-affecting API call.`
-}
-
-function mpReviewPrompt(input: string): string {
-	const scope = input.trim() || "full"
-	return `Review this project's Mercado Pago integration with scope ${JSON.stringify(scope)}.
-
-Use the bundled mp-review skill. Pull the official quality checklist from the Mercado Pago MCP server named "mercadopago"; there is no offline substitute for the official checklist.
-
-Also perform the fixed security floor: credentials are environment-backed, HTTPS is used, webhook signatures are validated, post-payment status is verified server-side, idempotency keys are sent on create calls, and test-user credentials are not committed to production deployment. Do not mutate Mercado Pago state during the review.`
-}
-
 function hasMercadoPagoManifestSignal(root: string): boolean {
 	let current = root
 	const stop = parse(current).root
@@ -139,24 +115,6 @@ const plugin: AgentPlugin = {
 			handler: () => ({
 				reply: "Starting Mercado Pago MCP connection check.",
 				submitPrompt: mpConnectPrompt(),
-			}),
-		})
-
-		api.registerCommand({
-			name: "mp-integrate",
-			description: "Run the Mercado Pago integration wizard, webhook flow, or test-user setup.",
-			handler: (input) => ({
-				reply: "Starting Mercado Pago integration workflow.",
-				submitPrompt: mpIntegratePrompt(input),
-			}),
-		})
-
-		api.registerCommand({
-			name: "mp-review",
-			description: "Review a Mercado Pago integration against MCP-backed quality and security checks.",
-			handler: (input) => ({
-				reply: "Starting Mercado Pago integration review.",
-				submitPrompt: mpReviewPrompt(input),
 			}),
 		})
 

--- a/plugins/mercadopago/package.json
+++ b/plugins/mercadopago/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "mercadopago",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Cline plugin for Mercado Pago MCP-backed payment integration workflows.",
+  "cline": {
+    "plugins": [
+      {
+        "paths": [
+          "./index.ts"
+        ],
+        "capabilities": [
+          "commands",
+          "hooks",
+          "mcp",
+          "rules",
+          "skills"
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/mercadopago/skills/mp-integrate/SKILL.md
+++ b/plugins/mercadopago/skills/mp-integrate/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: mp-integrate
+description: Build Mercado Pago payment integrations using the official MCP server for current docs, product constraints, and code patterns.
+---
+
+# Mercado Pago Integrate
+
+Use this skill when the user wants to add, migrate, or scaffold a Mercado Pago payment flow.
+
+The `mercadopago` MCP server is the source of truth. Do not invent payloads, endpoints, country availability, or SDK snippets from memory.
+
+## Authentication Gate
+
+Before product work, verify that a real data tool such as `mercadopago__application_list` is callable and returns an application payload. If only auth tools are available, call `mercadopago__authenticate`, show the returned URL, and wait for the user to return after browser success. Never ask for the callback URL.
+
+## Discovery
+
+Resolve:
+
+- Country: ask when it cannot be resolved from explicit user input.
+- Product: checkout-pro, checkout-api, bricks, qr, point, subscriptions, marketplace, wallet-connect, money-out, smartapps.
+- Server SDK: infer from manifests when possible; otherwise default to Node and say so.
+- Client framework, mode, 3DS, recurrence, marketplace split, or brick variant only when relevant.
+
+Hard rules:
+
+- Do not ask for an environment. Mercado Pago test users use production API URLs with test-user credentials.
+- Checkout Pro uses preferences, not Orders API.
+- Never create or overwrite `.env`; write `.env.example` only.
+- Ask before installing SDKs or writing files.
+
+## MCP Queries
+
+Use targeted `mercadopago__search_documentation` queries for the selected product, country, SDK, and client framework.
+
+Use one fallback web fetch only if the MCP has no useful result for the exact combination. Do not fan out across languages or multiple docs pages.
+
+## Output Bundle
+
+Return:
+
+- Install command for the detected SDK.
+- Credential variable names only: `MP_ACCESS_TOKEN`, `MP_PUBLIC_KEY`, `MP_WEBHOOK_SECRET`, and app URL variables.
+- Server code pattern from MCP results.
+- Client code pattern when applicable.
+- Webhook next step that points to `mp-webhooks`.
+- Test next step that points to `mp-test-setup`.
+- Gotchas relevant to the selected product.
+
+## File Writes
+
+If the user asks to write files:
+
+- Install the SDK in the correct package directory.
+- Inject code into existing files rather than overwriting.
+- Create `.env.example` with placeholders.
+- Do not write outside the workspace.
+- Stop on the first failed write or install command.
+
+## Safety
+
+Use idempotency keys on payment/order creation. Never trust redirect query parameters alone; verify status server-side. Never hardcode preference IDs, payment IDs, access tokens, public keys, webhook secrets, or client secrets.

--- a/plugins/mercadopago/skills/mp-review/SKILL.md
+++ b/plugins/mercadopago/skills/mp-review/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: mp-review
+description: Review Mercado Pago integrations against MCP-backed quality criteria and a fixed payment-security checklist.
+---
+
+# Mercado Pago Review
+
+Use this skill after a Mercado Pago integration exists, or when `/mp-review` is invoked.
+
+## Authentication Gate
+
+The official checklist must come from the Mercado Pago MCP server. Verify `mercadopago__quality_checklist` before reviewing. If auth is needed, call `mercadopago__authenticate` and never ask for callback URLs.
+
+## Discover The Integration
+
+Inspect:
+
+- SDK imports and package manifests.
+- Payment, order, preference, preapproval, QR, Point, and disbursement endpoints.
+- Webhook handlers and notification routes.
+- Credential loading and environment-variable usage.
+- Idempotency handling on create calls.
+- Server-side status verification after redirects or notifications.
+
+## Review Sources
+
+Call `mercadopago__quality_checklist` for the official current criteria. Suggest `mercadopago__quality_evaluation` only when the project has a compatible recent test payment or order ID and the user approves.
+
+Do not mutate Mercado Pago state during review.
+
+## Security Floor
+
+Always evaluate:
+
+- Access tokens, public keys, client secrets, and webhook secrets are not hardcoded.
+- `.env` is not read or committed; `.env.example` documents variables.
+- HTTPS is used for production redirects and webhook URLs.
+- Webhook `x-signature` is validated.
+- Payment/order status is re-fetched server-side.
+- Idempotency keys are sent on create calls.
+- Test-user credentials are not mixed into production deployment.
+
+## Final Report
+
+Return a structured report with:
+
+- Scope.
+- Critical blockers.
+- Warnings and forward-looking migration notes.
+- Passes.
+- Quality checklist items from MCP.
+- Security checklist.
+- Recommendations and next steps.

--- a/plugins/mercadopago/skills/mp-test-setup/SKILL.md
+++ b/plugins/mercadopago/skills/mp-test-setup/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: mp-test-setup
+description: Create Mercado Pago test users, load test funds, and retrieve current testing guidance through the Mercado Pago MCP server.
+---
+
+# Mercado Pago Test Setup
+
+Use this skill when the user needs test users, test-user funds, test cards, or a clear explanation of the current Mercado Pago testing model.
+
+## Current Model
+
+- There is no separate sandbox URL.
+- Test users use production API URLs with test-user credentials.
+- Modern credentials use the `APP_USR-` prefix. Do not suggest a `TEST-` prefix for new work.
+- Test credentials must still be treated as secrets.
+
+## Authentication Gate
+
+Verify `mercadopago__application_list` before creating users or funds. If auth is needed, call `mercadopago__authenticate` and never ask for OAuth callback URLs.
+
+## Create Test Users
+
+Ask for country/site, role, and description. For marketplace, subscription, or buyer/seller flows, suggest creating separate buyer and seller users.
+
+Call `mercadopago__create_test_user` only after the user confirms.
+
+## Load Funds
+
+Call `mercadopago__add_money_test_user` only after the user confirms the test user and amount. Explain that per-country limits can apply.
+
+## Test Cards
+
+Do not invent card numbers. Query `mercadopago__search_documentation` with the current country and product.
+
+## Output
+
+Return the test user's IDs, credential variable names, and next steps. Do not print secrets unless the MCP explicitly returns non-secret setup fields and the user needs to copy them.

--- a/plugins/mercadopago/skills/mp-webhooks/SKILL.md
+++ b/plugins/mercadopago/skills/mp-webhooks/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: mp-webhooks
+description: Add, configure, simulate, and diagnose Mercado Pago webhooks with HMAC signature validation.
+---
+
+# Mercado Pago Webhooks
+
+Use this skill when adding, debugging, or hardening Mercado Pago webhook and notification handling.
+
+## Authentication Gate
+
+Verify the `mercadopago` MCP server with `mercadopago__application_list`. If auth is needed, call `mercadopago__authenticate`, show the authorization URL, and never ask for callback URLs or OAuth codes.
+
+## Receiver Requirements
+
+Every webhook receiver must:
+
+- Validate `x-signature` with HMAC-SHA256 before trusting the body.
+- Use `x-request-id`, notification `data.id`, and `ts` from the signature header in the canonical string.
+- Fetch the payment, order, merchant order, preapproval, or authorized payment server-side after validation.
+- Return quickly and move heavy processing to a queue when possible.
+- Treat legacy IPN-style `id` and `topic` query notifications as deprecated for new integrations.
+
+## MCP Actions
+
+Use MCP tools only after the user approves:
+
+- Configure or rotate webhook URLs with `mercadopago__save_webhook`.
+- Smoke test receiver delivery with `mercadopago__simulate_webhook`.
+- Diagnose missed deliveries with `mercadopago__notifications_history_diagnostics`.
+
+Ask before configuring production callback URLs.
+
+## Implementation Pattern
+
+Add the receiver code in the app's existing server framework. Use environment variables for webhook signing secrets, never hardcoded values.
+
+For languages beyond the current project stack, query MCP documentation with `webhook signature validation {language}`.
+
+## Before Finishing
+
+Verify:
+
+- `.env.example` lists `MP_WEBHOOK_SECRET`.
+- Receiver rejects missing or invalid signatures.
+- Receiver re-fetches resource status server-side.
+- Webhook topics match the product and API mode.
+- A simulated webhook reaches the endpoint when the user approved simulation.


### PR DESCRIPTION
# mercadopago

Adds a Mercado Pago payment-integration plugin backed by the official Mercado Pago MCP server.

## Cline Primitives

The plugin registers the remote `mercadopago` MCP server at `https://mcp.mercadopago.com/mcp`. OAuth is handled through Cline's MCP flow, so users do not paste access-token headers into plugin settings.

It bundles four workflow skills:

- `mp-integrate` for building Mercado Pago payment flows from MCP-backed docs and product constraints.
- `mp-webhooks` for signed webhook receivers, webhook URL configuration, simulated notifications, and delivery diagnostics.
- `mp-test-setup` for test users, test-user funds, and current test-card guidance.
- `mp-review` for quality-checklist review plus a fixed payment-security checklist.

It also registers `/mp-connect` for MCP OAuth and status checks, plus a payment-safety rule and a runtime hook that blocks Mercado Pago credential patterns in tool inputs and blocks `.env` reads in Mercado Pago workspaces.

## Requirements

Users need a Mercado Pago account and must complete OAuth before account-specific MCP tools return data. Project work may require installing the Mercado Pago SDK for the target app's language or framework.

The plugin itself does not require local CLIs, static access-token headers, or install-time services.

## Trust Boundary

Payment integrations can create real financial effects. The skills require user approval before file writes, SDK installs, test-user creation, test-fund loading, webhook configuration, or payment-affecting MCP calls.

Secrets stay out of chat and source files: no access tokens, OAuth callback URLs, webhook secrets, client secrets, or `.env` contents. The plugin uses `.env.example` for variable names and expects actual values to live in user-managed environment variables or a secret manager.
