### PR TITLE
feat: add oracle aidp connectors plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Each plugin lives in `plugins/<slug>`. The directory name is the install keyword
 | `linear` | Linear SDK scripting skill for issue, project, team, cycle, and comment workflows. |
 | `mac-notify` | macOS notifications when a Cline run completes. |
 | `nanobanana` | Image generation through OpenRouter and Gemini image models. |
+| `oracle-aidp-connectors` | Oracle AI Data Platform Workbench Spark connector skills for Oracle, OCI, databases, SaaS, object stores, and Excel. |
 | `speak` | Speaks completed Cline replies with ElevenLabs text to speech. |
 | `typescript-lsp` | TypeScript language service `goto_definition` support. |
 | `weather-metrics` | Demo weather tool plus runtime metrics hooks. |

--- a/plugins/oracle-aidp-connectors/.env.example
+++ b/plugins/oracle-aidp-connectors/.env.example
@@ -1,0 +1,221 @@
+# Oracle AI Data Platform - Spark Connectors: example environment variables
+#
+# Copy to .env and fill in for live testing. Never commit .env.
+# Production: prefer OCI Vault via oracle_ai_data_platform_connectors.auth.secrets.get(name)
+
+# -------- ALH / ADW / ATP (Oracle Autonomous DB family - same skill covers all three) --------
+# For ADW or ATP, just substitute the prefix and follow identical logic; the skill is product-agnostic.
+ALH_TNS_SERVICE=alh_high                          # _high / _medium / _low - confirm via wallet's tnsnames.ora
+ALH_USER=ADMIN
+ALH_PASSWORD=
+ALH_WALLET_ZIP_PATH=                              # local path to wallet ZIP, or in-AIDP path
+ALH_WALLET_PATH=/tmp/wallet/alh                   # target dir under /tmp where wallet is extracted
+ALH_TABLE_FOR_TEST=                               # a known table with non-zero rows
+ALH_COMPARTMENT_OCID=                             # for IAM DB-Token scope: urn:oracle:db::id::<COMPARTMENT_OCID>
+ALH_EXTERNAL_CATALOG_TABLE=                       # for the catalog-sync test (optional)
+
+# -------- ExaCS --------
+# Auth: plain user/password on TCP 1521 with server-enforced AES256 NNE (only supported path from AIDP notebooks).
+# Workspace prereq: networkConfigurationDetails.scanDetails must register the SCAN FQDN+port (PE-ARCH 3c, RCE with SCAN Proxy).
+EXACS_HOST=                                       # SCAN FQDN, e.g. <scan>.clientsubnet.dns.oraclevcn.com
+EXACS_PORT=1521                                   # plain TCP listener; encryption negotiated server-side via NNE
+EXACS_SERVICE_NAME=                               # PDB service, e.g. <pdb>.<paas>.oracle.com
+EXACS_USER=
+EXACS_PASSWORD=
+EXACS_TABLE_FOR_TEST=                             # any known table for the smoke test (or use a v$ view query)
+
+# -------- Fusion ERP REST (HTTP Basic only) --------
+FUSION_BASE_URL=                                  # https://<pod>.fa.<region>.oraclecloud.com
+FUSION_USER=
+FUSION_PASSWORD=
+FUSION_TEST_PATH=                                 # optional REST resource path for smoke tests
+FUSION_TEST_FIELDS=                               # optional comma-separated REST fields
+
+# -------- Fusion BICC (HTTP Basic; AIDP `aidataplatform` format handler) --------
+# Matches the official Oracle AIDP sample at oracle-samples/oracle-aidp-samples
+# (data-engineering/ingestion/Read_Only_Ingestion_Connectors.ipynb).
+FUSION_BICC_BASE_URL=                             # Fusion pod URL
+FUSION_BICC_USER=                                 # MUST have BICC privileges (e.g. BIA_ADMINISTRATOR_DUTY role)
+FUSION_BICC_PASSWORD=
+FUSION_BICC_SCHEMA=                               # e.g. ERP, HCM, SCM
+FUSION_BICC_PVO=                                  # PVO name (Public View Object) e.g. FscmTopModelAM.AnalyticsServiceAM
+FUSION_BICC_EXTERNAL_STORAGE=                     # AIDP catalog name of the external-storage profile
+                                                  # (registered once by admin; user references by name)
+# Option B / fallback (custom REST trigger flow only) - not used by the recommended path:
+FUSION_BICC_OFFERING=                             # offering name (Option B)
+OCI_NAMESPACE=                                    # Object Storage namespace (Option B)
+OCI_BUCKET_BICC=                                  # bucket BICC writes to (Option B)
+OCI_REGION=us-ashburn-1
+
+# -------- EPM Cloud Planning (HTTP Basic only) --------
+EPM_BASE_URL=                                     # https://epm-<id>.epm.<region>.ocs.oraclecloud.com
+EPM_USERNAME=                                     # tenancy.user@domain - e.g. epmloaner622.first.last@oracle.com
+EPM_PASSWORD=
+EPM_APPLICATION=                                  # planning app name
+EPM_PLAN_TYPE=                                    # e.g. Plan1
+EPM_GRID_DEFINITION_JSON=                         # optional JSON grid definition for advanced reads
+
+# -------- Essbase 21c --------
+ESSBASE_BASE_URL=                                 # https://<host>:9000/essbase/rest/v1
+ESSBASE_USER=
+ESSBASE_PASSWORD=
+ESSBASE_APPLICATION=
+ESSBASE_CUBE=
+ESSBASE_MDX_QUERY=                                # optional explicit MDX query
+
+# -------- OCI Streaming (Kafka, SASL/PLAIN only) --------
+# Matches the official Oracle AIDP sample at oracle-samples/oracle-aidp-samples
+# (data-engineering/ingestion/Streaming/StreamingFromOCIStreamingService.ipynb)
+OCI_REGION=us-ashburn-1                           # used by bootstrap_for_region()
+OCI_TENANCY_NAME=                                 # tenancy display name (not OCID)
+OCI_STREAM_POOL_OCID=                             # ocid1.streampool.oc1...
+OCI_USERNAME=                                     # 'oracleidentitycloudservice/<email>' for IAM-Domains
+OCI_AUTH_TOKEN=                                   # generated in OCI Console -> Profile -> Auth tokens (1h TTL)
+KAFKA_TOPIC=
+KAFKA_CHECKPOINT_VOLUME=/Volumes/<catalog>/<schema>/<volume>/_checkpoints/streaming_v1
+KAFKA_SINK_VOLUME=/Volumes/<catalog>/<schema>/<volume>/streaming/kafkaStreamingSink
+
+# -------- OCI API Key (for inline PEM auth path) --------
+OCI_USER_OCID=
+OCI_TENANCY_OCID=
+OCI_FINGERPRINT=
+OCI_PRIVATE_KEY_PEM=                              # paste the PEM body here, on one line with \n escapes; never commit
+
+
+# ============================================================================
+# v0.2.0 additions - official-AIDP-samples-driven connectors
+# ============================================================================
+
+# -------- Generic Oracle DB (Compute / Base DB / on-prem) --------
+ORADB_HOST=                                       # e.g. orcl.example.com
+ORADB_PORT=1521
+ORADB_DATABASE_NAME=                              # service name, e.g. ORCLPDB1
+ORADB_USER=
+ORADB_PASSWORD=
+ORADB_SCHEMA=                                     # Oracle schema (often = user)
+ORADB_TABLE=
+ORADB_TARGET_TABLE=                               # for write-mode tests
+ORADB_CATALOG_ID=                                 # optional AIDP catalog id for external catalog examples
+
+# -------- PostgreSQL --------
+PG_HOST=
+PG_PORT=5432
+PG_DB=
+PG_USER=
+PG_PASSWORD=
+PG_SCHEMA=public
+PG_TABLE=
+PG_TARGET_TABLE=                                  # for write-mode tests
+
+# -------- MySQL / MySQL HeatWave --------
+MYSQL_TYPE=MYSQL                                  # or MYSQL_HEATWAVE
+MYSQL_HOST=
+MYSQL_PORT=3306
+MYSQL_USER=
+MYSQL_PASSWORD=
+MYSQL_SCHEMA=                                     # MySQL "schema" = database name
+MYSQL_TABLE=
+MYSQL_TARGET_TABLE=
+
+# -------- Microsoft SQL Server / Azure SQL DB --------
+MSSQL_HOST=
+MSSQL_PORT=1433
+MSSQL_DATABASE=                                   # required on write
+MSSQL_USER=
+MSSQL_PASSWORD=
+MSSQL_SCHEMA=dbo
+MSSQL_TABLE=
+MSSQL_TARGET_TABLE=
+
+# -------- Apache Hive / HiveServer2 --------
+HIVE_HOST=
+HIVE_PORT=10000
+HIVE_USER=
+HIVE_PASSWORD=
+HIVE_SCHEMA=
+HIVE_TABLE=
+HIVE_TARGET_TABLE=                                # for write-mode tests
+
+# -------- Oracle PeopleSoft --------
+PSFT_HOST=
+PSFT_PORT=1521
+PSFT_DATABASE_NAME=
+PSFT_USER=
+PSFT_PASSWORD=
+PSFT_SCHEMA=SYSADM
+PSFT_TABLE=
+
+# -------- Oracle Siebel CRM --------
+SIEBEL_HOST=
+SIEBEL_PORT=1521
+SIEBEL_DATABASE_NAME=
+SIEBEL_USER=
+SIEBEL_PASSWORD=
+SIEBEL_SCHEMA=SIEBEL
+SIEBEL_TABLE=
+
+# -------- Salesforce via AIDP connector --------
+SFDC_HOST=                                        # e.g. login.salesforce.com or <domain>.my.salesforce.com
+SFDC_PORT=443
+SFDC_DATABASE_NAME=
+SFDC_USER=
+SFDC_PASSWORD=                                    # password plus security token when required
+SFDC_SCHEMA=SFORCE
+SFDC_TABLE=
+
+# -------- OCI Object Storage native (oci://) --------
+# Auth: implicit IAM via the workspace identity. No keys here.
+OCI_OS_TEST_PATH=                                 # e.g. oci://my-bucket@my-namespace/aidp-test/roundtrip.csv
+OCI_BUCKET=
+OCI_OBJECT_PREFIX=
+
+# -------- Apache Iceberg on OCI Object Storage --------
+# OCI_NAMESPACE already set above (re-used).
+ICEBERG_BUCKET=                                   # bucket holding the Iceberg warehouse
+ICEBERG_CATALOG=oci_catalog                       # Spark catalog name
+ICEBERG_DB=demo_db
+ICEBERG_TABLE=employees
+
+# -------- Snowflake --------
+SNOW_URL=                                         # e.g. xy12345.us-east-1.snowflakecomputing.com
+SNOW_USER=
+SNOW_PASSWORD=
+SNOW_DATABASE=
+SNOW_SCHEMA=
+SNOW_WAREHOUSE=
+SNOW_TABLE=
+SNOW_TARGET_TABLE=
+
+# -------- Azure ADLS Gen2 (abfss://) --------
+ADLS_STORAGE_ACCOUNT=                             # account name only (no .dfs.core.windows.net)
+ADLS_CLIENT_ID=                                   # Service Principal application id
+ADLS_CLIENT_SECRET=                               # SP secret
+ADLS_TENANT=                                      # Azure AD tenant id (GUID)
+ADLS_CONTAINER=
+ADLS_DATA_FILE=                                   # e.g. data/2025/january/orders.csv
+
+# -------- AWS S3 (s3a://) --------
+S3_ACCESS_KEY=
+S3_SECRET_KEY=
+AWS_ACCESS_KEY_ID=                                # optional alias used by some Spark/Hadoop snippets
+AWS_SECRET_ACCESS_KEY=                            # optional alias used by some Spark/Hadoop snippets
+S3_REGION=us-east-1
+S3_BUCKET=
+S3_FILE=                                          # object key
+
+# -------- Generic REST (aidataplatform GENERIC_REST) --------
+REST_BASE_URL=                                    # e.g. http://api.internal/v1
+REST_MANIFEST_URL=                                # e.g. http://api.internal/v1/manifest
+REST_USER=
+REST_PASSWORD=
+REST_SCHEMA=default
+REST_API=                                         # API operation name (per manifest)
+REST_ORDER_NO=                                    # example value used by sample manifests
+
+# -------- Custom JDBC (escape hatch) --------
+CUST_DB_USER=
+CUST_DB_PASSWORD=
+CUST_DB_TABLE=                                    # or a "(SELECT ...)" subquery
+
+# -------- Excel --------
+EXCEL_PATH=                                       # e.g. /Volumes/default/default/uploads/data.xlsx

--- a/plugins/oracle-aidp-connectors/.npmignore
+++ b/plugins/oracle-aidp-connectors/.npmignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.py[cod]

--- a/plugins/oracle-aidp-connectors/LICENSE.oracle-aidp-connectors
+++ b/plugins/oracle-aidp-connectors/LICENSE.oracle-aidp-connectors
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Ahmed Awan
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/plugins/oracle-aidp-connectors/README.md
+++ b/plugins/oracle-aidp-connectors/README.md
@@ -1,0 +1,29 @@
+# Oracle AIDP Connectors Plugin
+
+Oracle AI Data Platform Workbench Spark connector skills for building notebook snippets that read from Oracle, OCI, external databases, SaaS APIs, object stores, and spreadsheet sources.
+
+This plugin bundles skill and reference material plus a small helper Python package. It does not register MCP servers, contact Oracle services, upload helper code, run notebooks, or write credentials during installation.
+
+## Included Skills
+
+- `aidp-connectors-overview`: route from a data-source request to the right connector skill.
+- `aidp-connectors-bootstrap`: guide first-time upload of the helper Python package into a Workbench workspace.
+- Oracle and OCI connectors: ALH/ADW/ATP, generic Oracle Database, ExaCS, PeopleSoft, Siebel, Fusion REST, Fusion BICC, EPM Cloud, Essbase, OCI Streaming, OCI Object Storage, and Apache Iceberg.
+- External database and Hadoop connectors: PostgreSQL, MySQL/HeatWave, SQL Server, Hive, Snowflake, custom JDBC, AWS S3, Azure ADLS Gen2, generic REST, Salesforce, and Excel.
+
+## Requirements
+
+The selected workflow may require an Oracle AI Data Platform Workbench workspace, a Spark notebook session, relevant connector jars or built-in AIDP connector support, network reachability to the source system, and credentials for the target database, SaaS account, object store, or OCI resource.
+
+Some workflows require the bundled helper package under `scripts/oracle_ai_data_platform_connectors/` to be uploaded into the user's Workbench workspace or otherwise made importable by the notebook.
+
+## Trust Boundaries
+
+Installation is passive. The plugin does not run Spark, upload files to Workbench, read databases, call REST APIs, or write to user data stores.
+
+Live connector workflows can expose private data or mutate tables, buckets, streams, catalogs, shared workspace files, and SaaS systems. The bundled safety rule requires explicit approval before writes, helper uploads, credential storage, or broad data access.
+
+## Attribution
+
+The bundled connector skills and helper package are derived from Oracle sample material licensed under MIT. See `LICENSE.oracle-aidp-connectors`.
+Some bundled example notebooks include their own Oracle Universal Permissive License notices.

--- a/plugins/oracle-aidp-connectors/README.md
+++ b/plugins/oracle-aidp-connectors/README.md
@@ -17,6 +17,12 @@ The selected workflow may require an Oracle AI Data Platform Workbench workspace
 
 Some workflows require the bundled helper package under `scripts/oracle_ai_data_platform_connectors/` to be uploaded into the user's Workbench workspace or otherwise made importable by the notebook.
 
+Use `.env.example` as a checklist for connector-specific variable names, but keep filled secrets in the user's own environment, OCI Vault, notebook-scoped state, or another user-owned secret store. Do not commit a filled `.env`.
+
+## Getting Started
+
+After installing the plugin, ask Cline to run the `aidp-connectors-bootstrap` skill for first-time setup. Then use `.env.example` to identify the variables for the target connector, make those values available from the notebook runtime or a user-owned secret store, and ask Cline for the specific connector skill such as `aidp-oracle-db`, `aidp-alh`, or `aidp-snowflake`.
+
 ## Trust Boundaries
 
 Installation is passive. The plugin does not run Spark, upload files to Workbench, read databases, call REST APIs, or write to user data stores.

--- a/plugins/oracle-aidp-connectors/README.md
+++ b/plugins/oracle-aidp-connectors/README.md
@@ -27,7 +27,7 @@ After installing the plugin, ask Cline to run the `aidp-connectors-bootstrap` sk
 
 Installation is passive. The plugin does not run Spark, upload files to Workbench, read databases, call REST APIs, or write to user data stores.
 
-Live connector workflows can expose private data or mutate tables, buckets, streams, catalogs, shared workspace files, and SaaS systems. The bundled safety rule requires explicit approval before writes, helper uploads, credential storage, or broad data access.
+Live connector workflows can expose private data or mutate tables, buckets, streams, catalogs, shared workspace files, and SaaS systems. The bundled skills require explicit approval before writes, helper uploads, credential storage, or broad data access.
 
 ## Attribution
 

--- a/plugins/oracle-aidp-connectors/examples/00_bootstrap_helpers.ipynb
+++ b/plugins/oracle-aidp-connectors/examples/00_bootstrap_helpers.ipynb
@@ -1,0 +1,108 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# `00_bootstrap_helpers` - confirm the AIDP connectors helper package is set up\n",
+    "\n",
+    "Run this notebook once per AIDP workspace after the plugin's helpers have been uploaded to `/Workspace/Shared/oracle_ai_data_platform_connectors/scripts/`.\n",
+    "\n",
+    "If you haven't uploaded the helpers yet, ask Cline: *\"set up the AIDP connectors plugin in this workspace\"* - the `aidp-connectors-bootstrap` skill drives the upload via MCP. Or upload `scripts/oracle_ai_data_platform_connectors/` manually via the AIDP UI to that path.\n",
+    "\n",
+    "Pass criteria: the final cell prints `BOOTSTRAP OK` plus the package version and a list of submodules.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys, os\n",
+    "# Adjust this if you've uploaded the plugin scripts/ dir elsewhere.\n",
+    "sys.path.insert(0, '/Workspace/Shared/oracle_ai_data_platform_connectors/scripts')\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Confirm the directory layout the helpers expect.\n",
+    "import os, pathlib\n",
+    "expected = pathlib.Path('/Workspace/Shared/oracle_ai_data_platform_connectors/scripts/oracle_ai_data_platform_connectors')\n",
+    "if not expected.exists():\n",
+    "    raise RuntimeError(\n",
+    "        f'Helpers not found at {expected}. Run the aidp-connectors-bootstrap skill (ask Cline: \"set up the AIDP connectors plugin\") '\n",
+    "        f'or upload the plugin scripts/ directory to /Workspace/Shared/ manually.'\n",
+    "    )\n",
+    "files = sorted(p.name for p in expected.rglob('*.py'))\n",
+    "print(f'found {len(files)} Python files under {expected}')\n",
+    "for f in files: print(' ', f)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# Sanity-import every public submodule.\nimport importlib\nimport oracle_ai_data_platform_connectors as pkg\nfrom oracle_ai_data_platform_connectors import auth, jdbc, rest, streaming\nfrom oracle_ai_data_platform_connectors.auth import (\n    write_wallet_to_tmp, generate_db_token, from_inline_pem,\n    http_basic_session, oauth_token, get_secret,\n)\nfrom oracle_ai_data_platform_connectors.jdbc import (\n    build_oracle_jdbc_url,\n    spark_jdbc_options_wallet, spark_jdbc_options_dbtoken, spark_jdbc_options_password,\n)\nfrom oracle_ai_data_platform_connectors.rest import fusion, epm, essbase  # noqa: F401\nfrom oracle_ai_data_platform_connectors.streaming import (\n    bootstrap_for_region, build_kafka_options_sasl_plain, validate_checkpoint_path,\n)\nprint('all imports OK; package version:', pkg.__version__)\n"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Quick logic smoke test: run the URL builder and the checkpoint validator.\n",
+    "url = build_oracle_jdbc_url(tns_alias='atp_high', tns_admin='/tmp/aidp-wallet-example')\n",
+    "assert url == 'jdbc:oracle:thin:@atp_high?TNS_ADMIN=/tmp/aidp-wallet-example', f'unexpected URL: {url}'\n",
+    "import pytest as _pytest\n",
+    "try:\n",
+    "    validate_checkpoint_path('/Workspace/cp')\n",
+    "    raise AssertionError('checkpoint validator should have raised')\n",
+    "except ValueError:\n",
+    "    pass\n",
+    "print('smoke test OK')\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Final result marker - the live-test driver picks this up if you run it as part of a batch.\n",
+    "import json, time\n",
+    "summary = {\n",
+    "    'connector': 'bootstrap',\n",
+    "    'auth': 'n/a',\n",
+    "    'rows': 1,                  # 1 = bootstrap success\n",
+    "    'schema': ['BOOTSTRAP_OK'],\n",
+    "    'package_version': pkg.__version__,\n",
+    "    'timestamp_utc': int(time.time()),\n",
+    "}\n",
+    "print('BOOTSTRAP OK')\n",
+    "print('AIDP_EXAMPLE_RESULT_BEGIN')\n",
+    "print(json.dumps(summary, indent=2))\n",
+    "print('AIDP_EXAMPLE_RESULT_END')\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  },
+  "aidp_connector": "00_bootstrap_helpers"
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/plugins/oracle-aidp-connectors/examples/adls_read.ipynb
+++ b/plugins/oracle-aidp-connectors/examples/adls_read.ipynb
@@ -1,0 +1,88 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# `aidp-azure-adls` example - `abfss://` via OAuth client-creds\n",
+    "Sets the Hadoop ABFS OAuth provider and reads a CSV from an ADLS Gen2 container.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys, os\n",
+    "# Adjust this if you've uploaded the plugin scripts/ dir elsewhere.\n",
+    "sys.path.insert(0, '/Workspace/Shared/oracle_ai_data_platform_connectors/scripts')\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sa     = os.environ['ADLS_STORAGE_ACCOUNT']\n",
+    "cid    = os.environ['ADLS_CLIENT_ID']\n",
+    "secret = os.environ['ADLS_CLIENT_SECRET']\n",
+    "tenant = os.environ['ADLS_TENANT']\n",
+    "host   = f'{sa}.dfs.core.windows.net'\n",
+    "spark.conf.set(f'fs.azure.account.auth.type.{host}',           'OAuth')\n",
+    "spark.conf.set(f'fs.azure.account.oauth.provider.type.{host}', 'org.apache.hadoop.fs.azurebfs.oauth2.ClientCredsTokenProvider')\n",
+    "spark.conf.set(f'fs.azure.account.oauth2.client.id.{host}',     cid)\n",
+    "spark.conf.set(f'fs.azure.account.oauth2.client.secret.{host}', secret)\n",
+    "spark.conf.set(f'fs.azure.account.oauth2.client.endpoint.{host}', f'https://login.microsoftonline.com/{tenant}/oauth2/token')\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "container = os.environ['ADLS_CONTAINER']\n",
+    "data_file = os.environ['ADLS_DATA_FILE']\n",
+    "df = (spark.read.format('csv').option('header', True)\n",
+    "        .load(f'abfss://{container}@{sa}.dfs.core.windows.net/{data_file}'))\n",
+    "df.show()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# The final cell prints a JSON summary for quick validation.\n",
+    "import json, time\n",
+    "summary = {\n",
+    "    'connector': 'aidp-azure-adls',\n",
+    "    'auth': 'oauth-clientcreds',\n",
+    "    'rows': int(df.count()),\n",
+    "    'schema': sorted([f.name for f in df.schema.fields]),\n",
+    "    'timestamp_utc': int(time.time()),\n",
+    "}\n",
+    "print('AIDP_EXAMPLE_RESULT_BEGIN')\n",
+    "print(json.dumps(summary, indent=2))\n",
+    "print('AIDP_EXAMPLE_RESULT_END')\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  },
+  "aidp_connector": "adls_read"
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/plugins/oracle-aidp-connectors/examples/alh_catalog_sync_apikey.ipynb
+++ b/plugins/oracle-aidp-connectors/examples/alh_catalog_sync_apikey.ipynb
@@ -10,6 +10,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Warning: this notebook refreshes AIDP external-catalog metadata. Confirm the catalog/table target and credential source before running catalog-sync cells.\n"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},

--- a/plugins/oracle-aidp-connectors/examples/alh_catalog_sync_apikey.ipynb
+++ b/plugins/oracle-aidp-connectors/examples/alh_catalog_sync_apikey.ipynb
@@ -1,0 +1,90 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# `aidp-alh` example - API Key + inline OCI config (catalog-sync side)\n",
+    "\n",
+    "Example. Refreshes the AIDP external catalog metadata from ALH using inline-PEM OCI auth, then reads the synced table via Spark.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys, os\n",
+    "# Adjust this if you've uploaded the plugin scripts/ dir elsewhere.\n",
+    "sys.path.insert(0, '/Workspace/Shared/oracle_ai_data_platform_connectors/scripts')\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from oracle_ai_data_platform_connectors.auth import from_inline_pem\n",
+    "import oci\n",
+    "\n",
+    "config = from_inline_pem(\n",
+    "    user_ocid=os.environ['OCI_USER_OCID'],\n",
+    "    tenancy_ocid=os.environ['OCI_TENANCY_OCID'],\n",
+    "    fingerprint=os.environ['OCI_FINGERPRINT'],\n",
+    "    private_key_pem=os.environ['OCI_PRIVATE_KEY_PEM'],\n",
+    "    region=os.environ['OCI_REGION'],\n",
+    ")\n",
+    "# A control-plane sanity check - proves the config works without writing a PEM file.\n",
+    "identity = oci.identity.IdentityClient(config=config)\n",
+    "print('user:', identity.get_user(config['user']).data.name)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Downstream Spark read against the externally-cataloged ALH table.\n",
+    "df = spark.read.table(os.environ['ALH_EXTERNAL_CATALOG_TABLE'])\n",
+    "df.show(5)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# The final cell prints a JSON summary for quick validation.\n",
+    "import json, time\n",
+    "summary = {\n",
+    "    'connector': 'aidp-alh',\n",
+    "    'auth': 'apikey-catalog-sync',\n",
+    "    'rows': int(df.count()),\n",
+    "    'schema': sorted([f.name for f in df.schema.fields]),\n",
+    "    'timestamp_utc': int(time.time()),\n",
+    "}\n",
+    "print('AIDP_EXAMPLE_RESULT_BEGIN')\n",
+    "print(json.dumps(summary, indent=2))\n",
+    "print('AIDP_EXAMPLE_RESULT_END')\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  },
+  "aidp_connector": "alh_catalog_sync_apikey"
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/plugins/oracle-aidp-connectors/examples/alh_dbtoken_query.ipynb
+++ b/plugins/oracle-aidp-connectors/examples/alh_dbtoken_query.ipynb
@@ -1,0 +1,87 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# `aidp-alh` example - IAM DB-Token\n",
+    "\n",
+    "Example. Same query as row 1, but auth is via DB-token instead of password.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys, os\n",
+    "# Adjust this if you've uploaded the plugin scripts/ dir elsewhere.\n",
+    "sys.path.insert(0, '/Workspace/Shared/oracle_ai_data_platform_connectors/scripts')\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from oracle_ai_data_platform_connectors.auth import generate_db_token\n",
+    "from oracle_ai_data_platform_connectors.jdbc import build_oracle_jdbc_url, spark_jdbc_options_dbtoken\n",
+    "\n",
+    "token_dir = generate_db_token(\n",
+    "    compartment_ocid=os.environ['ALH_COMPARTMENT_OCID'],\n",
+    ")\n",
+    "url = build_oracle_jdbc_url(\n",
+    "    tns_alias=os.environ['ALH_TNS_SERVICE'],\n",
+    "    tns_admin=os.environ['ALH_WALLET_PATH'],\n",
+    ")\n",
+    "opts = spark_jdbc_options_dbtoken(url=url, token_dir=token_dir)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = spark.read.format('jdbc').options(**opts).option('dbtable', os.environ['ALH_TABLE_FOR_TEST']).load()\n",
+    "df.show(5)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# The final cell prints a JSON summary for quick validation.\n",
+    "import json, time\n",
+    "summary = {\n",
+    "    'connector': 'aidp-alh',\n",
+    "    'auth': 'dbtoken',\n",
+    "    'rows': int(df.count()),\n",
+    "    'schema': sorted([f.name for f in df.schema.fields]),\n",
+    "    'timestamp_utc': int(time.time()),\n",
+    "}\n",
+    "print('AIDP_EXAMPLE_RESULT_BEGIN')\n",
+    "print(json.dumps(summary, indent=2))\n",
+    "print('AIDP_EXAMPLE_RESULT_END')\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  },
+  "aidp_connector": "alh_dbtoken_query"
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/plugins/oracle-aidp-connectors/examples/alh_wallet_query.ipynb
+++ b/plugins/oracle-aidp-connectors/examples/alh_wallet_query.ipynb
@@ -1,0 +1,86 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# `aidp-alh` example - wallet (mTLS)\n",
+    "\n",
+    "Example. Reads a known ALH table via Spark JDBC using a wallet.\n",
+    "\n",
+    "Prerequisites: `ALH_*` env vars set or OCI Vault configured. ALH wallet ZIP available.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys, os\n",
+    "# Adjust this if you've uploaded the plugin scripts/ dir elsewhere.\n",
+    "sys.path.insert(0, '/Workspace/Shared/oracle_ai_data_platform_connectors/scripts')\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from oracle_ai_data_platform_connectors.auth import write_wallet_to_tmp\n",
+    "from oracle_ai_data_platform_connectors.jdbc import build_oracle_jdbc_url, spark_jdbc_options_wallet\n",
+    "\n",
+    "tns_admin = write_wallet_to_tmp(\n",
+    "    wallet=os.environ.get('ALH_WALLET_ZIP_PATH', '/tmp/alh-wallet.zip'),\n",
+    ")\n",
+    "url = build_oracle_jdbc_url(tns_alias=os.environ['ALH_TNS_SERVICE'], tns_admin=tns_admin)\n",
+    "opts = spark_jdbc_options_wallet(url=url, user=os.environ['ALH_USER'], password=os.environ['ALH_PASSWORD'])\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = spark.read.format('jdbc').options(**opts).option('dbtable', os.environ['ALH_TABLE_FOR_TEST']).load()\n",
+    "df.show(5)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# The final cell prints a JSON summary for quick validation.\n",
+    "import json, time\n",
+    "summary = {\n",
+    "    'connector': 'aidp-alh',\n",
+    "    'auth': 'wallet',\n",
+    "    'rows': int(df.count()),\n",
+    "    'schema': sorted([f.name for f in df.schema.fields]),\n",
+    "    'timestamp_utc': int(time.time()),\n",
+    "}\n",
+    "print('AIDP_EXAMPLE_RESULT_BEGIN')\n",
+    "print(json.dumps(summary, indent=2))\n",
+    "print('AIDP_EXAMPLE_RESULT_END')\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  },
+  "aidp_connector": "alh_wallet_query"
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/plugins/oracle-aidp-connectors/examples/epm_planning_basic.ipynb
+++ b/plugins/oracle-aidp-connectors/examples/epm_planning_basic.ipynb
@@ -1,0 +1,90 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# `aidp-epm-cloud` example - HTTP Basic (default for v0.1)\n",
+    "Example. Username MUST be in `tenancy.user@domain` form (e.g. `epmloaner622.first.last@oracle.com`).\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys, os\n",
+    "# Adjust this if you've uploaded the plugin scripts/ dir elsewhere.\n",
+    "sys.path.insert(0, '/Workspace/Shared/oracle_ai_data_platform_connectors/scripts')\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from oracle_ai_data_platform_connectors.auth import http_basic_session\n",
+    "from oracle_ai_data_platform_connectors.rest.epm import (\n",
+    "    list_applications, export_data_slice, slice_to_long_dataframe,\n",
+    ")\n",
+    "\n",
+    "session = http_basic_session(\n",
+    "    username=os.environ['EPM_USERNAME'],\n",
+    "    password=os.environ['EPM_PASSWORD'],\n",
+    "    base_url=os.environ['EPM_BASE_URL'],\n",
+    ")\n",
+    "apps = list_applications(session, os.environ['EPM_BASE_URL'])\n",
+    "print('apps:', [a['name'] for a in apps])\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import json\n",
+    "grid = json.loads(os.environ['EPM_GRID_DEFINITION_JSON'])\n",
+    "resp = export_data_slice(session, os.environ['EPM_BASE_URL'], os.environ['EPM_APPLICATION'], os.environ['EPM_PLAN_TYPE'], grid)\n",
+    "df = slice_to_long_dataframe(spark, resp)\n",
+    "df.show(10)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# The final cell prints a JSON summary for quick validation.\n",
+    "import json, time\n",
+    "summary = {\n",
+    "    'connector': 'aidp-epm-cloud',\n",
+    "    'auth': 'basic',\n",
+    "    'rows': int(df.count()),\n",
+    "    'schema': sorted([f.name for f in df.schema.fields]),\n",
+    "    'timestamp_utc': int(time.time()),\n",
+    "}\n",
+    "print('AIDP_EXAMPLE_RESULT_BEGIN')\n",
+    "print(json.dumps(summary, indent=2))\n",
+    "print('AIDP_EXAMPLE_RESULT_END')\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  },
+  "aidp_connector": "epm_planning_basic"
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/plugins/oracle-aidp-connectors/examples/essbase_mdx_basic.ipynb
+++ b/plugins/oracle-aidp-connectors/examples/essbase_mdx_basic.ipynb
@@ -1,0 +1,87 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# `aidp-essbase` example - HTTP Basic + MDX\n",
+    "Example. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys, os\n",
+    "# Adjust this if you've uploaded the plugin scripts/ dir elsewhere.\n",
+    "sys.path.insert(0, '/Workspace/Shared/oracle_ai_data_platform_connectors/scripts')\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from oracle_ai_data_platform_connectors.auth import http_basic_session\n",
+    "from oracle_ai_data_platform_connectors.rest.essbase import (\n",
+    "    execute_mdx, mdx_result_to_spark_dataframe,\n",
+    ")\n",
+    "\n",
+    "session = http_basic_session(\n",
+    "    username=os.environ['ESSBASE_USER'],\n",
+    "    password=os.environ['ESSBASE_PASSWORD'],\n",
+    "    base_url=os.environ['ESSBASE_BASE_URL'],\n",
+    ")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mdx = os.environ['ESSBASE_MDX_QUERY']\n",
+    "resp = execute_mdx(session, os.environ['ESSBASE_BASE_URL'], os.environ['ESSBASE_APPLICATION'], os.environ['ESSBASE_CUBE'], mdx)\n",
+    "df = mdx_result_to_spark_dataframe(spark, resp)\n",
+    "df.show(10)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# The final cell prints a JSON summary for quick validation.\n",
+    "import json, time\n",
+    "summary = {\n",
+    "    'connector': 'aidp-essbase',\n",
+    "    'auth': 'basic',\n",
+    "    'rows': int(df.count()),\n",
+    "    'schema': sorted([f.name for f in df.schema.fields]),\n",
+    "    'timestamp_utc': int(time.time()),\n",
+    "}\n",
+    "print('AIDP_EXAMPLE_RESULT_BEGIN')\n",
+    "print(json.dumps(summary, indent=2))\n",
+    "print('AIDP_EXAMPLE_RESULT_END')\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  },
+  "aidp_connector": "essbase_mdx_basic"
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/plugins/oracle-aidp-connectors/examples/exacs_user_password.ipynb
+++ b/plugins/oracle-aidp-connectors/examples/exacs_user_password.ipynb
@@ -1,0 +1,186 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# `aidp-exacs` example - plain user/password on TCP 1521 + server-enforced NNE\n",
+    "Example. Mirrors the working pattern from `exacs_intransit_encryption_demo.ipynb` in the `exacs-private-test` workspace, which proved AES256 NNE end-to-end against a customer ExaCS cluster running Oracle 23ai.\n",
+    "\n",
+    "Workspace prereq: `networkConfigurationDetails.scanDetails` must include the SCAN FQDN+port (PE-ARCH 3c, RCE with SCAN Proxy). Without it the RAC redirect dies with ORA-17820.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys, os\n",
+    "# Adjust this if you've uploaded the plugin scripts/ dir elsewhere.\n",
+    "sys.path.insert(0, '/Workspace/Shared/oracle_ai_data_platform_connectors/scripts')\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 1 - Configuration\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "SCAN_HOST = os.environ['EXACS_HOST']\n",
+    "SCAN_PORT = int(os.environ.get('EXACS_PORT_LEGACY', '1521'))\n",
+    "SERVICE   = os.environ['EXACS_SERVICE_NAME']\n",
+    "DB_USER   = os.environ['EXACS_USER']\n",
+    "DB_PASS   = os.environ['EXACS_PASSWORD']\n",
+    "TABLE     = os.environ['EXACS_TABLE_FOR_TEST']\n",
+    "print(f'  SCAN  : {SCAN_HOST}:{SCAN_PORT}')\n",
+    "print(f'  SVC   : {SERVICE}')\n",
+    "print(f'  USER  : {DB_USER}')\n",
+    "print(f'  TABLE : {TABLE}')\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 2 - DNS resolution check\n",
+    "SCAN host must resolve to a Class-E (240.0.0.0/4 / 255.x) or RFC-1918 (10.x/172.16-31.x/192.168.x) IP. A public IP would mean traffic isn't going through the PE.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import socket, ipaddress\n",
+    "ips = sorted({r[4][0] for r in socket.getaddrinfo(SCAN_HOST, SCAN_PORT, socket.AF_INET)})\n",
+    "for ip in ips:\n",
+    "    is_class_e = int(ip.split('.')[0]) >= 240\n",
+    "    is_priv    = ipaddress.ip_address(ip).is_private\n",
+    "    kind = 'Class-E NAT' if is_class_e else 'RFC-1918 private' if is_priv else 'PUBLIC (FAIL)'\n",
+    "    print(f'  {SCAN_HOST} -> {ip}  [{kind}]')\n",
+    "assert any(int(ip.split('.')[0]) >= 240 or ipaddress.ip_address(ip).is_private for ip in ips), 'PE routing not active'\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 3 - TCP connectivity\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import socket, time\n",
+    "t0 = time.time()\n",
+    "with socket.create_connection((SCAN_HOST, SCAN_PORT), timeout=15) as s:\n",
+    "    print(f'  Connected in {(time.time()-t0)*1000:.0f} ms  (local={s.getsockname()}  remote={s.getpeername()})')\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 4 - Spark JDBC connect (plain user/password)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from oracle_ai_data_platform_connectors.jdbc import (\n",
+    "    build_oracle_jdbc_url, spark_jdbc_options_password,\n",
+    ")\n",
+    "url = build_oracle_jdbc_url(host=SCAN_HOST, port=SCAN_PORT, service_name=SERVICE, use_tcps=False)\n",
+    "opts = spark_jdbc_options_password(url=url, user=DB_USER, password=DB_PASS)\n",
+    "# Optional: enable for the SYS user only.\n",
+    "# opts['oracle.jdbc.internal_logon'] = 'sysdba'\n",
+    "print('JDBC URL:', url)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = (spark.read.format('jdbc').options(**opts).option('dbtable', TABLE).load())\n",
+    "df.show(5)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 5 - In-transit encryption verification\n",
+    "Read `v$session_connect_info.network_service_banner` for the active session - proves AES256 NNE.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "enc_q = (\n",
+    "    \"SELECT network_service_banner FROM v$session_connect_info \"\n",
+    "    \"WHERE sid = SYS_CONTEXT('USERENV','SID')\"\n",
+    ")\n",
+    "banners = (spark.read.format('jdbc').options(**opts)\n",
+    "             .option('query', enc_q).load().collect())\n",
+    "for r in banners:\n",
+    "    print(' ', r[0])\n",
+    "encryption = next((b[0] for b in (b.split(' Encryption service adapter') for b in (r[0] for r in banners)) if len(b) > 1), None)\n",
+    "print('Negotiated algorithm:', encryption)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# The final cell prints a JSON summary for quick validation.\n",
+    "import json, time\n",
+    "summary = {\n",
+    "    'connector': 'aidp-exacs',\n",
+    "    'auth': 'password-tcp-nne',\n",
+    "    'rows': int(df.count()),\n",
+    "    'schema': sorted([f.name for f in df.schema.fields]),\n",
+    "    'timestamp_utc': int(time.time()),\n",
+    "}\n",
+    "print('AIDP_EXAMPLE_RESULT_BEGIN')\n",
+    "print(json.dumps(summary, indent=2))\n",
+    "print('AIDP_EXAMPLE_RESULT_END')\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  },
+  "aidp_connector": "exacs_user_password"
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/plugins/oracle-aidp-connectors/examples/exacs_user_password.ipynb
+++ b/plugins/oracle-aidp-connectors/examples/exacs_user_password.ipynb
@@ -5,7 +5,7 @@
    "metadata": {},
    "source": [
     "# `aidp-exacs` example - plain user/password on TCP 1521 + server-enforced NNE\n",
-    "Example. Mirrors the working pattern from `exacs_intransit_encryption_demo.ipynb` in the `exacs-private-test` workspace, which proved AES256 NNE end-to-end against a customer ExaCS cluster running Oracle 23ai.\n",
+    "Example. Shows the plain TCP 1521 plus server-enforced NNE pattern for ExaCS connections from AIDP notebooks.\n",
     "\n",
     "Workspace prereq: `networkConfigurationDetails.scanDetails` must include the SCAN FQDN+port (PE-ARCH 3c, RCE with SCAN Proxy). Without it the RAC redirect dies with ORA-17820.\n"
    ]
@@ -35,7 +35,7 @@
    "outputs": [],
    "source": [
     "SCAN_HOST = os.environ['EXACS_HOST']\n",
-    "SCAN_PORT = int(os.environ.get('EXACS_PORT_LEGACY', '1521'))\n",
+    "SCAN_PORT = int(os.environ.get('EXACS_PORT', '1521'))\n",
     "SERVICE   = os.environ['EXACS_SERVICE_NAME']\n",
     "DB_USER   = os.environ['EXACS_USER']\n",
     "DB_PASS   = os.environ['EXACS_PASSWORD']\n",

--- a/plugins/oracle-aidp-connectors/examples/excel_read.ipynb
+++ b/plugins/oracle-aidp-connectors/examples/excel_read.ipynb
@@ -1,0 +1,75 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# `aidp-excel` example - `pandas \u2192 CSV \u2192 Spark` (no jars)\n",
+    "Reads an .xlsx via pandas (driver-side), converts to CSV in the same path, then\n",
+    "re-reads as Spark. The `com.crealytics.spark.excel` path is also documented in\n",
+    "the SKILL but requires a cluster JAR install.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys, os\n",
+    "# Adjust this if you've uploaded the plugin scripts/ dir elsewhere.\n",
+    "sys.path.insert(0, '/Workspace/Shared/oracle_ai_data_platform_connectors/scripts')\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "excel_path = os.environ['EXCEL_PATH']\n",
+    "csv_path   = excel_path.replace('.xlsx', '.csv')\n",
+    "pdf = pd.read_excel(excel_path)\n",
+    "pdf.to_csv(csv_path, index=False)\n",
+    "print('rows in pandas:', len(pdf))\n",
+    "df = spark.read.csv(csv_path, header=True, inferSchema=True)\n",
+    "df.show()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# The final cell prints a JSON summary for quick validation.\n",
+    "import json, time\n",
+    "summary = {\n",
+    "    'connector': 'aidp-excel',\n",
+    "    'auth': 'pandas-csv-fallback',\n",
+    "    'rows': int(df.count()),\n",
+    "    'schema': sorted([f.name for f in df.schema.fields]),\n",
+    "    'timestamp_utc': int(time.time()),\n",
+    "}\n",
+    "print('AIDP_EXAMPLE_RESULT_BEGIN')\n",
+    "print(json.dumps(summary, indent=2))\n",
+    "print('AIDP_EXAMPLE_RESULT_END')\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  },
+  "aidp_connector": "excel_read"
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/plugins/oracle-aidp-connectors/examples/fusion_bicc_to_dataframe.ipynb
+++ b/plugins/oracle-aidp-connectors/examples/fusion_bicc_to_dataframe.ipynb
@@ -1,0 +1,90 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# `aidp-fusion-bicc` example - AIDP `aidataplatform` format (BICC PVO \u2192 Spark)\n",
+    "Example. Uses AIDP's built-in `spark.read.format('aidataplatform')` connector - matches the official Oracle AIDP sample at `oracle-samples/oracle-aidp-samples` (`Read_Only_Ingestion_Connectors.ipynb`). The connector triggers the BICC extract, polls for completion, and reads the resulting CSVs from OCI Object Storage internally.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys, os\n",
+    "# Adjust this if you've uploaded the plugin scripts/ dir elsewhere.\n",
+    "sys.path.insert(0, '/Workspace/Shared/oracle_ai_data_platform_connectors/scripts')\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from oracle_ai_data_platform_connectors.rest.fusion import read_bicc_via_aidp_format\n",
+    "\n",
+    "# Prereqs: Fusion user has a BICC-admin role; an AIDP `EXTERNAL STORAGE`\n",
+    "# profile is registered in the catalog pointing at the OCI Object Storage\n",
+    "# bucket BICC writes to (configured once by an admin).\n",
+    "df = read_bicc_via_aidp_format(\n",
+    "    spark=spark,\n",
+    "    fusion_service_url=os.environ['FUSION_BICC_BASE_URL'],\n",
+    "    username=os.environ['FUSION_BICC_USER'],\n",
+    "    password=os.environ['FUSION_BICC_PASSWORD'],\n",
+    "    schema=os.environ['FUSION_BICC_SCHEMA'],            # e.g. 'ERP'\n",
+    "    datastore=os.environ['FUSION_BICC_PVO'],            # PVO name\n",
+    "    fusion_external_storage=os.environ['FUSION_BICC_EXTERNAL_STORAGE'],\n",
+    ")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df.show(5)\n",
+    "print('rows:', df.count())\n",
+    "df.printSchema()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# The final cell prints a JSON summary for quick validation.\n",
+    "import json, time\n",
+    "summary = {\n",
+    "    'connector': 'aidp-fusion-bicc',\n",
+    "    'auth': 'basic-aidp-format',\n",
+    "    'rows': int(df.count()),\n",
+    "    'schema': sorted([f.name for f in df.schema.fields]),\n",
+    "    'timestamp_utc': int(time.time()),\n",
+    "}\n",
+    "print('AIDP_EXAMPLE_RESULT_BEGIN')\n",
+    "print(json.dumps(summary, indent=2))\n",
+    "print('AIDP_EXAMPLE_RESULT_END')\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  },
+  "aidp_connector": "fusion_bicc_to_dataframe"
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/plugins/oracle-aidp-connectors/examples/fusion_rest_basic.ipynb
+++ b/plugins/oracle-aidp-connectors/examples/fusion_rest_basic.ipynb
@@ -1,0 +1,89 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# `aidp-fusion-rest` example - HTTP Basic\n",
+    "Example. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys, os\n",
+    "# Adjust this if you've uploaded the plugin scripts/ dir elsewhere.\n",
+    "sys.path.insert(0, '/Workspace/Shared/oracle_ai_data_platform_connectors/scripts')\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from oracle_ai_data_platform_connectors.auth import http_basic_session\n",
+    "from oracle_ai_data_platform_connectors.rest.fusion import fetch_paged, rows_to_spark_dataframe\n",
+    "\n",
+    "session = http_basic_session(\n",
+    "    username=os.environ['FUSION_USER'],\n",
+    "    password=os.environ['FUSION_PASSWORD'],\n",
+    "    base_url=os.environ['FUSION_BASE_URL'],\n",
+    ")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rows = fetch_paged(\n",
+    "    session=session,\n",
+    "    base_url=os.environ['FUSION_BASE_URL'],\n",
+    "    path=os.environ['FUSION_TEST_PATH'],   # e.g. '/fscmRestApi/resources/11.13.18.05/invoices'\n",
+    "    fields=os.environ.get('FUSION_TEST_FIELDS'),\n",
+    ")\n",
+    "df = rows_to_spark_dataframe(spark, rows)\n",
+    "df.show(5)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# The final cell prints a JSON summary for quick validation.\n",
+    "import json, time\n",
+    "summary = {\n",
+    "    'connector': 'aidp-fusion-rest',\n",
+    "    'auth': 'basic',\n",
+    "    'rows': int(df.count()),\n",
+    "    'schema': sorted([f.name for f in df.schema.fields]),\n",
+    "    'timestamp_utc': int(time.time()),\n",
+    "}\n",
+    "print('AIDP_EXAMPLE_RESULT_BEGIN')\n",
+    "print(json.dumps(summary, indent=2))\n",
+    "print('AIDP_EXAMPLE_RESULT_END')\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  },
+  "aidp_connector": "fusion_rest_basic"
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/plugins/oracle-aidp-connectors/examples/hive_read_write.ipynb
+++ b/plugins/oracle-aidp-connectors/examples/hive_read_write.ipynb
@@ -10,6 +10,13 @@
   {
    "cell_type": "markdown",
    "metadata": {},
+   "source": [
+    "Warning: this notebook includes live Hive write examples. Confirm the target schema/table and write mode before running any write cell.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": "# Hive Connector Samples\n\nRead/write ingestion samples for the `HIVE` connector.\n"
   },
   {

--- a/plugins/oracle-aidp-connectors/examples/hive_read_write.ipynb
+++ b/plugins/oracle-aidp-connectors/examples/hive_read_write.ipynb
@@ -1,0 +1,79 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "Oracle AI Data Platform v1.0\n\nCopyright (c) 2025, Oracle and/or its affiliates.\n\nLicensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "# Hive Connector Samples\n\nRead/write ingestion samples for the `HIVE` connector.\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Ingestion Sample\n\nSet `HIVE_*` environment variables before running the notebook. Do not paste passwords or tokens into shared notebook cells.\n"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "import os\n\n# Read from Hive\nhive_df = spark.read.format(\"aidataplatform\") \\\n    .option(\"type\", \"HIVE\") \\\n    .option(\"host\", os.environ[\"HIVE_HOST\"]) \\\n    .option(\"port\", os.environ.get(\"HIVE_PORT\", \"10000\")) \\\n    .option(\"user.name\", os.environ[\"HIVE_USER\"]) \\\n    .option(\"password\", os.environ[\"HIVE_PASSWORD\"]) \\\n    .option(\"schema\", os.environ[\"HIVE_SCHEMA\"]) \\\n    .option(\"table\", os.environ[\"HIVE_TABLE\"]) \\\n    .load()\n\nhive_df.show()\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Write Sample\n\nThe write sample uses `CREATE`; switch `write.mode` to `APPEND` or `OVERWRITE` when that matches the target behavior.\n"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "import os\n\n# Write to Hive\nhive_df.write.format(\"aidataplatform\") \\\n    .option(\"type\", \"HIVE\") \\\n    .option(\"host\", os.environ[\"HIVE_HOST\"]) \\\n    .option(\"port\", os.environ.get(\"HIVE_PORT\", \"10000\")) \\\n    .option(\"user.name\", os.environ[\"HIVE_USER\"]) \\\n    .option(\"password\", os.environ[\"HIVE_PASSWORD\"]) \\\n    .option(\"schema\", os.environ[\"HIVE_SCHEMA\"]) \\\n    .option(\"table\", os.environ[\"HIVE_TARGET_TABLE\"]) \\\n    .option(\"write.mode\", \"CREATE\") \\\n    .save()\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Pushdown SQL Sample\n\nUse `pushdown.sql` when you want the connector to execute a complete source SQL query instead of building the query from `schema` and `table` options.\n"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "import os\n\n# Full SQL pushdown for Hive\nhive_df_pushdown = spark.read.format(\"aidataplatform\") \\\n    .option(\"type\", \"HIVE\") \\\n    .option(\"host\", os.environ[\"HIVE_HOST\"]) \\\n    .option(\"port\", os.environ.get(\"HIVE_PORT\", \"10000\")) \\\n    .option(\"user.name\", os.environ[\"HIVE_USER\"]) \\\n    .option(\"password\", os.environ[\"HIVE_PASSWORD\"]) \\\n    .option(\"pushdown.sql\", \"SELECT * FROM <SCHEMA>.<TABLE_NAME> WHERE <COLUMN_NAME> = '<VALUE>'\") \\\n    .load()\n\nhive_df_pushdown.show()\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Connector Options\n\n| Parameter name | Valid values | Mandatory | Description |\n| --- | --- | --- | --- |\n| `type` | `HIVE` | Y | Data source type. |\n| `host` | Valid hostname or IP | Y | Hive host. |\n| `port` | Valid port number | Y | Hive port. |\n| `database.name` | Database name | N | Optional database name when needed. |\n| `authentication.method` | `basic`, `kerberos` | N | Authentication method. If omitted, the connector attempts a non-explicit auth flow. |\n| `user.name` | Valid username | Y for basic, N for some Kerberos flows | Username used for connectivity. |\n| `password` | Valid password | Y for basic, N for some Kerberos flows | Password used for connectivity. |\n| `service.principal.name` | Kerberos principal name | Y for Kerberos | Service principal name for Kerberos authentication. |\n| `key.tab.content` | Keytab content | Y for Kerberos | Keytab content used for Kerberos authentication. |\n| `key.distribution.center` | Valid hostname or IP | Y for Kerberos | KDC host used for Kerberos authentication. |\n| `schema` | Valid schema name | Y | Schema to read from or write to. |\n| `table` | Valid table name | Y for table access | Table name inside the schema. |\n| `view` | Valid view name | N | View name inside the schema. |\n| `sql` | Valid SQL query | N | Custom SQL query for reads. |\n| `fetch.size` | Positive integer | N | Number of records fetched per round trip for reads. |\n| `row.limit` | Positive integer | N | Limits the number of rows read. |\n| `partition.column` | Column name | N | Column used for range-based partitioned reads or writes. |\n| `partition.num` | Integer >= 1 | N | Number of partitions to use. |\n| `partition.lower` | Numeric value or ISO-8601 date/time | N | Lower bound for range partitioning. |\n| `partition.upper` | Numeric value or ISO-8601 date/time | N | Upper bound for range partitioning. |\n| `pushdown.columns` | Comma-separated column names | N | Restricts the read to only the requested columns. |\n| `pushdown.filter` | SQL predicate | N | Predicate pushed down to the source. |\n| `pushdown.sql` | SQL query | N | Full SQL pushdown query. |\n| `write.mode` | `CREATE`, `APPEND`, `OVERWRITE` | Y during write | Write mode to use. |\n| `write.empty.value.as.null` | `true`, `false` | N | Convert empty incoming string values to null before writing. |\n| `write.batch.size` | Positive integer | N | Number of rows written in a batch. |\n| `write.reject.limit` | Non-negative integer | N | Maximum rejected-row threshold before the write fails. |\n| `login.timeout.seconds` | Integer from `1` to `300` | N | JDBC login timeout in seconds. |\n"
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.12"
+  },
+  "title": "Hive Connector Samples"
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/plugins/oracle-aidp-connectors/examples/iceberg_smoke.ipynb
+++ b/plugins/oracle-aidp-connectors/examples/iceberg_smoke.ipynb
@@ -9,6 +9,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Warning: this notebook creates an Iceberg database/table and appends rows. Confirm the catalog, database, table, and workspace before running write cells.\n"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},

--- a/plugins/oracle-aidp-connectors/examples/iceberg_smoke.ipynb
+++ b/plugins/oracle-aidp-connectors/examples/iceberg_smoke.ipynb
@@ -1,0 +1,98 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# `aidp-iceberg` example - Hadoop catalog on `oci://`\n",
+    "Registers an Iceberg catalog backed by an OCI bucket, creates a database + partitioned table, inserts rows, queries snapshots, time-travels.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys, os, time\n",
+    "# Adjust this if you've uploaded the plugin scripts/ dir elsewhere.\n",
+    "sys.path.insert(0, '/Workspace/Shared/oracle_ai_data_platform_connectors/scripts')\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "OCI_NAMESPACE = os.environ['OCI_NAMESPACE']\n",
+    "BUCKET_NAME   = os.environ['ICEBERG_BUCKET']\n",
+    "WAREHOUSE     = f'oci://{BUCKET_NAME}@{OCI_NAMESPACE}/iceberg-warehouse'\n",
+    "CATALOG       = os.environ.get('ICEBERG_CATALOG', 'oci_catalog')\n",
+    "DB            = os.environ.get('ICEBERG_DB', 'demo_db')\n",
+    "TABLE         = os.environ.get('ICEBERG_TABLE', f'aidp_demo_employees_{int(time.time())}')\n",
+    "FQN           = f'{CATALOG}.{DB}.{TABLE}'\n",
+    "spark.conf.set(f'spark.sql.catalog.{CATALOG}',           'org.apache.iceberg.spark.SparkCatalog')\n",
+    "spark.conf.set(f'spark.sql.catalog.{CATALOG}.type',      'hadoop')\n",
+    "spark.conf.set(f'spark.sql.catalog.{CATALOG}.warehouse', WAREHOUSE)\n",
+    "print('warehouse:', WAREHOUSE)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "spark.sql(f'CREATE DATABASE IF NOT EXISTS {CATALOG}.{DB}')\n",
+    "spark.sql(f'''CREATE TABLE IF NOT EXISTS {FQN} (id INT, name STRING, dept STRING) USING iceberg PARTITIONED BY (dept)''')\n",
+    "data = [(1,'Alice','eng'), (2,'Bob','eng'), (3,'Carol','sales')]\n",
+    "spark.createDataFrame(data, ['id','name','dept']).writeTo(FQN).append()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = spark.sql(f'SELECT * FROM {FQN} ORDER BY id')\n",
+    "df.show()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# The final cell prints a JSON summary for quick validation.\n",
+    "import json, time\n",
+    "summary = {\n",
+    "    'connector': 'aidp-iceberg',\n",
+    "    'auth': 'hadoop-catalog-oci',\n",
+    "    'rows': int(df.count()),\n",
+    "    'schema': sorted([f.name for f in df.schema.fields]),\n",
+    "    'timestamp_utc': int(time.time()),\n",
+    "}\n",
+    "print('AIDP_EXAMPLE_RESULT_BEGIN')\n",
+    "print(json.dumps(summary, indent=2))\n",
+    "print('AIDP_EXAMPLE_RESULT_END')\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  },
+  "aidp_connector": "iceberg_smoke"
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/plugins/oracle-aidp-connectors/examples/jdbc_custom_sqlite.ipynb
+++ b/plugins/oracle-aidp-connectors/examples/jdbc_custom_sqlite.ipynb
@@ -1,0 +1,73 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# `aidp-jdbc-custom` example - generic `format('jdbc')` (SQLite memory DB)\n",
+    "Smoke test using SQLite (no external infra needed; in-memory DB). Validates the\n",
+    "Spark JDBC plumbing on the cluster - useful before swapping in a customer DB.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys, os\n",
+    "# Adjust this if you've uploaded the plugin scripts/ dir elsewhere.\n",
+    "sys.path.insert(0, '/Workspace/Shared/oracle_ai_data_platform_connectors/scripts')\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "JDBC_URL  = 'jdbc:sqlite::memory:'\n",
+    "DRIVER    = 'org.sqlite.JDBC'\n",
+    "props = {'driver': DRIVER, 'user': '', 'password': '', 'fetchsize': '1000'}\n",
+    "df = (spark.read.format('jdbc').options(**props)\n",
+    "      .option('url', JDBC_URL)\n",
+    "      .option('dbtable', '(SELECT 1 c1, 2 c2)').load())\n",
+    "df.show()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# The final cell prints a JSON summary for quick validation.\n",
+    "import json, time\n",
+    "summary = {\n",
+    "    'connector': 'aidp-jdbc-custom',\n",
+    "    'auth': 'sqlite-memory',\n",
+    "    'rows': int(df.count()),\n",
+    "    'schema': sorted([f.name for f in df.schema.fields]),\n",
+    "    'timestamp_utc': int(time.time()),\n",
+    "}\n",
+    "print('AIDP_EXAMPLE_RESULT_BEGIN')\n",
+    "print(json.dumps(summary, indent=2))\n",
+    "print('AIDP_EXAMPLE_RESULT_END')\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  },
+  "aidp_connector": "jdbc_custom_sqlite"
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/plugins/oracle-aidp-connectors/examples/kafka_streaming_apikey.ipynb
+++ b/plugins/oracle-aidp-connectors/examples/kafka_streaming_apikey.ipynb
@@ -1,0 +1,98 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# `aidp-streaming-kafka` example - SASL/PLAIN with OCI auth token\n",
+    "Example. Mirrors the official Oracle AIDP sample at `oracle-samples/oracle-aidp-samples` (`StreamingFromOCIStreamingService.ipynb`). 1-hour token TTL - refresh before long jobs.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys, os\n",
+    "# Adjust this if you've uploaded the plugin scripts/ dir elsewhere.\n",
+    "sys.path.insert(0, '/Workspace/Shared/oracle_ai_data_platform_connectors/scripts')\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from oracle_ai_data_platform_connectors.streaming import (\n",
+    "    bootstrap_for_region, build_kafka_options_sasl_plain, validate_checkpoint_path,\n",
+    ")\n",
+    "\n",
+    "bootstrap = bootstrap_for_region(os.environ['OCI_REGION'])\n",
+    "opts = build_kafka_options_sasl_plain(\n",
+    "    bootstrap_servers=bootstrap,\n",
+    "    tenancy_name=os.environ['OCI_TENANCY_NAME'],\n",
+    "    username=os.environ['OCI_USERNAME'],     # 'oracleidentitycloudservice/<email>' for IAM-Domains\n",
+    "    stream_pool_ocid=os.environ['OCI_STREAM_POOL_OCID'],\n",
+    "    auth_token=os.environ['OCI_AUTH_TOKEN'],\n",
+    "    topic=os.environ['KAFKA_TOPIC'],\n",
+    "    starting_offsets='earliest',\n",
+    "    max_partition_fetch_bytes=1024*1024,\n",
+    "    max_offsets_per_trigger=5,\n",
+    ")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "checkpoint = validate_checkpoint_path(os.environ['KAFKA_CHECKPOINT_VOLUME'])\n",
+    "raw = spark.readStream.format('kafka').options(**opts).load()\n",
+    "out_df = raw.selectExpr(\"CAST(key AS STRING) AS k\", \"CAST(value AS STRING) AS v\", \"topic\", \"partition\", \"offset\")\n",
+    "query = out_df.writeStream.format('memory').queryName('kafka_apikey_test').option('checkpointLocation', checkpoint).trigger(processingTime='5 seconds').start()\n",
+    "query.awaitTermination(timeout=60)\n",
+    "df = spark.sql('SELECT * FROM kafka_apikey_test')\n",
+    "df.show()\n",
+    "query.stop()\n",
+    "print('input rows in last batch:', (query.lastProgress or {}).get('numInputRows'))\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# The final cell prints a JSON summary for quick validation.\n",
+    "import json, time\n",
+    "summary = {\n",
+    "    'connector': 'aidp-streaming-kafka',\n",
+    "    'auth': 'sasl-plain',\n",
+    "    'rows': int(df.count()),\n",
+    "    'schema': sorted([f.name for f in df.schema.fields]),\n",
+    "    'timestamp_utc': int(time.time()),\n",
+    "}\n",
+    "print('AIDP_EXAMPLE_RESULT_BEGIN')\n",
+    "print(json.dumps(summary, indent=2))\n",
+    "print('AIDP_EXAMPLE_RESULT_END')\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  },
+  "aidp_connector": "kafka_streaming_apikey"
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/plugins/oracle-aidp-connectors/examples/mysql_read.ipynb
+++ b/plugins/oracle-aidp-connectors/examples/mysql_read.ipynb
@@ -1,0 +1,89 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# `aidp-mysql` example - `aidataplatform` `type=MYSQL`\n",
+    "Mirrors the official Oracle AIDP sample. Set the env vars listed below (see `.env.example`) and run end-to-end.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys, os\n",
+    "# Adjust this if you've uploaded the plugin scripts/ dir elsewhere.\n",
+    "sys.path.insert(0, '/Workspace/Shared/oracle_ai_data_platform_connectors/scripts')\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from oracle_ai_data_platform_connectors.aidataplatform import (\n",
+    "    AIDP_FORMAT, aidataplatform_options,\n",
+    ")\n",
+    "\n",
+    "opts = aidataplatform_options(\n",
+    "    type='MYSQL',\n",
+    "    host=os.environ['MYSQL_HOST'],\n",
+    "    port=int(os.environ['MYSQL_PORT']),\n",
+    "",
+    "    user=os.environ['MYSQL_USER'],\n",
+    "    password=os.environ['MYSQL_PASSWORD'],\n",
+    "    schema=os.environ['MYSQL_SCHEMA'],\n",
+    "    table=os.environ['MYSQL_TABLE'],\n",
+    ")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = spark.read.format(AIDP_FORMAT).options(**opts).load()\n",
+    "df.show(5)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# The final cell prints a JSON summary for quick validation.\n",
+    "import json, time\n",
+    "summary = {\n",
+    "    'connector': 'aidp-mysql',\n",
+    "    'auth': 'aidataplatform-mysql',\n",
+    "    'rows': int(df.count()),\n",
+    "    'schema': sorted([f.name for f in df.schema.fields]),\n",
+    "    'timestamp_utc': int(time.time()),\n",
+    "}\n",
+    "print('AIDP_EXAMPLE_RESULT_BEGIN')\n",
+    "print(json.dumps(summary, indent=2))\n",
+    "print('AIDP_EXAMPLE_RESULT_END')\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  },
+  "aidp_connector": "mysql_read"
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/plugins/oracle-aidp-connectors/examples/object_storage_csv_roundtrip.ipynb
+++ b/plugins/oracle-aidp-connectors/examples/object_storage_csv_roundtrip.ipynb
@@ -9,6 +9,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Warning: this notebook writes a CSV object to OCI Object Storage. Confirm the bucket, namespace, object path, and overwrite behavior before running the write cell.\n"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},

--- a/plugins/oracle-aidp-connectors/examples/object_storage_csv_roundtrip.ipynb
+++ b/plugins/oracle-aidp-connectors/examples/object_storage_csv_roundtrip.ipynb
@@ -1,0 +1,80 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# `aidp-object-storage` example - direct read/write `oci://`\n",
+    "Writes a small CSV to OCI Object Storage and reads it back. Auth is implicit via the cluster's IAM identity - no keys.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys, os\n",
+    "# Adjust this if you've uploaded the plugin scripts/ dir elsewhere.\n",
+    "sys.path.insert(0, '/Workspace/Shared/oracle_ai_data_platform_connectors/scripts')\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "oci_path = os.environ['OCI_OS_TEST_PATH']  # e.g. oci://my-bucket@my-ns/aidp-test/roundtrip.csv\n",
+    "data = [('Alice', 30), ('Bob', 35), ('Charlie', 25)]\n",
+    "df = spark.createDataFrame(data, ['name','age'])\n",
+    "(df.write.mode('errorifexists').option('header', True).format('csv').save(oci_path))\n",
+    "print('wrote:', oci_path)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = spark.read.option('header', True).format('csv').load(os.environ['OCI_OS_TEST_PATH'])\n",
+    "df.show()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# The final cell prints a JSON summary for quick validation.\n",
+    "import json, time\n",
+    "summary = {\n",
+    "    'connector': 'aidp-object-storage',\n",
+    "    'auth': 'oci-implicit-iam',\n",
+    "    'rows': int(df.count()),\n",
+    "    'schema': sorted([f.name for f in df.schema.fields]),\n",
+    "    'timestamp_utc': int(time.time()),\n",
+    "}\n",
+    "print('AIDP_EXAMPLE_RESULT_BEGIN')\n",
+    "print(json.dumps(summary, indent=2))\n",
+    "print('AIDP_EXAMPLE_RESULT_END')\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  },
+  "aidp_connector": "object_storage_csv_roundtrip"
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/plugins/oracle-aidp-connectors/examples/oracle_db_read_write.ipynb
+++ b/plugins/oracle-aidp-connectors/examples/oracle_db_read_write.ipynb
@@ -10,6 +10,13 @@
   {
    "cell_type": "markdown",
    "metadata": {},
+   "source": [
+    "Warning: this notebook includes live Oracle DB write examples. Confirm the target catalog/schema/table and write mode before running any write cell.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
    "source": "# Oracle Database Connector Samples\n\nRead/write ingestion and external-catalog samples for the `ORACLE_DB` connector.\n"
   },
   {

--- a/plugins/oracle-aidp-connectors/examples/oracle_db_read_write.ipynb
+++ b/plugins/oracle-aidp-connectors/examples/oracle_db_read_write.ipynb
@@ -1,0 +1,119 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "Oracle AI Data Platform v1.0\n\nCopyright (c) 2025, Oracle and/or its affiliates.\n\nLicensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "# Oracle Database Connector Samples\n\nRead/write ingestion and external-catalog samples for the `ORACLE_DB` connector.\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Ingestion Samples\n\nUse inline connector options when you want the notebook to carry all connection properties explicitly.\n"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "import os\n\n# Ingestion-style read using inline connector options\noracle_df = spark.read.format(\"aidataplatform\") \\\n    .option(\"type\", \"ORACLE_DB\") \\\n    .option(\"host\", os.environ[\"ORADB_HOST\"]) \\\n    .option(\"port\", os.environ.get(\"ORADB_PORT\", \"1521\")) \\\n    .option(\"database.name\", os.environ[\"ORADB_DATABASE_NAME\"]) \\\n    .option(\"user.name\", os.environ[\"ORADB_USER\"]) \\\n    .option(\"password\", os.environ[\"ORADB_PASSWORD\"]) \\\n    .option(\"schema\", os.environ[\"ORADB_SCHEMA\"]) \\\n    .option(\"table\", os.environ[\"ORADB_TABLE\"]) \\\n    .load()\n\noracle_df.show()\n"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "import os\n\n# Ingestion-style write using inline connector options\noracle_df.write.format(\"aidataplatform\") \\\n    .option(\"type\", \"ORACLE_DB\") \\\n    .option(\"host\", os.environ[\"ORADB_HOST\"]) \\\n    .option(\"port\", os.environ.get(\"ORADB_PORT\", \"1521\")) \\\n    .option(\"database.name\", os.environ[\"ORADB_DATABASE_NAME\"]) \\\n    .option(\"user.name\", os.environ[\"ORADB_USER\"]) \\\n    .option(\"password\", os.environ[\"ORADB_PASSWORD\"]) \\\n    .option(\"schema\", os.environ[\"ORADB_SCHEMA\"]) \\\n    .option(\"table\", os.environ[\"ORADB_TARGET_TABLE\"]) \\\n    .option(\"write.mode\", \"APPEND\") \\\n    .save()\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Ingestion Samples Using `catalog.id`\n\nUse `catalog.id` to reuse an existing external catalog connection and avoid placing credentials directly in the notebook.\n"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "import os\n\n# Ingestion-style read using an existing external catalog connection\noracle_df_catalog = spark.read.format(\"aidataplatform\") \\\n    .option(\"catalog.id\", \"<CATALOG_ID>\") \\\n    .option(\"schema\", os.environ[\"ORADB_SCHEMA\"]) \\\n    .option(\"table\", os.environ[\"ORADB_TABLE\"]) \\\n    .load()\n\noracle_df_catalog.show()\n\n# Ingestion-style write using an existing external catalog connection\noracle_df.write.format(\"aidataplatform\") \\\n    .option(\"catalog.id\", \"<CATALOG_ID>\") \\\n    .option(\"schema\", os.environ[\"ORADB_SCHEMA\"]) \\\n    .option(\"table\", os.environ[\"ORADB_TARGET_TABLE\"]) \\\n    .option(\"write.mode\", \"APPEND\") \\\n    .save()\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## External Catalog Samples\n\nAfter creating an external catalog in Master Catalogs, use three-part names in the form `<CATALOG_ID>.<SCHEMA>.<TABLE_NAME>` for Spark table access.\n"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# External catalog read with three-part name\ncatalog_df = spark.table(\"<CATALOG_ID>.<SCHEMA>.<TABLE_NAME>\")\ncatalog_df.show()\n\n# External catalog write - create\ncatalog_df.write.saveAsTable(\"<CATALOG_ID>.<SCHEMA>.<TARGET_TABLE_NAME>\")\n\n# External catalog write - overwrite only after explicit approval\ncatalog_df.write.mode(\"overwrite\").saveAsTable(\"<CATALOG_ID>.<SCHEMA>.<TARGET_TABLE_NAME>\")\n\n# External catalog write - append\ncatalog_df.write.mode(\"append\").insertInto(\"<CATALOG_ID>.<SCHEMA>.<TARGET_TABLE_NAME>\")\n\n# External catalog write - merge\ncatalog_df.write     .option(\"write.mode\", \"MERGE\")     .option(\"write.merge.keys\", \"<KEY_COLUMN>\")     .insertInto(\"<CATALOG_ID>.<SCHEMA>.<TARGET_TABLE_NAME>\")\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Pushdown Samples\n\nUse these samples when the source should execute filters or full SQL instead of Spark reading the full table first.\n"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "import os\n\n# Auto pushdown from DataFrame operations\noracle_df_filtered = spark.read.format(\"aidataplatform\") \\\n    .option(\"type\", \"ORACLE_DB\") \\\n    .option(\"host\", os.environ[\"ORADB_HOST\"]) \\\n    .option(\"port\", os.environ.get(\"ORADB_PORT\", \"1521\")) \\\n    .option(\"database.name\", os.environ[\"ORADB_DATABASE_NAME\"]) \\\n    .option(\"user.name\", os.environ[\"ORADB_USER\"]) \\\n    .option(\"password\", os.environ[\"ORADB_PASSWORD\"]) \\\n    .option(\"schema\", os.environ[\"ORADB_SCHEMA\"]) \\\n    .option(\"table\", os.environ[\"ORADB_TABLE\"]) \\\n    .option(\"row.limit\", \"1000\") \\\n    .load() \\\n    .select(\"<COLUMN_1>\", \"<COLUMN_2>\") \\\n    .filter(\"<COLUMN_1> = '<VALUE>'\")\n\noracle_df_filtered.show()\n"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "import os\n\n# Oracle SQL pushdown using inline connector options\noracle_df_pushdown = spark.read.format(\"aidataplatform\") \\\n    .option(\"type\", \"ORACLE_DB\") \\\n    .option(\"host\", os.environ[\"ORADB_HOST\"]) \\\n    .option(\"port\", os.environ.get(\"ORADB_PORT\", \"1521\")) \\\n    .option(\"database.name\", os.environ[\"ORADB_DATABASE_NAME\"]) \\\n    .option(\"user.name\", os.environ[\"ORADB_USER\"]) \\\n    .option(\"password\", os.environ[\"ORADB_PASSWORD\"]) \\\n    .option(\"pushdown.sql\", \"SELECT * FROM <SCHEMA>.<TABLE_NAME> WHERE <COLUMN_NAME> = '<VALUE>'\") \\\n    .load()\n\noracle_df_pushdown.show()\n"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# Oracle SQL pushdown using an external catalog connection\noracle_df_catalog_pushdown = spark.read.format(\"aidataplatform\") \\\n    .option(\"catalog.id\", \"<CATALOG_ID>\") \\\n    .option(\"pushdown.sql\", \"SELECT * FROM <SCHEMA>.<TABLE_NAME> WHERE <COLUMN_NAME> = '<VALUE>'\") \\\n    .load()\n\noracle_df_catalog_pushdown.show()\n"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "# External catalog pushdown through Spark DataFrame operations\ncatalog_df = spark.read.table(\"<CATALOG_ID>.<SCHEMA>.<TABLE_NAME>\")\n\ncatalog_df     .select(\"<COLUMN_1>\", \"<COLUMN_2>\")     .filter(\"<COLUMN_1> = '<VALUE>'\")     .orderBy(\"<COLUMN_2>\")     .limit(100)     .show()\n\n# Aggregate pushdown is supported for external catalog reads where Spark delegates it.\ncatalog_df.groupBy(\"<COLUMN_1>\").count().show()\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Connector Options\n\n| Parameter name | Valid values | Mandatory | Description |\n| --- | --- | --- | --- |\n| `type` | `ORACLE_DB` | Y for inline connector config | Data source type. |\n| `catalog.id` | Existing external catalog identifier | N | Reuse the connection details from an already created external catalog instead of passing the connector connection properties inline. |\n| `host` | Valid hostname or IP | Y | Database host. |\n| `port` | Valid port number | Y | Database listener port. |\n| `database.name` | Oracle service name | Y, if `database.sid` is not passed | Oracle service name. |\n| `database.sid` | Oracle SID | Y, if `database.name` is not passed | Oracle SID. |\n| `ssl.enabled` | `true`, `false` | N | Enable SSL or TLS-based Oracle connectivity. |\n| `rac.enabled` | `true`, `false` | N | Enable RAC-aware Oracle connectivity. |\n| `wallet.content` | Base64-encoded wallet content | N | Optional wallet content for wallet-based connectivity. |\n| `wallet.path` | `/Workspace/<path>` or `/Volumes/<path>` | N | Optional wallet path for wallet-based connectivity. |\n| `wallet.password` | Wallet password | N | Optional wallet password. |\n| `user.name` | Valid DB user | Y | Login user used for connectivity. |\n| `password` | Valid DB password | Y | Password for `user.name`. |\n| `oracle.user.name.quoted` | `true`, `false` | N | Use this when the Oracle login user itself was created as a quoted mixed-case or lower-case username. |\n| `schema` | Valid schema name | Y | Schema to read from or write to. |\n| `table` | Valid table name | Y for table-based access | Table name inside the schema. |\n| `view` | Valid view name | N | View name inside the schema when reading through a view. |\n| `sql` | Valid SQL query | N | Custom SQL query for read scenarios. |\n| `fetch.size` | Positive integer | N | Number of records fetched per round trip for reads. |\n| `row.limit` | Positive integer | N | Limits the number of rows read. |\n| `partition.column` | Column name | N | Column used for range-based partitioned reads or writes. |\n| `partition.num` | Integer >= 1 | N | Number of partitions to use for range partitioning. |\n| `partition.lower` | Numeric value or ISO-8601 date/time | N | Lower bound for range partitioning. |\n| `partition.upper` | Numeric value or ISO-8601 date/time | N | Upper bound for range partitioning. |\n| `pushdown.columns` | Comma-separated column names | N | Restricts the read to only the requested columns. |\n| `pushdown.filter` | SQL predicate | N | Predicate pushed down to the source. |\n| `pushdown.sql` | SQL query | N | Full SQL pushdown query. |\n| `source.projection.pushdown.disabled` | `true`, `false` | N | Disable projection pushdown for external-catalog reads. |\n| `source.filter.pushdown.disabled` | `true`, `false` | N | Disable filter pushdown for external-catalog reads. |\n| `source.topn.pushdown.disabled` | `true`, `false` | N | Disable TopN pushdown for external-catalog reads. |\n| `source.aggregation.pushdown.disabled` | `true`, `false` | N | Disable aggregation pushdown for external-catalog reads. |\n| `source.limit.pushdown.disabled` | `true`, `false` | N | Disable limit pushdown for external-catalog reads. |\n| `source.offset.pushdown.disabled` | `true`, `false` | N | Disable offset pushdown for external-catalog reads. |\n| `write.mode` | `CREATE`, `APPEND`, `OVERWRITE`, `MERGE` | Y during write | Write mode to use. This is primarily used for ingestion samples; refer to the sample code above for external catalog write examples. |\n| `write.empty.value.as.null` | `true`, `false` | N | Convert empty incoming string values to null before writing. |\n| `write.batch.size` | Positive integer | N | Number of rows written in a batch. |\n| `write.reject.limit` | Non-negative integer | N | Maximum rejected-row threshold before the write fails. |\n| `write.merge.keys` | Comma-separated column names | Y for `MERGE` | Key columns used in the `MERGE` condition. |\n| `merge.matched.where` | SQL condition using `tgt` and `src` aliases | N | Additional filter applied to rows where the `MERGE` match condition succeeds. |\n| `merge.matched.delete` | SQL condition using `tgt` and `src` aliases | N | Delete matching target rows when the given condition evaluates to true. |\n| `merge.not.matched.where` | SQL condition using `tgt` and `src` aliases | N | Additional filter applied before inserting rows that do not match. |\n| `merge.staging.using.username` | `true`, `false` | N | For `MERGE`, stage the temporary merge table in the login user's schema from `user.name` instead of the default target schema. |\n| `overwrite.with.recreate` | `true`, `false` | N | Controls overwrite behavior when the target shape is incompatible and overwrite needs a drop-and-recreate. |\n| `oracle.write.native.boolean` | `true`, `false` | N | Write Spark boolean columns as native Oracle `BOOLEAN` when the target Oracle version supports it. Leave it unset to keep the backward-compatible non-native path. |\n| `oracle.append.hint.enabled` | `true`, `false` | N | For append writes, request Oracle append-insert behavior when you want the target write path to honor the append hint. |\n| `preserve.oracle.column.types` | Comma-separated column/type mappings such as `EMBEDDING VECTOR(512, FLOAT32)`, `DOC JSON`, `RAW_PAYLOAD RAW(16)` | N | Create-only Oracle option to preserve Oracle-native target types during table creation instead of falling back to generic mapped types. Use this when the new table must keep special Oracle types such as `VECTOR`, `JSON`, or `RAW`. |\n| `login.timeout.seconds` | Integer from `1` to `300` | N | JDBC login timeout in seconds. |\n"
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.12"
+  },
+  "title": "Oracle Database Connector Samples"
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/plugins/oracle-aidp-connectors/examples/peoplesoft_read.ipynb
+++ b/plugins/oracle-aidp-connectors/examples/peoplesoft_read.ipynb
@@ -1,0 +1,67 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "Oracle AI Data Platform v1.0\n\nCopyright (c) 2025, Oracle and/or its affiliates.\n\nLicensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "# Oracle PeopleSoft Connector Samples\n\nRead-only ingestion samples for the `ORACLE_PEOPLESOFT` connector.\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Ingestion Sample\n\nSet `PEOPLESOFT_*` environment variables before running the notebook. Do not paste passwords or tokens into shared notebook cells.\n"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "import os\n\n# Read from Oracle PeopleSoft\noracle_peoplesoft_df = spark.read.format(\"aidataplatform\") \\\n    .option(\"type\", \"ORACLE_PEOPLESOFT\") \\\n    .option(\"host\", os.environ[\"PEOPLESOFT_HOST\"]) \\\n    .option(\"port\", os.environ.get(\"PEOPLESOFT_PORT\", \"1521\")) \\\n    .option(\"database.name\", os.environ[\"PEOPLESOFT_DATABASE_NAME\"]) \\\n    .option(\"user.name\", os.environ[\"PEOPLESOFT_USER\"]) \\\n    .option(\"password\", os.environ[\"PEOPLESOFT_PASSWORD\"]) \\\n    .option(\"schema\", os.environ[\"PEOPLESOFT_SCHEMA\"]) \\\n    .option(\"table\", os.environ[\"PEOPLESOFT_TABLE\"]) \\\n    .load()\n\noracle_peoplesoft_df.show()\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Pushdown SQL Sample\n\nUse `pushdown.sql` when you want the connector to execute a complete source SQL query instead of building the query from `schema` and `table` options.\n"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "import os\n\n# Full SQL pushdown for Oracle PeopleSoft\noracle_peoplesoft_df_pushdown = spark.read.format(\"aidataplatform\") \\\n    .option(\"type\", \"ORACLE_PEOPLESOFT\") \\\n    .option(\"host\", os.environ[\"PEOPLESOFT_HOST\"]) \\\n    .option(\"port\", os.environ.get(\"PEOPLESOFT_PORT\", \"1521\")) \\\n    .option(\"database.name\", os.environ[\"PEOPLESOFT_DATABASE_NAME\"]) \\\n    .option(\"user.name\", os.environ[\"PEOPLESOFT_USER\"]) \\\n    .option(\"password\", os.environ[\"PEOPLESOFT_PASSWORD\"]) \\\n    .option(\"pushdown.sql\", \"SELECT * FROM <SCHEMA>.<TABLE_NAME> WHERE <COLUMN_NAME> = '<VALUE>'\") \\\n    .load()\n\noracle_peoplesoft_df_pushdown.show()\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Connector Options\n\n| Parameter name | Valid values | Mandatory | Description |\n| --- | --- | --- | --- |\n| `type` | Connector type shown in the sample | Y | Data source type. |\n| `host` | Valid hostname or IP address | Y | Source host. |\n| `port` | Valid port number | Y | Source port. |\n| `database.name` | Database or service name | N | Database name when the connector requires one. |\n| `user.name` | Valid source username | Y | Login user used for connectivity. |\n| `password` | Valid source password | Y | Password for `user.name`. |\n| `schema` | Valid schema name | Y | Schema to read from. |\n| `table` | Valid table name | Y for table-based access | Table name inside the schema. |\n| `view` | Valid view name | N | View name inside the schema when reading through a view. |\n| `sql` | Valid SQL query | N | Custom SQL query for read scenarios. |\n| `fetch.size` | Positive integer | N | Number of records fetched per round trip for reads. |\n| `row.limit` | Positive integer | N | Limits the number of rows read. |\n| `partition.column` | Column name | N | Column used for range-based partitioned reads. |\n| `partition.num` | Integer >= 1 | N | Number of partitions to use. |\n| `partition.lower` | Numeric value or ISO-8601 date/time | N | Lower bound for range partitioning. |\n| `partition.upper` | Numeric value or ISO-8601 date/time | N | Upper bound for range partitioning. |\n| `pushdown.columns` | Comma-separated column names | N | Restricts the read to only the requested columns. |\n| `pushdown.filter` | SQL predicate | N | Predicate pushed down to the source. |\n| `pushdown.sql` | SQL query | N | Full SQL pushdown query. |\n| `login.timeout.seconds` | Integer from `1` to `300` | N | JDBC login timeout in seconds. |\n"
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.12"
+  },
+  "title": "Oracle PeopleSoft Connector Samples"
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/plugins/oracle-aidp-connectors/examples/postgresql_read.ipynb
+++ b/plugins/oracle-aidp-connectors/examples/postgresql_read.ipynb
@@ -1,0 +1,89 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# `aidp-postgresql` example - `aidataplatform` `type=POSTGRESQL`\n",
+    "Mirrors the official Oracle AIDP sample. Set the env vars listed below (see `.env.example`) and run end-to-end.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys, os\n",
+    "# Adjust this if you've uploaded the plugin scripts/ dir elsewhere.\n",
+    "sys.path.insert(0, '/Workspace/Shared/oracle_ai_data_platform_connectors/scripts')\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from oracle_ai_data_platform_connectors.aidataplatform import (\n",
+    "    AIDP_FORMAT, aidataplatform_options,\n",
+    ")\n",
+    "\n",
+    "opts = aidataplatform_options(\n",
+    "    type='POSTGRESQL',\n",
+    "    host=os.environ['PG_HOST'],\n",
+    "    port=int(os.environ['PG_PORT']),\n",
+    "",
+    "    user=os.environ['PG_USER'],\n",
+    "    password=os.environ['PG_PASSWORD'],\n",
+    "    schema=os.environ['PG_SCHEMA'],\n",
+    "    table=os.environ['PG_TABLE'],\n",
+    ")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = spark.read.format(AIDP_FORMAT).options(**opts).load()\n",
+    "df.show(5)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# The final cell prints a JSON summary for quick validation.\n",
+    "import json, time\n",
+    "summary = {\n",
+    "    'connector': 'aidp-postgresql',\n",
+    "    'auth': 'aidataplatform-postgresql',\n",
+    "    'rows': int(df.count()),\n",
+    "    'schema': sorted([f.name for f in df.schema.fields]),\n",
+    "    'timestamp_utc': int(time.time()),\n",
+    "}\n",
+    "print('AIDP_EXAMPLE_RESULT_BEGIN')\n",
+    "print(json.dumps(summary, indent=2))\n",
+    "print('AIDP_EXAMPLE_RESULT_END')\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  },
+  "aidp_connector": "postgresql_read"
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/plugins/oracle-aidp-connectors/examples/rest_generic_read.ipynb
+++ b/plugins/oracle-aidp-connectors/examples/rest_generic_read.ipynb
@@ -1,0 +1,95 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# `aidp-rest-generic` example - `aidataplatform` `type=GENERIC_REST`\n",
+    "Reads from any REST endpoint that publishes a `manifest.url`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys, os\n",
+    "# Adjust this if you've uploaded the plugin scripts/ dir elsewhere.\n",
+    "sys.path.insert(0, '/Workspace/Shared/oracle_ai_data_platform_connectors/scripts')\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from oracle_ai_data_platform_connectors.aidataplatform import (\n",
+    "    AIDP_FORMAT, aidataplatform_options,\n",
+    ")\n",
+    "extra = {\n",
+    "    'base.url':     os.environ['REST_BASE_URL'],\n",
+    "    'manifest.url': os.environ['REST_MANIFEST_URL'],\n",
+    "    'auth.type':    'basic',\n",
+    "    'api':          os.environ['REST_API'],\n",
+    "}\n",
+    "# Each REST_PROP_* env var becomes a derived.property.* option.\n",
+    "for k, v in os.environ.items():\n",
+    "    if k.startswith('REST_PROP_'):\n",
+    "        extra[f'derived.property.{k[len(\"REST_PROP_\"):]}'] = v\n",
+    "opts = aidataplatform_options(\n",
+    "    type='GENERIC_REST',\n",
+    "    user=os.environ['REST_USER'],\n",
+    "    password=os.environ['REST_PASSWORD'],\n",
+    "    schema=os.environ.get('REST_SCHEMA', 'default'),\n",
+    "    extra=extra,\n",
+    ")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = spark.read.format(AIDP_FORMAT).options(**opts).load()\n",
+    "df.show(5)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# The final cell prints a JSON summary for quick validation.\n",
+    "import json, time\n",
+    "summary = {\n",
+    "    'connector': 'aidp-rest-generic',\n",
+    "    'auth': 'basic',\n",
+    "    'rows': int(df.count()),\n",
+    "    'schema': sorted([f.name for f in df.schema.fields]),\n",
+    "    'timestamp_utc': int(time.time()),\n",
+    "}\n",
+    "print('AIDP_EXAMPLE_RESULT_BEGIN')\n",
+    "print(json.dumps(summary, indent=2))\n",
+    "print('AIDP_EXAMPLE_RESULT_END')\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  },
+  "aidp_connector": "rest_generic_read"
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/plugins/oracle-aidp-connectors/examples/s3_read.ipynb
+++ b/plugins/oracle-aidp-connectors/examples/s3_read.ipynb
@@ -1,0 +1,72 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# `aidp-aws-s3` example - `s3a://` via access key\n",
+    "Requires `aws-java-sdk-bundle-<ver>.jar` matching the cluster's `hadoop-aws`.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys, os\n",
+    "# Adjust this if you've uploaded the plugin scripts/ dir elsewhere.\n",
+    "sys.path.insert(0, '/Workspace/Shared/oracle_ai_data_platform_connectors/scripts')\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "spark.conf.set('fs.s3a.aws.credentials.provider', 'org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider')\n",
+    "os.environ['AWS_ACCESS_KEY_ID']     = os.environ['S3_ACCESS_KEY']\n",
+    "os.environ['AWS_SECRET_ACCESS_KEY'] = os.environ['S3_SECRET_KEY']\n",
+    "bucket = os.environ['S3_BUCKET']\n",
+    "key    = os.environ['S3_FILE']\n",
+    "df = spark.read.json(f's3a://{bucket}/{key}')\n",
+    "df.show()\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# The final cell prints a JSON summary for quick validation.\n",
+    "import json, time\n",
+    "summary = {\n",
+    "    'connector': 'aidp-aws-s3',\n",
+    "    'auth': 'access-key',\n",
+    "    'rows': int(df.count()),\n",
+    "    'schema': sorted([f.name for f in df.schema.fields]),\n",
+    "    'timestamp_utc': int(time.time()),\n",
+    "}\n",
+    "print('AIDP_EXAMPLE_RESULT_BEGIN')\n",
+    "print(json.dumps(summary, indent=2))\n",
+    "print('AIDP_EXAMPLE_RESULT_END')\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  },
+  "aidp_connector": "s3_read"
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/plugins/oracle-aidp-connectors/examples/salesforce_read.ipynb
+++ b/plugins/oracle-aidp-connectors/examples/salesforce_read.ipynb
@@ -1,0 +1,67 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "Oracle AI Data Platform v1.0\n\nCopyright (c) 2025, Oracle and/or its affiliates.\n\nLicensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "# Salesforce Connector Samples\n\nRead-only ingestion samples for the `SFORCE` connector.\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Ingestion Sample\n\nSet `SALESFORCE_*` environment variables before running the notebook. Do not paste passwords or tokens into shared notebook cells.\n"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "import os\n\n# Read from Salesforce\nsalesforce_df = spark.read.format(\"aidataplatform\") \\\n    .option(\"type\", \"SFORCE\") \\\n    .option(\"host\", os.environ[\"SALESFORCE_HOST\"]) \\\n    .option(\"port\", os.environ.get(\"SALESFORCE_PORT\", \"443\")) \\\n    .option(\"database.name\", os.environ[\"SALESFORCE_DATABASE_NAME\"]) \\\n    .option(\"user.name\", os.environ[\"SALESFORCE_USER\"]) \\\n    .option(\"password\", os.environ[\"SALESFORCE_PASSWORD\"]) \\\n    .option(\"schema\", os.environ[\"SALESFORCE_SCHEMA\"]) \\\n    .option(\"table\", os.environ[\"SALESFORCE_TABLE\"]) \\\n    .load()\n\nsalesforce_df.show()\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Pushdown SQL Sample\n\nUse `pushdown.sql` when you want the connector to execute a complete source SQL query instead of building the query from `schema` and `table` options.\n"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "import os\n\n# Full SQL pushdown for Salesforce\nsalesforce_df_pushdown = spark.read.format(\"aidataplatform\") \\\n    .option(\"type\", \"SFORCE\") \\\n    .option(\"host\", os.environ[\"SALESFORCE_HOST\"]) \\\n    .option(\"port\", os.environ.get(\"SALESFORCE_PORT\", \"443\")) \\\n    .option(\"database.name\", os.environ[\"SALESFORCE_DATABASE_NAME\"]) \\\n    .option(\"user.name\", os.environ[\"SALESFORCE_USER\"]) \\\n    .option(\"password\", os.environ[\"SALESFORCE_PASSWORD\"]) \\\n    .option(\"pushdown.sql\", \"SELECT * FROM <SCHEMA>.<TABLE_NAME> WHERE <COLUMN_NAME> = '<VALUE>'\") \\\n    .load()\n\nsalesforce_df_pushdown.show()\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Connector Options\n\n| Parameter name | Valid values | Mandatory | Description |\n| --- | --- | --- | --- |\n| `type` | `SFORCE` | Y | Data source type. |\n| `host` | Valid Salesforce JDBC host or endpoint | Y | Salesforce endpoint host. |\n| `port` | Valid port number | Y | Network port used by the Salesforce JDBC endpoint. |\n| `database.name` | Optional Salesforce database or catalog name exposed by the driver | N | Optional logical database name when the Salesforce JDBC configuration expects it. |\n| `user.name` | Valid Salesforce username | Y | Username used for Salesforce connectivity. |\n| `password` | Valid Salesforce password or security-token-appended password, depending on the configured endpoint | Y | Password used for Salesforce connectivity. |\n| `schema` | Valid schema name | Y | Schema exposed by the Salesforce JDBC driver. |\n| `table` | Valid object or table name | Y for table access | Salesforce object name to read. |\n| `view` | Valid view name | N | View name when the driver exposes the target object as a view. |\n| `sql` | Valid SQL query | N | Custom SQL query for reads. |\n| `fetch.size` | Positive integer | N | Number of records fetched per round trip for reads. |\n| `row.limit` | Positive integer | N | Limits the number of rows read. |\n| `partition.column` | Column name | N | Column used for range-based partitioned reads. |\n| `partition.num` | Integer >= 1 | N | Number of partitions to use for reads. |\n| `partition.lower` | Numeric value or ISO-8601 date/time | N | Lower bound for range partitioning. |\n| `partition.upper` | Numeric value or ISO-8601 date/time | N | Upper bound for range partitioning. |\n| `pushdown.columns` | Comma-separated column names | N | Restricts the read to only the requested columns. |\n| `pushdown.filter` | SQL predicate | N | Predicate pushed down to the source. |\n| `pushdown.sql` | SQL query | N | Full SQL pushdown query. |\n| `login.timeout.seconds` | Integer from `1` to `300` | N | JDBC login timeout in seconds. |\n"
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.12"
+  },
+  "title": "Salesforce Connector Samples"
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/plugins/oracle-aidp-connectors/examples/siebel_read.ipynb
+++ b/plugins/oracle-aidp-connectors/examples/siebel_read.ipynb
@@ -1,0 +1,67 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "Oracle AI Data Platform v1.0\n\nCopyright (c) 2025, Oracle and/or its affiliates.\n\nLicensed under the Universal Permissive License v 1.0 as shown at https://oss.oracle.com/licenses/upl/"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "# Oracle Siebel Connector Samples\n\nRead-only ingestion samples for the `ORACLE_SIEBEL` connector.\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Ingestion Sample\n\nSet `SIEBEL_*` environment variables before running the notebook. Do not paste passwords or tokens into shared notebook cells.\n"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "import os\n\n# Read from Oracle Siebel\noracle_siebel_df = spark.read.format(\"aidataplatform\") \\\n    .option(\"type\", \"ORACLE_SIEBEL\") \\\n    .option(\"host\", os.environ[\"SIEBEL_HOST\"]) \\\n    .option(\"port\", os.environ.get(\"SIEBEL_PORT\", \"1521\")) \\\n    .option(\"database.name\", os.environ[\"SIEBEL_DATABASE_NAME\"]) \\\n    .option(\"user.name\", os.environ[\"SIEBEL_USER\"]) \\\n    .option(\"password\", os.environ[\"SIEBEL_PASSWORD\"]) \\\n    .option(\"schema\", os.environ[\"SIEBEL_SCHEMA\"]) \\\n    .option(\"table\", os.environ[\"SIEBEL_TABLE\"]) \\\n    .load()\n\noracle_siebel_df.show()\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Pushdown SQL Sample\n\nUse `pushdown.sql` when you want the connector to execute a complete source SQL query instead of building the query from `schema` and `table` options.\n"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": "import os\n\n# Full SQL pushdown for Oracle Siebel\noracle_siebel_df_pushdown = spark.read.format(\"aidataplatform\") \\\n    .option(\"type\", \"ORACLE_SIEBEL\") \\\n    .option(\"host\", os.environ[\"SIEBEL_HOST\"]) \\\n    .option(\"port\", os.environ.get(\"SIEBEL_PORT\", \"1521\")) \\\n    .option(\"database.name\", os.environ[\"SIEBEL_DATABASE_NAME\"]) \\\n    .option(\"user.name\", os.environ[\"SIEBEL_USER\"]) \\\n    .option(\"password\", os.environ[\"SIEBEL_PASSWORD\"]) \\\n    .option(\"pushdown.sql\", \"SELECT * FROM <SCHEMA>.<TABLE_NAME> WHERE <COLUMN_NAME> = '<VALUE>'\") \\\n    .load()\n\noracle_siebel_df_pushdown.show()\n"
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": "## Connector Options\n\n| Parameter name | Valid values | Mandatory | Description |\n| --- | --- | --- | --- |\n| `type` | Connector type shown in the sample | Y | Data source type. |\n| `host` | Valid hostname or IP address | Y | Source host. |\n| `port` | Valid port number | Y | Source port. |\n| `database.name` | Database or service name | N | Database name when the connector requires one. |\n| `user.name` | Valid source username | Y | Login user used for connectivity. |\n| `password` | Valid source password | Y | Password for `user.name`. |\n| `schema` | Valid schema name | Y | Schema to read from. |\n| `table` | Valid table name | Y for table-based access | Table name inside the schema. |\n| `view` | Valid view name | N | View name inside the schema when reading through a view. |\n| `sql` | Valid SQL query | N | Custom SQL query for read scenarios. |\n| `fetch.size` | Positive integer | N | Number of records fetched per round trip for reads. |\n| `row.limit` | Positive integer | N | Limits the number of rows read. |\n| `partition.column` | Column name | N | Column used for range-based partitioned reads. |\n| `partition.num` | Integer >= 1 | N | Number of partitions to use. |\n| `partition.lower` | Numeric value or ISO-8601 date/time | N | Lower bound for range partitioning. |\n| `partition.upper` | Numeric value or ISO-8601 date/time | N | Upper bound for range partitioning. |\n| `pushdown.columns` | Comma-separated column names | N | Restricts the read to only the requested columns. |\n| `pushdown.filter` | SQL predicate | N | Predicate pushed down to the source. |\n| `pushdown.sql` | SQL query | N | Full SQL pushdown query. |\n| `login.timeout.seconds` | Integer from `1` to `300` | N | JDBC login timeout in seconds. |\n"
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.12"
+  },
+  "title": "Oracle Siebel Connector Samples"
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/plugins/oracle-aidp-connectors/examples/snowflake_read.ipynb
+++ b/plugins/oracle-aidp-connectors/examples/snowflake_read.ipynb
@@ -1,0 +1,76 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# `aidp-snowflake` example - Snowflake Spark connector\n",
+    "Requires `spark-snowflake_2.12-3.1.1.jar` + `snowflake-jdbc-3.19.0.jar` on the cluster classpath.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys, os\n",
+    "# Adjust this if you've uploaded the plugin scripts/ dir elsewhere.\n",
+    "sys.path.insert(0, '/Workspace/Shared/oracle_ai_data_platform_connectors/scripts')\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "snow = {\n",
+    "    'sfUrl':       os.environ['SNOW_URL'],\n",
+    "    'sfUser':      os.environ['SNOW_USER'],\n",
+    "    'sfPassword':  os.environ['SNOW_PASSWORD'],\n",
+    "    'sfDatabase':  os.environ['SNOW_DATABASE'],\n",
+    "    'sfSchema':    os.environ['SNOW_SCHEMA'],\n",
+    "    'sfWarehouse': os.environ['SNOW_WAREHOUSE'],\n",
+    "}\n",
+    "df = (spark.read.format('snowflake').options(**snow)\n",
+    "          .option('dbtable', os.environ['SNOW_TABLE']).load())\n",
+    "df.show(5)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# The final cell prints a JSON summary for quick validation.\n",
+    "import json, time\n",
+    "summary = {\n",
+    "    'connector': 'aidp-snowflake',\n",
+    "    'auth': 'user-password',\n",
+    "    'rows': int(df.count()),\n",
+    "    'schema': sorted([f.name for f in df.schema.fields]),\n",
+    "    'timestamp_utc': int(time.time()),\n",
+    "}\n",
+    "print('AIDP_EXAMPLE_RESULT_BEGIN')\n",
+    "print(json.dumps(summary, indent=2))\n",
+    "print('AIDP_EXAMPLE_RESULT_END')\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  },
+  "aidp_connector": "snowflake_read"
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/plugins/oracle-aidp-connectors/examples/sqlserver_read.ipynb
+++ b/plugins/oracle-aidp-connectors/examples/sqlserver_read.ipynb
@@ -1,0 +1,89 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# `aidp-sqlserver` example - `aidataplatform` `type=SQLSERVER`\n",
+    "Mirrors the official Oracle AIDP sample. Set the env vars listed below (see `.env.example`) and run end-to-end.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import sys, os\n",
+    "# Adjust this if you've uploaded the plugin scripts/ dir elsewhere.\n",
+    "sys.path.insert(0, '/Workspace/Shared/oracle_ai_data_platform_connectors/scripts')\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from oracle_ai_data_platform_connectors.aidataplatform import (\n",
+    "    AIDP_FORMAT, aidataplatform_options,\n",
+    ")\n",
+    "\n",
+    "opts = aidataplatform_options(\n",
+    "    type='SQLSERVER',\n",
+    "    host=os.environ['MSSQL_HOST'],\n",
+    "    port=int(os.environ['MSSQL_PORT']),\n",
+    "",
+    "    user=os.environ['MSSQL_USER'],\n",
+    "    password=os.environ['MSSQL_PASSWORD'],\n",
+    "    schema=os.environ['MSSQL_SCHEMA'],\n",
+    "    table=os.environ['MSSQL_TABLE'],\n",
+    ")\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = spark.read.format(AIDP_FORMAT).options(**opts).load()\n",
+    "df.show(5)\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# The final cell prints a JSON summary for quick validation.\n",
+    "import json, time\n",
+    "summary = {\n",
+    "    'connector': 'aidp-sqlserver',\n",
+    "    'auth': 'aidataplatform-sqlserver',\n",
+    "    'rows': int(df.count()),\n",
+    "    'schema': sorted([f.name for f in df.schema.fields]),\n",
+    "    'timestamp_utc': int(time.time()),\n",
+    "}\n",
+    "print('AIDP_EXAMPLE_RESULT_BEGIN')\n",
+    "print(json.dumps(summary, indent=2))\n",
+    "print('AIDP_EXAMPLE_RESULT_END')\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  },
+  "aidp_connector": "sqlserver_read"
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/plugins/oracle-aidp-connectors/index.ts
+++ b/plugins/oracle-aidp-connectors/index.ts
@@ -1,0 +1,30 @@
+import type { AgentPlugin } from "@cline/sdk"
+
+const PLUGIN_NAME = "oracle-aidp-connectors"
+
+const aidpSafetyRule = [
+	"Oracle AIDP connector skills are active. Treat bundled snippets as notebook guidance, not approval to access data sources, write tables, upload helper code, or store credentials.",
+	"Before running or asking the user to run connector code that writes to a database, table, bucket, volume, stream, catalog, or SaaS object, explain the destination, write mode, affected account or workspace, and wait for explicit user approval.",
+	"Never paste raw passwords, private keys, wallet contents, OCI config PEMs, database tokens, Salesforce tokens, AWS keys, Azure secrets, or HTTP Basic credentials into chat, committed files, shared notebooks, logs, or `/Workspace/Shared/` paths.",
+	"Prefer existing environment variables, OCI Vault secrets, private notebook state, `/tmp` files for transient wallet material, and user-owned secret stores. Do not write secrets into bundled plugin files or shared helper-package uploads.",
+	"When uploading helper files or notebooks into an Oracle AI Data Platform Workbench workspace, confirm the workspace id and destination path first, and upload code-only artifacts unless the user explicitly requests otherwise.",
+	"Before downloading or classloading JDBC, Spark connector, Hadoop, or cloud SDK JARs into a running Spark JVM, explain the source URL, version pin, optional checksum, and the cluster-managed library alternative, then wait for user approval.",
+	"Treat database schemas, table samples, REST responses, notebooks, and generated query results as private user data. Keep queries bounded, avoid unnecessary full-table reads, and summarize sensitive results instead of dumping them.",
+].join("\n")
+
+const plugin: AgentPlugin = {
+	name: PLUGIN_NAME,
+	manifest: {
+		capabilities: ["skills", "rules"],
+	},
+
+	setup(api) {
+		api.registerRule({
+			id: "oracle-aidp-connectors:safety",
+			source: PLUGIN_NAME,
+			content: aidpSafetyRule,
+		})
+	},
+}
+
+export default plugin

--- a/plugins/oracle-aidp-connectors/index.ts
+++ b/plugins/oracle-aidp-connectors/index.ts
@@ -2,28 +2,10 @@ import type { AgentPlugin } from "@cline/sdk"
 
 const PLUGIN_NAME = "oracle-aidp-connectors"
 
-const aidpSafetyRule = [
-	"Oracle AIDP connector skills are active. Treat bundled snippets as notebook guidance, not approval to access data sources, write tables, upload helper code, or store credentials.",
-	"Before running or asking the user to run connector code that writes to a database, table, bucket, volume, stream, catalog, or SaaS object, explain the destination, write mode, affected account or workspace, and wait for explicit user approval.",
-	"Never paste raw passwords, private keys, wallet contents, OCI config PEMs, database tokens, Salesforce tokens, AWS keys, Azure secrets, or HTTP Basic credentials into chat, committed files, shared notebooks, logs, or `/Workspace/Shared/` paths.",
-	"Prefer existing environment variables, OCI Vault secrets, private notebook state, `/tmp` files for transient wallet material, and user-owned secret stores. Do not write secrets into bundled plugin files or shared helper-package uploads.",
-	"When uploading helper files or notebooks into an Oracle AI Data Platform Workbench workspace, confirm the workspace id and destination path first, and upload code-only artifacts unless the user explicitly requests otherwise.",
-	"Before downloading or classloading JDBC, Spark connector, Hadoop, or cloud SDK JARs into a running Spark JVM, explain the source URL, version pin, optional checksum, and the cluster-managed library alternative, then wait for user approval.",
-	"Treat database schemas, table samples, REST responses, notebooks, and generated query results as private user data. Keep queries bounded, avoid unnecessary full-table reads, and summarize sensitive results instead of dumping them.",
-].join("\n")
-
 const plugin: AgentPlugin = {
 	name: PLUGIN_NAME,
 	manifest: {
-		capabilities: ["skills", "rules"],
-	},
-
-	setup(api) {
-		api.registerRule({
-			id: "oracle-aidp-connectors:safety",
-			source: PLUGIN_NAME,
-			content: aidpSafetyRule,
-		})
+		capabilities: ["skills"],
 	},
 }
 

--- a/plugins/oracle-aidp-connectors/package.json
+++ b/plugins/oracle-aidp-connectors/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "oracle-aidp-connectors",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Cline plugin that bundles Oracle AI Data Platform Workbench Spark connector skills.",
+  "cline": {
+    "plugins": [
+      {
+        "paths": [
+          "./index.ts"
+        ],
+        "capabilities": [
+          "skills",
+          "rules"
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/oracle-aidp-connectors/package.json
+++ b/plugins/oracle-aidp-connectors/package.json
@@ -11,8 +11,7 @@
           "./index.ts"
         ],
         "capabilities": [
-          "skills",
-          "rules"
+          "skills"
         ]
       }
     ]

--- a/plugins/oracle-aidp-connectors/scripts/oracle_ai_data_platform_connectors/__init__.py
+++ b/plugins/oracle-aidp-connectors/scripts/oracle_ai_data_platform_connectors/__init__.py
@@ -1,0 +1,34 @@
+"""Oracle AI Data Platform Spark connectors helper package.
+
+Importable from an AIDP notebook after the user adds the plugin's scripts/
+directory to sys.path. Public surface is intentionally small; each connector
+skill points users at one or two helpers below.
+
+Submodules:
+    auth            - wallet, dbtoken, oci_config, user_principal, secrets
+    jdbc            - oracle (ALH/ATP/ExaCS),
+                      runtime_load (load custom JDBC JARs without restart)
+    rest            - fusion, epm, essbase
+    streaming       - kafka
+    aidataplatform  - builder for the AIDP `aidataplatform` Spark format
+                      (ORACLE_DB, ORACLE_EXADATA, ORACLE_ALH, ORACLE_ATP,
+                      POSTGRESQL, MYSQL, MYSQL_HEATWAVE, SQLSERVER,
+                      KAFKA, FUSION_BICC, GENERIC_REST)
+    excel           - stdlib-only .xlsx parser for AIDP clusters that have
+                      neither openpyxl nor com.crealytics.spark.excel
+"""
+
+__version__ = "0.3.0"
+
+from .aidataplatform import AIDP_FORMAT, aidataplatform_options
+from .excel import read_xlsx_stdlib
+
+__all__ = [
+    "auth",
+    "jdbc",
+    "rest",
+    "streaming",
+    "AIDP_FORMAT",
+    "aidataplatform_options",
+    "read_xlsx_stdlib",
+]

--- a/plugins/oracle-aidp-connectors/scripts/oracle_ai_data_platform_connectors/aidataplatform.py
+++ b/plugins/oracle-aidp-connectors/scripts/oracle_ai_data_platform_connectors/aidataplatform.py
@@ -1,0 +1,107 @@
+"""Helpers for AIDP's built-in `aidataplatform` Spark format handler.
+
+The `aidataplatform` format is registered on every AIDP cluster and dispatches
+on the `type` option to a connector implementation. The shape is identical
+across many connector types - host/port/user/password/schema/table - only
+`type` and a small handful of type-specific keys differ.
+
+Connector types known to be supported by the format handler (from the official
+oracle-aidp-samples repo):
+
+* ``ORACLE_DB``          - Oracle DB on Compute / on-prem / Base DB
+* ``ORACLE_EXADATA``     - Exadata Cloud Service
+* ``ORACLE_ALH``         - Autonomous Data Warehouse / Lakehouse
+* ``ORACLE_ATP``         - Autonomous Transaction Processing
+* ``ORACLE_PEOPLESOFT``  - Oracle PeopleSoft (read-only)
+* ``ORACLE_SIEBEL``      - Oracle Siebel CRM (read-only)
+* ``SFORCE``             - Salesforce (read-only)
+* ``HIVE``               - Apache Hive (read-write, non-Kerberos)
+* ``POSTGRESQL``         - PostgreSQL
+* ``MYSQL``              - MySQL
+* ``MYSQL_HEATWAVE``     - OCI MySQL HeatWave
+* ``SQLSERVER``          - Microsoft SQL Server
+* ``KAFKA``              - Kafka via the format-handler shape
+* ``FUSION_BICC``        - Fusion BICC bulk extracts
+* ``GENERIC_REST``       - any REST API with a manifest
+
+This module exposes one canonical builder, ``aidataplatform_options()``, that
+takes the common keys and lets caller-specific extras flow through. Skills
+that wrap a particular ``type`` should compose this helper rather than
+re-declaring the option dict.
+
+Common ``extra`` options seen across multiple types (added in oracle-samples
+PR #46):
+
+* ``write.mode``       - ``CREATE`` | ``APPEND`` | ``OVERWRITE`` | ``MERGE``
+* ``write.merge.keys`` - comma-separated key columns (when ``write.mode=MERGE``)
+* ``pushdown.sql``     - full SQL pushed at the source instead of
+                         host/schema/table option building
+* ``catalog.id``       - reference an existing AIDP external catalog by id
+                         (replaces host/port/user/password)
+* ``manifest.path``    - workspace/volume path to a REST manifest file
+                         (alternative to ``manifest.url``)
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+
+AIDP_FORMAT = "aidataplatform"
+
+
+def aidataplatform_options(
+    *,
+    type: str,
+    host: Optional[str] = None,
+    port: Optional[int] = None,
+    database_name: Optional[str] = None,
+    user: Optional[str] = None,
+    password: Optional[str] = None,
+    schema: Optional[str] = None,
+    table: Optional[str] = None,
+    extra: Optional[dict] = None,
+) -> dict:
+    """Build an option dict for ``spark.read.format("aidataplatform").options(**...)``.
+
+    Args:
+        type: Connector type - one of the constants documented at the module
+            top. Required.
+        host: DB host or service-FQDN.
+        port: DB port. Coerced to ``str`` because Spark options are stringly
+            typed.
+        database_name: DB/schema name where the type uses one (SQLSERVER,
+            ORACLE_DB, ORACLE_EXADATA on write).
+        user: ``user.name`` option value.
+        password: ``password`` option value.
+        schema: Logical schema (different from ``database_name`` - e.g.
+            Oracle SCHEMA, Postgres schema).
+        table: Source/target table.
+        extra: Any additional ``aidataplatform`` options (e.g. wallet.content,
+            tns, ssl.enabled, manifest.url, fusion.external.storage,
+            datastore, write.mode, catalog.id, pushdown.sql).
+
+    Returns:
+        A dict ready to pass to ``.options(**opts)``. Keys absent in the
+        arguments are absent in the result.
+    """
+    if not type:
+        raise ValueError("aidataplatform_options requires a `type`")
+    opts: dict = {"type": type}
+    if host is not None:
+        opts["host"] = host
+    if port is not None:
+        opts["port"] = str(port)
+    if database_name is not None:
+        opts["database.name"] = database_name
+    if user is not None:
+        opts["user.name"] = user
+    if password is not None:
+        opts["password"] = password
+    if schema is not None:
+        opts["schema"] = schema
+    if table is not None:
+        opts["table"] = table
+    if extra:
+        opts.update(extra)
+    return opts

--- a/plugins/oracle-aidp-connectors/scripts/oracle_ai_data_platform_connectors/auth/__init__.py
+++ b/plugins/oracle-aidp-connectors/scripts/oracle_ai_data_platform_connectors/auth/__init__.py
@@ -1,0 +1,29 @@
+"""Auth helpers for Oracle AIDP Spark connectors.
+
+Re-exports the most commonly used callables so notebooks can do:
+
+    from oracle_ai_data_platform_connectors.auth import (
+        write_wallet_to_tmp,
+        generate_db_token,
+        from_inline_pem,
+        http_basic_session,
+        oauth_token,
+        get_secret,
+    )
+"""
+
+from .wallet import write_wallet_to_tmp
+from .dbtoken import generate_db_token, refresh_on_executors
+from .oci_config import from_inline_pem
+from .user_principal import http_basic_session, oauth_token
+from .secrets import get_secret
+
+__all__ = [
+    "write_wallet_to_tmp",
+    "generate_db_token",
+    "refresh_on_executors",
+    "from_inline_pem",
+    "http_basic_session",
+    "oauth_token",
+    "get_secret",
+]

--- a/plugins/oracle-aidp-connectors/scripts/oracle_ai_data_platform_connectors/auth/dbtoken.py
+++ b/plugins/oracle-aidp-connectors/scripts/oracle_ai_data_platform_connectors/auth/dbtoken.py
@@ -187,7 +187,7 @@ def refresh_on_executors(
 
 def _write_world_readable(path: Path, data: bytes) -> None:
     flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
-    fd = os.open(str(path), flags, 0o666)
+    fd = os.open(str(path), flags, 0o644)
     try:
         os.write(fd, data)
     finally:

--- a/plugins/oracle-aidp-connectors/scripts/oracle_ai_data_platform_connectors/auth/dbtoken.py
+++ b/plugins/oracle-aidp-connectors/scripts/oracle_ai_data_platform_connectors/auth/dbtoken.py
@@ -1,0 +1,194 @@
+"""IAM DB-Token issuance helpers for AIDP notebooks.
+
+Executor-side token refresh is an advanced path: it only works when each
+executor can resolve OCI auth/config and writes token material to the same
+executor-local directory used by the JDBC options. Prefer driver-issued tokens
+for short jobs or a platform-supported credential pattern for long jobs.
+
+Usage from a notebook:
+
+    from oracle_ai_data_platform_connectors.auth.dbtoken import (
+        generate_db_token, refresh_on_executors,
+    )
+
+    # Driver-side: write the initial token to a unique /tmp/aidp-dbtoken-* dir
+    token_path = generate_db_token(
+        compartment_ocid=os.environ["ATP_COMPARTMENT_OCID"],
+    )
+
+    # Set spark JDBC options to use it
+    jdbc_opts = {
+        "driver": "oracle.jdbc.OracleDriver",
+        "oracle.jdbc.tokenAuthentication": "OCI_TOKEN",
+        "oracle.jdbc.tokenLocation": token_path,
+    }
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+import time
+from pathlib import Path
+from typing import Any, Callable, Optional
+
+
+_DEFAULT_REFRESH_AFTER_SECONDS = 25 * 60  # tokens are 1h, refresh at 25 min
+
+
+def generate_db_token(
+    compartment_ocid: str,
+    target_dir: Optional[str] = None,
+    config: Optional[dict] = None,
+    signer: Optional[Any] = None,
+    region: Optional[str] = None,
+) -> str:
+    """Issue an IAM DB token and write it to ``<target_dir>/token``.
+
+    Args:
+        compartment_ocid: Compartment OCID for the DB-token scope. The OCI
+            data-plane endpoint requires
+            ``urn:oracle:db::id::<COMPARTMENT_OCID>``.
+        target_dir: Directory under /tmp where the token file lands. Must be
+            under /tmp for the JDBC driver to read it (FUSE caveat). If omitted,
+            a unique ``/tmp/aidp-dbtoken-*`` directory is created for this run.
+        config: Optional OCI config dict (from ``oci.config.from_file`` or
+            ``from_inline_pem``). If omitted, the helper falls back to the
+            default OCI profile.
+        signer: Optional explicit OCI signer. Mutually-exclusive-ish with
+            ``config`` (oci SDK accepts both for some clients).
+        region: Optional region override for the data-plane client.
+
+    Returns:
+        The directory containing the token file (the value you pass to
+        ``oracle.jdbc.tokenLocation``). NOT the path to the token file
+        itself - the Oracle JDBC driver wants the directory.
+    """
+    import oci  # imported lazily so unit tests don't need oci installed
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric import rsa
+
+    if target_dir is None:
+        target_dir = tempfile.mkdtemp(prefix="aidp-dbtoken-", dir="/tmp")
+        os.chmod(str(target_dir), 0o755)
+
+    _validate_tmp_dir(target_dir)
+
+    Path(target_dir).mkdir(parents=True, exist_ok=True)
+    os.chmod(str(target_dir), 0o755)
+
+    if config is None and signer is None:
+        config = oci.config.from_file()
+    if region:
+        if config is None:
+            config = {}
+        config = {**config, "region": region}
+
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=4096)
+    public_pem = private_key.public_key().public_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PublicFormat.SubjectPublicKeyInfo,
+    ).decode("ascii")
+    private_pem = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+
+    client_kwargs: dict = {}
+    if config is not None:
+        client_kwargs["config"] = config
+    if signer is not None:
+        client_kwargs["signer"] = signer
+
+    client = oci.identity_data_plane.DataplaneClient(**client_kwargs)
+    details = oci.identity_data_plane.models.GenerateScopedAccessTokenDetails(
+        scope=f"urn:oracle:db::id::{compartment_ocid}",
+        public_key=public_pem,
+    )
+    response = client.generate_scoped_access_token(
+        generate_scoped_access_token_details=details,
+    )
+    token = response.data.token
+
+    # Oracle JDBC's OCI_TOKEN auth requires BOTH files in the same directory:
+    #   <target_dir>/token              - the scoped JWT
+    #   <target_dir>/oci_db_key.pem    - the matching private key (proof of possession)
+    # Driver looks for these names by convention; do not rename.
+    _write_world_readable(Path(target_dir) / "token", token.encode("utf-8"))
+    _write_world_readable(Path(target_dir) / "oci_db_key.pem", private_pem)
+    return target_dir
+
+
+def _validate_tmp_dir(target_dir: str) -> None:
+    target_str = str(target_dir).replace("\\", "/").rstrip("/")
+    if target_str != "/tmp" and not target_str.startswith("/tmp/"):
+        raise ValueError(
+            "dbtoken target_dir must be under /tmp; /Workspace breaks JDBC"
+        )
+
+
+def refresh_on_executors(
+    spark: Any,
+    compartment_ocid: str,
+    target_dir: Optional[str] = None,
+    refresh_after_seconds: int = _DEFAULT_REFRESH_AFTER_SECONDS,
+) -> Callable[[Any], Any]:
+    """Return a mapPartitions-callable that refreshes the DB token per executor.
+
+    This is an advanced escape hatch for long-running Spark jobs. It assumes
+    each executor can resolve OCI auth/config and can write to the same
+    executor-local ``target_dir`` already configured as
+    ``oracle.jdbc.tokenLocation``. Do not use it as the default path.
+
+    Example:
+
+        refresh = refresh_on_executors(spark, compartment_ocid, "/tmp/aidp-dbtoken-job")
+        result = (
+            df.rdd.mapPartitions(lambda part: refresh(part))
+                  .toDF()
+        )
+
+    Args:
+        spark: SparkSession (kept for API symmetry).
+        compartment_ocid: same as ``generate_db_token``.
+        target_dir: explicit executor-local token directory already used by
+            the JDBC tokenLocation option.
+        refresh_after_seconds: refresh threshold; defaults to 25 min.
+
+    Returns:
+        A function suitable for ``rdd.mapPartitions`` that ensures a token
+        younger than ``refresh_after_seconds`` exists in ``target_dir``
+        before the partition's user code runs.
+    """
+    if target_dir is None:
+        raise ValueError(
+            "refresh_on_executors requires an explicit target_dir that matches "
+            "the JDBC oracle.jdbc.tokenLocation setting"
+        )
+
+    # Capture state in closure rather than relying on broadcast; each executor
+    # process maintains its own (timestamp, path) pair.
+    _state = {"last_refresh": 0.0}
+
+    def ensure_token(partition_iter):
+        now = time.time()
+        if now - _state["last_refresh"] > refresh_after_seconds:
+            generate_db_token(
+                compartment_ocid=compartment_ocid,
+                target_dir=target_dir,
+            )
+            _state["last_refresh"] = now
+        for row in partition_iter:
+            yield row
+
+    return ensure_token
+
+
+def _write_world_readable(path: Path, data: bytes) -> None:
+    flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
+    fd = os.open(str(path), flags, 0o666)
+    try:
+        os.write(fd, data)
+    finally:
+        os.close(fd)

--- a/plugins/oracle-aidp-connectors/scripts/oracle_ai_data_platform_connectors/auth/oci_config.py
+++ b/plugins/oracle-aidp-connectors/scripts/oracle_ai_data_platform_connectors/auth/oci_config.py
@@ -1,0 +1,48 @@
+"""Build an OCI config dict from an inline PEM string.
+
+The standard ``oci.config.from_file`` reads a key file from disk. In an AIDP
+notebook, secret files often live on /Workspace (FUSE), which intermittently
+disconnects with Errno 107. Passing the PEM body inline as a Python string
+avoids the FUSE round-trip entirely.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+
+def from_inline_pem(
+    user_ocid: str,
+    tenancy_ocid: str,
+    fingerprint: str,
+    private_key_pem: str,
+    region: str,
+    pass_phrase: Optional[str] = None,
+) -> dict:
+    """Return an OCI config dict suitable for ``oci.<service>Client(config=...)``.
+
+    Args:
+        user_ocid: ``ocid1.user.oc1...`` of the OCI user whose API key this is.
+        tenancy_ocid: ``ocid1.tenancy.oc1...``.
+        fingerprint: API key fingerprint (e.g. ``aa:bb:cc:...``).
+        private_key_pem: PEM-encoded private key body, including the
+            ``-----BEGIN PRIVATE KEY-----`` / ``-----END PRIVATE KEY-----``
+            markers and the newlines between them.
+        region: e.g. ``us-ashburn-1``.
+        pass_phrase: Passphrase for the private key, if any.
+
+    Returns:
+        A dict that the OCI Python SDK accepts as the ``config`` argument.
+        The SDK reads the key from the ``key_content`` field rather than
+        ``key_file``, so no on-disk file is created.
+    """
+    config: dict = {
+        "user": user_ocid,
+        "tenancy": tenancy_ocid,
+        "fingerprint": fingerprint,
+        "key_content": private_key_pem,
+        "region": region,
+    }
+    if pass_phrase is not None:
+        config["pass_phrase"] = pass_phrase
+    return config

--- a/plugins/oracle-aidp-connectors/scripts/oracle_ai_data_platform_connectors/auth/secrets.py
+++ b/plugins/oracle-aidp-connectors/scripts/oracle_ai_data_platform_connectors/auth/secrets.py
@@ -1,0 +1,102 @@
+"""Secret loading with an explicit fallback chain.
+
+Order of resolution:
+    1. OCI Vault secret (if ``OCI_VAULT_ID`` is set and the helper can resolve a
+       secret with ``name`` inside it)
+    2. Environment variable ``name`` (uppercase)
+    3. ``default`` parameter (or raise KeyError if not provided)
+
+The Vault path is optional. If no vault id is configured, the helper falls back
+to env vars/defaults. If a vault id is configured and lookup fails, the helper
+raises by default so notebook runs don't silently use the wrong secret source.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Optional
+
+_MISSING = object()
+
+
+def get_secret(
+    name: str,
+    default: Any = _MISSING,
+    vault_id: Optional[str] = None,
+    vault_compartment_id: Optional[str] = None,
+    best_effort_vault: bool = False,
+) -> str:
+    """Resolve ``name`` from OCI Vault -> env var -> default.
+
+    Args:
+        name: The secret name. Used both as the Vault secret name (case-sensitive)
+            and, after uppercasing, as the env-var fallback.
+        default: Returned if the secret can't be resolved anywhere. If left
+            unspecified, a ``KeyError`` is raised instead.
+        vault_id: Optional OCI Vault OCID override. Defaults to the
+            ``OCI_VAULT_ID`` env var.
+        vault_compartment_id: Optional compartment OCID for listing secrets.
+            Defaults to ``OCI_VAULT_COMPARTMENT_OCID`` or the OCI config tenancy.
+        best_effort_vault: If True, failed Vault lookups fall back to env/default.
+            If False, a configured Vault that fails raises immediately.
+
+    Returns:
+        The resolved secret value as a string.
+
+    Raises:
+        KeyError: If no value can be resolved and ``default`` is not provided.
+    """
+    vault_id = vault_id or os.environ.get("OCI_VAULT_ID")
+    vault_compartment_id = (
+        vault_compartment_id
+        or os.environ.get("OCI_VAULT_COMPARTMENT_OCID")
+    )
+    if vault_id:
+        try:
+            return _get_from_vault(name, vault_id, vault_compartment_id)
+        except Exception as exc:
+            if not best_effort_vault:
+                raise RuntimeError(
+                    f"failed to resolve secret {name!r} from OCI Vault {vault_id}"
+                ) from exc
+
+    env_value = os.environ.get(name.upper())
+    if env_value is not None:
+        return env_value
+
+    if default is _MISSING:
+        raise KeyError(
+            f"secret {name!r} not found in OCI Vault, env, or default"
+        )
+    return default
+
+
+def _get_from_vault(
+    name: str,
+    vault_id: str,
+    vault_compartment_id: Optional[str] = None,
+) -> str:
+    """Look up ``name`` as a secret in the given OCI Vault.
+
+    Imported lazily so unit tests don't need ``oci`` installed.
+    """
+    import base64
+    import oci
+
+    config = oci.config.from_file()
+    vaults_client = oci.vault.VaultsClient(config)
+    secrets_client = oci.secrets.SecretsClient(config)
+
+    # The Vault contains many secrets; we have to list and filter by name.
+    secrets = oci.pagination.list_call_get_all_results(
+        vaults_client.list_secrets,
+        compartment_id=vault_compartment_id or config.get("tenancy"),
+        vault_id=vault_id,
+    ).data
+    match = next((s for s in secrets if s.secret_name == name), None)
+    if match is None:
+        raise KeyError(f"secret {name!r} not in vault {vault_id}")
+
+    bundle = secrets_client.get_secret_bundle(secret_id=match.id).data
+    content = bundle.secret_bundle_content.content  # base64-encoded
+    return base64.b64decode(content).decode("utf-8")

--- a/plugins/oracle-aidp-connectors/scripts/oracle_ai_data_platform_connectors/auth/user_principal.py
+++ b/plugins/oracle-aidp-connectors/scripts/oracle_ai_data_platform_connectors/auth/user_principal.py
@@ -1,0 +1,145 @@
+"""HTTP Basic and OAuth helpers for REST-based connectors.
+
+Used by Fusion REST, Fusion BICC trigger, EPM Cloud, Essbase. OAuth path
+is reserved for v0.2 (EPM Cloud / Fusion OAuth profiles); Basic is the
+v0.1 default for all four products per the auth-strategy research.
+"""
+
+from __future__ import annotations
+
+import time
+import uuid
+from typing import FrozenSet, Optional
+
+
+def http_basic_session(
+    username: str,
+    password: str,
+    base_url: Optional[str] = None,
+    timeout: int = 60,
+    retries: int = 3,
+    backoff_factor: float = 1.5,
+    verify_tls: bool = True,
+    allowed_methods: FrozenSet[str] = frozenset(["GET", "HEAD", "OPTIONS"]),
+):
+    """Return a ``requests.Session`` with HTTP Basic auth + retry/backoff.
+
+    Args:
+        username: For EPM Cloud, this must include the identity-domain prefix:
+            ``tenancy.user@domain`` (e.g. ``epmloaner622.first.last@oracle.com``).
+            For Fusion REST, it's the standard Fusion user name. For Essbase 21c
+            on a customer-hosted realm (e.g. ``ess21c.cealinfra.com``), it's the
+            Essbase service-admin username.
+        password: Plain password.
+        base_url: Optional base URL captured on the session for joining
+            relative paths via ``session.get(url, ...)`` later.
+        timeout: Default per-request timeout (seconds).
+        retries: How many times to retry on transient errors (5xx, connection
+            drops). 401/403/404 are NOT retried. By default, retries only apply
+            to idempotent methods so POST/PUT/DELETE calls are not duplicated.
+        backoff_factor: passed to urllib3 ``Retry`` (delay = backoff * 2^attempt).
+        verify_tls: Whether to verify the server's TLS cert. Default ``True``.
+            Set ``False`` for Essbase 21c hosts using internal CA chains the
+            AIDP cluster doesn't trust (e.g. ``cealinfra.com``). When you set
+            this to False, you may also want to call
+            ``urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)``
+            to silence the noisy warning.
+        allowed_methods: HTTP methods eligible for retry. Keep the default for
+            normal reads. Only include mutating methods after confirming the
+            specific API endpoint is idempotent.
+
+    Returns:
+        A configured ``requests.Session``. ``auth`` and ``verify`` are
+        pre-bound, so callers just do ``session.get(...)`` / ``session.post(...)``.
+    """
+    import requests
+    from requests.adapters import HTTPAdapter
+    from urllib3.util.retry import Retry
+
+    session = requests.Session()
+    session.auth = (username, password)
+    session.verify = verify_tls
+    session.headers.update({"Content-Type": "application/json"})
+
+    retry = Retry(
+        total=retries,
+        connect=retries,
+        read=retries,
+        backoff_factor=backoff_factor,
+        status_forcelist=(500, 502, 503, 504),
+        allowed_methods=allowed_methods,
+        raise_on_status=False,
+    )
+    adapter = HTTPAdapter(max_retries=retry)
+    session.mount("http://", adapter)
+    session.mount("https://", adapter)
+
+    # Stash the timeout + base_url on the session for callers that want them.
+    session.request_timeout = timeout  # type: ignore[attr-defined]
+    if base_url:
+        session.base_url = base_url.rstrip("/")  # type: ignore[attr-defined]
+
+    return session
+
+
+def oauth_token(
+    token_url: str,
+    client_id: str,
+    private_key_pem: str,
+    audience: str = "https://identity.oraclecloud.com/",
+    scope: str = "urn:opc:idm:__myscopes__",
+    assertion_lifetime_seconds: int = 300,
+) -> str:
+    """Mint an OAuth2 bearer token via JWT client-credentials.
+
+    Used by EPM Cloud (Option B in v0.2) and Fusion REST OAuth profile.
+    Both IDCS and IAM Domains tenants accept the same payload shape, only
+    the ``token_url`` host differs:
+
+    - IDCS:        ``https://<idcs-instance>.identity.oraclecloud.com/oauth2/v1/token``
+    - IAM Domains: ``https://<iam-domain>.identity.oraclecloud.com/oauth2/v1/token``
+
+    Args:
+        token_url: Full token endpoint URL.
+        client_id: App registration client ID (also goes in ``iss`` and
+            ``sub`` claims for service-to-service flows).
+        private_key_pem: RS256 private key for signing the JWT assertion.
+            Pre-decoded - pass the PEM string body, not a file path.
+        audience: JWT ``aud`` claim. Default works for both IDCS and IAM
+            Domains tenants.
+        scope: OAuth scope. Default ``urn:opc:idm:__myscopes__`` covers
+            most enterprise app scopes.
+        assertion_lifetime_seconds: How long the JWT assertion is valid.
+            Default 5 min; the resulting access token typically has its own
+            longer lifetime (e.g. 60 min).
+
+    Returns:
+        The bearer access token string. Caller passes it as
+        ``Authorization: Bearer <token>``.
+    """
+    import jwt
+    import requests
+
+    now = int(time.time())
+    payload = {
+        "iss": client_id,
+        "sub": client_id,
+        "aud": audience,
+        "exp": now + assertion_lifetime_seconds,
+        "iat": now,
+        "jti": str(uuid.uuid4()),
+    }
+    assertion = jwt.encode(payload, private_key_pem, algorithm="RS256")
+
+    body = {
+        "grant_type": "client_credentials",
+        "client_assertion_type": (
+            "urn:ietf:params:oauth:client-assertion-type:jwt-bearer"
+        ),
+        "client_assertion": assertion,
+        "scope": scope,
+    }
+    response = requests.post(token_url, data=body, timeout=10)
+    response.raise_for_status()
+    data = response.json()
+    return data["access_token"]

--- a/plugins/oracle-aidp-connectors/scripts/oracle_ai_data_platform_connectors/auth/wallet.py
+++ b/plugins/oracle-aidp-connectors/scripts/oracle_ai_data_platform_connectors/auth/wallet.py
@@ -110,7 +110,7 @@ def _copy_dir_to(src: Path, target: Path) -> None:
 
 
 def _write_world_readable(path: Path, data: bytes) -> None:
-    """Write a file with mode 0o666 set up-front via os.open.
+    """Write a file with mode 0o644 set up-front via os.open.
 
     os.chmod does NOT work on FUSE mounts in the AIDP notebook environment, so
     permissions must be applied at file-creation time via the os.open mode
@@ -118,7 +118,7 @@ def _write_world_readable(path: Path, data: bytes) -> None:
     process; without world-readable bits, it can't read the wallet.
     """
     flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
-    fd = os.open(str(path), flags, 0o666)
+    fd = os.open(str(path), flags, 0o644)
     try:
         os.write(fd, data)
     finally:

--- a/plugins/oracle-aidp-connectors/scripts/oracle_ai_data_platform_connectors/auth/wallet.py
+++ b/plugins/oracle-aidp-connectors/scripts/oracle_ai_data_platform_connectors/auth/wallet.py
@@ -1,0 +1,125 @@
+"""Oracle wallet handling for AIDP notebooks.
+
+Wallets MUST live under /tmp - never /Workspace. The /Workspace mount is
+FUSE-backed and disconnects intermittently (Errno 107), and os.chmod is a no-op
+on it, so files cannot be made readable to the Java JDBC driver process.
+"""
+
+from __future__ import annotations
+
+import io
+import os
+import tempfile
+import zipfile
+from pathlib import Path
+from typing import Optional, Union
+
+
+def write_wallet_to_tmp(
+    wallet: Union[bytes, str, Path],
+    target_dir: Optional[Union[str, Path]] = None,
+    set_tns_admin: bool = True,
+) -> str:
+    """Materialize an Oracle wallet under /tmp and (optionally) export TNS_ADMIN.
+
+    Args:
+        wallet: One of:
+            - bytes: a wallet ZIP's raw content (e.g., from OCI Vault).
+            - str/Path: a filesystem path to either a wallet ZIP or an already-
+              extracted wallet directory.
+        target_dir: Where to write. Must be under /tmp (a non-FUSE filesystem)
+            so the JDBC driver process can read the files. If omitted, a unique
+            ``/tmp/aidp-wallet-*`` directory is created for this notebook run.
+        set_tns_admin: If True, set ``os.environ["TNS_ADMIN"]`` to the target
+            directory. The Oracle JDBC driver picks this up automatically.
+
+    Returns:
+        Absolute path of the directory containing the wallet files (the value
+        you'd pass as ``TNS_ADMIN`` to the JDBC URL).
+
+    Raises:
+        ValueError: If ``target_dir`` is not under ``/tmp``.
+        FileNotFoundError: If ``wallet`` is a path that does not exist.
+    """
+    if target_dir is None:
+        target_dir = tempfile.mkdtemp(prefix="aidp-wallet-", dir="/tmp")
+        os.chmod(str(target_dir), 0o755)
+
+    # Validate prefix on the literal string, not the resolved path. On Windows
+    # the AIDP-runtime convention "/tmp/..." resolves to "C:/tmp/..." which
+    # would falsely fail the prefix check. The intent is: in the AIDP Linux
+    # runtime, callers must pass a /tmp/... string.
+    _validate_tmp_dir(target_dir)
+
+    target = Path(target_dir)
+    target.mkdir(parents=True, exist_ok=True)
+    os.chmod(str(target), 0o755)
+
+    # Validate the wallet source EXISTS before creating the target directory
+    # - otherwise we leave an empty /tmp/... dir behind on every bad call.
+    if isinstance(wallet, (str, Path)):
+        src = Path(wallet)
+        if not src.exists():
+            raise FileNotFoundError(f"wallet path does not exist: {src}")
+
+    if isinstance(wallet, (bytes, bytearray, memoryview)):
+        # Spark's binaryFile reader hands back bytearray, not bytes. Accept either.
+        _extract_zip_bytes_to(bytes(wallet), target)
+    else:
+        src = Path(wallet)
+        if src.is_file() and src.suffix.lower() == ".zip":
+            with src.open("rb") as fh:
+                _extract_zip_bytes_to(fh.read(), target)
+        elif src.is_dir():
+            _copy_dir_to(src, target)
+        else:
+            raise ValueError(
+                f"wallet path must be a .zip or a directory, got {src}"
+            )
+
+    if set_tns_admin:
+        os.environ["TNS_ADMIN"] = str(target)
+
+    return str(target)
+
+
+def _validate_tmp_dir(target_dir: Union[str, Path]) -> None:
+    target_str = str(target_dir).replace("\\", "/").rstrip("/")
+    if target_str != "/tmp" and not target_str.startswith("/tmp/"):
+        raise ValueError(
+            "wallet target_dir must be under /tmp; "
+            "/Workspace is FUSE-mounted and breaks JDBC reads"
+        )
+
+
+def _extract_zip_bytes_to(zip_bytes: bytes, target: Path) -> None:
+    """Extract a wallet ZIP to ``target`` with world-readable permissions."""
+    with zipfile.ZipFile(io.BytesIO(zip_bytes)) as zf:
+        for member in zf.namelist():
+            if member.endswith("/"):
+                continue
+            data = zf.read(member)
+            out_path = target / Path(member).name
+            _write_world_readable(out_path, data)
+
+
+def _copy_dir_to(src: Path, target: Path) -> None:
+    for child in src.iterdir():
+        if child.is_file():
+            _write_world_readable(target / child.name, child.read_bytes())
+
+
+def _write_world_readable(path: Path, data: bytes) -> None:
+    """Write a file with mode 0o666 set up-front via os.open.
+
+    os.chmod does NOT work on FUSE mounts in the AIDP notebook environment, so
+    permissions must be applied at file-creation time via the os.open mode
+    bits. The JDBC driver process runs as a different UID than the Python
+    process; without world-readable bits, it can't read the wallet.
+    """
+    flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
+    fd = os.open(str(path), flags, 0o666)
+    try:
+        os.write(fd, data)
+    finally:
+        os.close(fd)

--- a/plugins/oracle-aidp-connectors/scripts/oracle_ai_data_platform_connectors/excel.py
+++ b/plugins/oracle-aidp-connectors/scripts/oracle_ai_data_platform_connectors/excel.py
@@ -1,0 +1,119 @@
+"""Excel ingestion helper using only the Python standard library.
+
+The two paths the official AIDP sample documents (the Crealytics
+``com.crealytics.spark.excel`` JAR and ``pandas.read_excel``+ ``openpyxl``)
+both require an install - a cluster JAR or a Python wheel. AIDP clusters
+commonly have neither (PyPI is unreachable; Maven Central is, but the
+Crealytics dependency closure is large).
+
+This module is a third path: parse the .xlsx with stdlib ``zipfile`` +
+``xml.etree.ElementTree``. .xlsx is a ZIP of XML files; sharedStrings.xml +
+worksheets/sheet1.xml together carry the cell data we need for read-only
+ingestion. No extra deps - works on any AIDP cluster regardless of PyPI /
+Maven access.
+
+Limitations:
+* Read-only. There's no stdlib path to write .xlsx without ``openpyxl`` or
+  similar; if you need to write Excel, install ``openpyxl`` or use one of
+  the JAR-based options.
+* Reads the FIRST sheet only (``xl/worksheets/sheet1.xml``). For multi-sheet
+  workbooks, list the sheets first and pass the right path.
+* Cell type coercion is "best effort" - numeric cells are int or float;
+  shared-string cells are strings; booleans are converted; everything else
+  passes through as the raw text.
+"""
+
+from __future__ import annotations
+
+import zipfile
+import xml.etree.ElementTree as ET
+from typing import Any, List, Optional
+
+
+_NS = "{http://schemas.openxmlformats.org/spreadsheetml/2006/main}"
+
+
+def _parse_shared_strings(zf: zipfile.ZipFile) -> List[str]:
+    """Return the workbook's shared-strings table, or [] if absent."""
+    if "xl/sharedStrings.xml" not in zf.namelist():
+        return []
+    root = ET.fromstring(zf.read("xl/sharedStrings.xml"))
+    out: List[str] = []
+    for si in root.iter(f"{_NS}si"):
+        # Each <si> may have one <t> directly or several <r><t> runs;
+        # concatenate all <t> nodes in document order.
+        out.append("".join((t.text or "") for t in si.iter(f"{_NS}t")))
+    return out
+
+
+def _coerce_cell(text: Optional[str]) -> Any:
+    if text is None:
+        return None
+    if "." in text:
+        try:
+            return float(text)
+        except ValueError:
+            return text
+    try:
+        return int(text)
+    except ValueError:
+        return text
+
+
+def read_xlsx_stdlib(
+    path: str,
+    *,
+    sheet_path: str = "xl/worksheets/sheet1.xml",
+) -> List[List[Any]]:
+    """Read a small .xlsx file using only the Python standard library.
+
+    Args:
+        path: Filesystem path to the .xlsx (Volume-mounted or ``/tmp/...``).
+        sheet_path: Internal path of the sheet inside the .xlsx zip.
+            Default is the first sheet. For other sheets, look at the
+            workbook's ``xl/workbook.xml`` to find the right name.
+
+    Returns:
+        List of rows, each row is a list of cell values. The first row is
+        commonly the header; callers typically pop it.
+
+    Example:
+        >>> rows = read_xlsx_stdlib("/Volumes/.../data.xlsx")
+        >>> header, *body = rows
+        >>> df = spark.createDataFrame(body, schema=header)
+    """
+    with zipfile.ZipFile(path) as z:
+        strings = _parse_shared_strings(z)
+        if sheet_path not in z.namelist():
+            raise FileNotFoundError(
+                f"Sheet not found in xlsx: {sheet_path}. "
+                f"Available: {[n for n in z.namelist() if n.startswith('xl/worksheets/')]}"
+            )
+        sheet = ET.fromstring(z.read(sheet_path))
+
+    rows: List[List[Any]] = []
+    for r in sheet.iter(f"{_NS}row"):
+        row: List[Any] = []
+        for c in r.findall(f"{_NS}c"):
+            t = c.get("t", "n")
+            v = c.find(f"{_NS}v")
+            if v is None or v.text is None:
+                row.append(None)
+                continue
+            if t == "s":
+                row.append(strings[int(v.text)])
+            elif t == "b":
+                row.append(bool(int(v.text)))
+            elif t == "inlineStr":
+                # Inline string - embedded <is><t>...</t></is>
+                is_node = c.find(f"{_NS}is")
+                if is_node is not None:
+                    row.append(
+                        "".join((tn.text or "") for tn in is_node.iter(f"{_NS}t"))
+                    )
+                else:
+                    row.append(_coerce_cell(v.text))
+            else:
+                row.append(_coerce_cell(v.text))
+        rows.append(row)
+    return rows

--- a/plugins/oracle-aidp-connectors/scripts/oracle_ai_data_platform_connectors/jdbc/__init__.py
+++ b/plugins/oracle-aidp-connectors/scripts/oracle_ai_data_platform_connectors/jdbc/__init__.py
@@ -1,0 +1,23 @@
+"""JDBC URL builders + Spark JDBC option helpers."""
+
+from .oracle import (
+    build_oracle_jdbc_url,
+    spark_jdbc_options_wallet,
+    spark_jdbc_options_dbtoken,
+    spark_jdbc_options_password,
+)
+from .runtime_load import (
+    add_jdbc_jar_at_runtime,
+    add_spark_connector_at_runtime,
+    download_jdbc_jar,
+)
+
+__all__ = [
+    "build_oracle_jdbc_url",
+    "spark_jdbc_options_wallet",
+    "spark_jdbc_options_dbtoken",
+    "spark_jdbc_options_password",
+    "add_jdbc_jar_at_runtime",
+    "add_spark_connector_at_runtime",
+    "download_jdbc_jar",
+]

--- a/plugins/oracle-aidp-connectors/scripts/oracle_ai_data_platform_connectors/jdbc/oracle.py
+++ b/plugins/oracle-aidp-connectors/scripts/oracle_ai_data_platform_connectors/jdbc/oracle.py
@@ -1,0 +1,139 @@
+"""Oracle JDBC URL + Spark options builders.
+
+Used by the ALH, ATP, and ExaCS skills. ALH is plain Oracle 26ai under the
+hood - same driver, same URL pattern, same TNS service-name shape - so the
+three skills share this module.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+ORACLE_DRIVER = "oracle.jdbc.OracleDriver"
+
+
+def build_oracle_jdbc_url(
+    host: Optional[str] = None,
+    port: int = 1522,
+    service_name: Optional[str] = None,
+    tns_alias: Optional[str] = None,
+    tns_admin: Optional[str] = None,
+    use_tcps: bool = True,
+) -> str:
+    """Build an Oracle thin-JDBC URL.
+
+    Two shapes are supported:
+
+    1. **Direct host/port/service** (ExaCS, plain Oracle):
+       ``jdbc:oracle:thin:@tcps://<host>:<port>/<service>``
+
+    2. **TNS alias** (ALH, ATP wallet flow):
+       ``jdbc:oracle:thin:@<tns_alias>?TNS_ADMIN=<dir>``
+
+    Args:
+        host: Hostname for direct mode. Mutually exclusive with ``tns_alias``.
+        port: Port for direct mode. Default 1522 (TCPS).
+        service_name: Oracle service name for direct mode (NOT a SID).
+        tns_alias: TNS alias from ``tnsnames.ora`` (e.g. ``alh_high``,
+            ``atp_high``).
+        tns_admin: Path to the directory containing ``tnsnames.ora`` /
+            ``sqlnet.ora`` / ``cwallet.sso``. Only relevant for the TNS-alias
+            mode. Helper appends ``?TNS_ADMIN=...`` to the URL so the JDBC
+            driver finds the wallet without an env-var dance.
+        use_tcps: Direct mode only - whether to prefix with ``tcps://`` (TLS).
+            Set to False for plain TCP (rare, only for legacy on-prem).
+
+    Returns:
+        A JDBC URL string.
+
+    Raises:
+        ValueError: If neither (host+service_name) nor tns_alias is given.
+    """
+    if tns_alias:
+        url = f"jdbc:oracle:thin:@{tns_alias}"
+        if tns_admin:
+            url += f"?TNS_ADMIN={tns_admin}"
+        return url
+
+    if not (host and service_name):
+        raise ValueError(
+            "build_oracle_jdbc_url requires either tns_alias or (host + service_name)"
+        )
+
+    proto = "tcps" if use_tcps else "tcp"
+    return f"jdbc:oracle:thin:@{proto}://{host}:{port}/{service_name}"
+
+
+def spark_jdbc_options_wallet(
+    url: str,
+    user: str,
+    password: str,
+    *,
+    fetchsize: int = 10_000,
+    timezone_as_region: bool = False,
+) -> dict:
+    """Spark JDBC options for wallet (mTLS) auth.
+
+    The wallet itself must already be on disk under a transient ``/tmp``
+    directory and the URL must include ``?TNS_ADMIN=...`` (or ``TNS_ADMIN`` env
+    var must be set). See
+    ``oracle_ai_data_platform_connectors.auth.wallet.write_wallet_to_tmp``.
+    """
+    return {
+        "url": url,
+        "driver": ORACLE_DRIVER,
+        "user": user,
+        "password": password,
+        "fetchsize": str(fetchsize),
+        "oracle.jdbc.timezoneAsRegion": str(timezone_as_region).lower(),
+    }
+
+
+def spark_jdbc_options_dbtoken(
+    url: str,
+    token_dir: str,
+    *,
+    fetchsize: int = 10_000,
+    timezone_as_region: bool = False,
+) -> dict:
+    """Spark JDBC options for IAM DB-Token auth.
+
+    Args:
+        url: The same URL as the wallet path (TCPS, port 1522, service name).
+        token_dir: Directory under /tmp containing the ``token`` file. See
+            ``oracle_ai_data_platform_connectors.auth.dbtoken.generate_db_token``.
+        fetchsize: JDBC fetch size.
+        timezone_as_region: Forwarded as ``oracle.jdbc.timezoneAsRegion``.
+            Default False - avoids the well-known TZ region warning.
+
+    Note:
+        DB-Token auth needs `user`/`password` to be unset; the JDBC driver
+        reads the token from ``oracle.jdbc.tokenLocation``.
+    """
+    return {
+        "url": url,
+        "driver": ORACLE_DRIVER,
+        "oracle.jdbc.tokenAuthentication": "OCI_TOKEN",
+        "oracle.jdbc.tokenLocation": token_dir,
+        "fetchsize": str(fetchsize),
+        "oracle.jdbc.timezoneAsRegion": str(timezone_as_region).lower(),
+    }
+
+
+def spark_jdbc_options_password(
+    url: str,
+    user: str,
+    password: str,
+    *,
+    fetchsize: int = 10_000,
+    timezone_as_region: bool = False,
+) -> dict:
+    """Plain user/password Spark JDBC options (legacy DB user, e.g. ExaCS)."""
+    return {
+        "url": url,
+        "driver": ORACLE_DRIVER,
+        "user": user,
+        "password": password,
+        "fetchsize": str(fetchsize),
+        "oracle.jdbc.timezoneAsRegion": str(timezone_as_region).lower(),
+    }

--- a/plugins/oracle-aidp-connectors/scripts/oracle_ai_data_platform_connectors/jdbc/runtime_load.py
+++ b/plugins/oracle-aidp-connectors/scripts/oracle_ai_data_platform_connectors/jdbc/runtime_load.py
@@ -1,0 +1,204 @@
+"""Load JDBC drivers and Spark DataSource JARs into a running AIDP Spark session at runtime.
+
+Spark's normal mechanism for adding a driver / DataSource JAR is to set
+``spark.jars`` at session creation time, which means stopping the kernel and
+re-bootstrapping the notebook context. That's awkward in AIDP because the
+notebook itself owns the SparkSession lifecycle.
+
+This module does it without restarting:
+
+* The **driver** JVM gets a new ``URLClassLoader`` rooted at the existing
+  thread context CL, with the JARs added. The loader is set as the thread
+  context CL so ``ServiceLoader`` (used by Spark to look up DataSources) and
+  ``Utils.classForName`` (used by JDBC) resolve the classes. For JDBC drivers
+  specifically, the driver class is also registered with
+  ``java.sql.DriverManager`` so any code path that goes through
+  ``DriverManager.getConnection`` finds it.
+
+* The **executors** receive the JARs via ``SparkContext.addJar()``. Without
+  this step, Spark can serialize task code that references the new classes
+  but executors can't deserialize it (``ClassNotFoundException`` deep in
+  ``ObjectInputStream.resolveClass``). Add-jar uploads each JAR to the
+  driver's HTTP file-server and adds it to each executor's
+  ``ExecutorClassLoader`` chain.
+
+Use ``add_spark_connector_at_runtime`` for Spark DataSource JARs (Snowflake,
+spark-excel, custom format providers). Use ``add_jdbc_jar_at_runtime`` for
+plain JDBC drivers (SQLite, ClickHouse, DuckDB, IBM DB2 ...).
+
+Two patterns covered:
+* SQLite JDBC and similar (no executor distribution needed - driver-only).
+* Snowflake-style Spark connectors (needs both driver and executor distribution).
+
+Maven Central is reachable from AIDP clusters; PyPI is not.
+"""
+
+from __future__ import annotations
+
+from typing import Iterable, Optional
+
+
+# Internal helper: shared classloader-rewire logic
+def _install_urlclassloader(spark, jar_paths: Iterable[str]):
+    """Build a URLClassLoader rooted at the current thread CL covering ``jar_paths``,
+    set it as the thread context class loader, and return it.
+    """
+    jar_paths = list(jar_paths)
+    jvm = spark._jvm
+    gw = spark.sparkContext._gateway
+
+    urls = gw.new_array(jvm.java.net.URL, len(jar_paths))
+    for i, p in enumerate(jar_paths):
+        urls[i] = jvm.java.io.File(p).toURI().toURL()
+
+    parent = jvm.java.lang.Thread.currentThread().getContextClassLoader()
+    loader = jvm.java.net.URLClassLoader(urls, parent)
+    jvm.java.lang.Thread.currentThread().setContextClassLoader(loader)
+    return loader
+
+
+def _distribute_to_executors(spark, jar_paths: Iterable[str]) -> None:
+    """Push JARs to executors via the SparkContext's HTTP file-server."""
+    for p in jar_paths:
+        spark._jsc.addJar(p)
+
+
+def add_jdbc_jar_at_runtime(
+    spark,
+    *,
+    jar_path: str,
+    driver_class: str,
+    distribute_to_executors: bool = True,
+) -> None:
+    """Make a JDBC driver class loadable in the current Spark session.
+
+    Args:
+        spark: The active ``SparkSession``.
+        jar_path: Filesystem path to the JDBC driver JAR. Must be visible to
+            the driver JVM - typically ``/tmp/...`` (after a download) or
+            ``/Volumes/...``.
+        driver_class: The JDBC driver class name, e.g. ``org.sqlite.JDBC``.
+        distribute_to_executors: If True (default), also call ``addJar`` so
+            executors fetch the JAR. Required when the JDBC read partitions
+            execute on multiple executors. Pass False only for fully
+            driver-local cases like in-memory SQLite.
+
+    Example:
+        >>> jar = download_jdbc_jar(
+        ...     maven_url="https://repo1.maven.org/maven2/org/xerial/"
+        ...               "sqlite-jdbc/3.46.0.0/sqlite-jdbc-3.46.0.0.jar",
+        ...     target_path="/tmp/sqlite-jdbc-3.46.0.0.jar")
+        >>> add_jdbc_jar_at_runtime(spark, jar_path=jar,
+        ...                         driver_class="org.sqlite.JDBC")
+    """
+    jvm = spark._jvm
+    loader = _install_urlclassloader(spark, [jar_path])
+
+    cls = loader.loadClass(driver_class)
+    driver = cls.newInstance()
+    jvm.java.sql.DriverManager.registerDriver(driver)
+
+    if distribute_to_executors:
+        _distribute_to_executors(spark, [jar_path])
+
+
+def add_spark_connector_at_runtime(
+    spark,
+    *,
+    jar_paths: Iterable[str],
+    verify_classes: Optional[Iterable[str]] = None,
+    register_jdbc_driver_class: Optional[str] = None,
+) -> None:
+    """Install a Spark DataSource (and optionally a JDBC driver) at runtime.
+
+    Use this for connectors that register a Spark format via
+    ``META-INF/services/org.apache.spark.sql.sources.DataSourceRegister``.
+    Examples:
+
+    * Snowflake (``net.snowflake.spark.snowflake.DefaultSource`` registered as
+      ``snowflake``).
+    * Crealytics Spark Excel
+      (``com.crealytics.spark.excel.WorkbookReader`` and the v2 source).
+    * Any third-party DataSource the user has on a Volume.
+
+    Args:
+        spark: The active ``SparkSession``.
+        jar_paths: All JARs the connector needs (typically the connector JAR
+            plus its JDBC driver JAR; e.g. for Snowflake pass both
+            ``spark-snowflake_2.12-X.Y.Z.jar`` and ``snowflake-jdbc-X.Y.Z.jar``).
+        verify_classes: Optional list of class names to load through the new
+            class loader as a sanity check before returning. If any class is
+            missing, ``ClassNotFoundException`` propagates.
+        register_jdbc_driver_class: If provided, also register an instance of
+            this JDBC driver with ``DriverManager`` (needed for connectors
+            that fall through to JDBC for some operations - e.g. Snowflake).
+
+    Example (Snowflake):
+        >>> add_spark_connector_at_runtime(
+        ...     spark,
+        ...     jar_paths=[
+        ...         "/tmp/spark-snowflake_2.12-3.1.1.jar",
+        ...         "/tmp/snowflake-jdbc-3.19.0.jar",
+        ...     ],
+        ...     verify_classes=[
+        ...         "net.snowflake.spark.snowflake.DefaultSource",
+        ...         "net.snowflake.client.jdbc.SnowflakeDriver",
+        ...     ],
+        ...     register_jdbc_driver_class="net.snowflake.client.jdbc.SnowflakeDriver",
+        ... )
+        >>> df = (spark.read.format("snowflake")
+        ...           .options(**snow_opts).option("query", "SELECT 1").load())
+    """
+    jvm = spark._jvm
+    loader = _install_urlclassloader(spark, jar_paths)
+
+    if verify_classes:
+        for cn in verify_classes:
+            loader.loadClass(cn)  # raises if missing
+
+    if register_jdbc_driver_class:
+        cls = loader.loadClass(register_jdbc_driver_class)
+        driver = cls.newInstance()
+        jvm.java.sql.DriverManager.registerDriver(driver)
+
+    _distribute_to_executors(spark, jar_paths)
+
+
+def download_jdbc_jar(
+    *,
+    maven_url: str,
+    target_path: str,
+    overwrite: bool = False,
+    sha256: Optional[str] = None,
+) -> str:
+    """Convenience wrapper around urllib to fetch a driver JAR from Maven Central.
+
+    Args:
+        maven_url: Full URL to the JAR.
+        target_path: Where to write it - must be JVM-readable (``/tmp/...`` is
+            recommended).
+        overwrite: If False (default) and the target already exists, skip the
+            download.
+        sha256: Optional expected SHA-256 hex digest. Provide it when using
+            runtime downloads in shared or regulated environments.
+
+    Returns:
+        ``target_path`` for chaining.
+    """
+    import hashlib
+    import os
+    import urllib.request
+
+    if overwrite or not os.path.exists(target_path):
+        urllib.request.urlretrieve(maven_url, target_path)
+    if sha256:
+        digest = hashlib.sha256()
+        with open(target_path, "rb") as fh:
+            for chunk in iter(lambda: fh.read(1024 * 1024), b""):
+                digest.update(chunk)
+        actual = digest.hexdigest()
+        if actual.lower() != sha256.lower():
+            raise ValueError(
+                f"SHA-256 mismatch for {target_path}: expected {sha256}, got {actual}"
+            )
+    return target_path

--- a/plugins/oracle-aidp-connectors/scripts/oracle_ai_data_platform_connectors/rest/__init__.py
+++ b/plugins/oracle-aidp-connectors/scripts/oracle_ai_data_platform_connectors/rest/__init__.py
@@ -1,0 +1,5 @@
+"""REST -> Spark DataFrame helpers for non-JDBC Oracle SaaS sources."""
+
+from . import essbase, epm, fusion
+
+__all__ = ["fusion", "epm", "essbase"]

--- a/plugins/oracle-aidp-connectors/scripts/oracle_ai_data_platform_connectors/rest/epm.py
+++ b/plugins/oracle-aidp-connectors/scripts/oracle_ai_data_platform_connectors/rest/epm.py
@@ -1,0 +1,114 @@
+"""Oracle EPM Cloud Planning REST helpers.
+
+Exports MDX-style data slices via the documented
+``/HyperionPlanning/rest/v3/applications/{app}/plantypes/{planType}/exportdataslice``
+endpoint and turns the result into a Spark DataFrame.
+
+v0.1 ships HTTP Basic only (default for current EPM Cloud, works today).
+v0.2 adds OAuth via JWT client-credentials (helper already in
+``oracle_ai_data_platform_connectors.auth.user_principal.oauth_token``).
+"""
+
+from __future__ import annotations
+
+from typing import Any, List, Optional
+
+
+def list_applications(session: Any, base_url: str) -> List[dict]:
+    """Sanity-check call: lists Planning applications visible to the caller.
+
+    Use this as a pre-flight to detect 401s early without paying for a full
+    MDX export. Returns the ``items`` list from the response.
+    """
+    base_url = base_url.rstrip("/")
+    response = session.get(
+        f"{base_url}/HyperionPlanning/rest/v3/applications",
+        timeout=60,
+    )
+    response.raise_for_status()
+    payload = response.json()
+    return payload.get("items", [])
+
+
+def export_data_slice(
+    session: Any,
+    base_url: str,
+    application: str,
+    plan_type: str,
+    grid_definition: dict,
+    *,
+    timeout: int = 120,
+) -> dict:
+    """Run a Planning data-slice export.
+
+    Args:
+        session: ``requests.Session`` with Basic auth. The username MUST be
+            in identity-domain form: ``tenancy.user@domain``
+            (e.g. ``epmloaner622.first.last@oracle.com``).
+        base_url: EPM pod base URL
+            (``https://epm-<id>.epm.<region>.ocs.oraclecloud.com``).
+        application: Planning application name (e.g. ``"Vision"``).
+        plan_type: Plan type within the app (e.g. ``"Plan1"``).
+        grid_definition: A dict matching the ``gridDefinition`` shape:
+            ``{"suppressMissingBlocks": True, "pov": {...}, "columns": [...], "rows": [...]}``.
+            POV members must be **leaf-level** - use ``IChildren(parent)`` etc.
+            to expand parents server-side.
+        timeout: Per-request timeout in seconds. EPM exports can be slow for
+            large slices; 120s is conservative.
+
+    Returns:
+        The parsed JSON response (``{"pov": [...], "columns": [...], "rows": [...]}``).
+    """
+    base_url = base_url.rstrip("/")
+    url = (
+        f"{base_url}/HyperionPlanning/rest/v3/"
+        f"applications/{application}/plantypes/{plan_type}/exportdataslice"
+    )
+    body = {
+        "exportPlanningData": False,
+        "gridDefinition": grid_definition,
+    }
+    response = session.post(url, json=body, timeout=timeout)
+    response.raise_for_status()
+    return response.json()
+
+
+def slice_to_long_dataframe(spark: Any, slice_response: dict):
+    """Convert an EPM data-slice response into a long-format Spark DataFrame.
+
+    Output columns: ``pov_<dim>...``, ``column_<dim>...``, ``row_<dim>...``,
+    ``value`` (string - the raw EPM value, including ``"#Missing"``).
+
+    Useful when you don't know up-front how many columns/rows the slice
+    contains and want a tidy long form to aggregate from.
+    """
+    import pandas as pd
+
+    pov_dims: list = slice_response.get("pov", [])
+    columns_grid: list = slice_response.get("columns", [])
+    rows: list = slice_response.get("rows", [])
+
+    out_records: list = []
+    # columns_grid is a list of [member, member, ...] one per column.
+    # rows is a list of {"headers": [...], "data": [...]}.
+    for row in rows:
+        row_headers = row.get("headers", [])
+        for col_index, value in enumerate(row.get("data", [])):
+            col_headers = (
+                columns_grid[col_index]
+                if col_index < len(columns_grid)
+                else []
+            )
+            record: dict = {"value": value}
+            for i, member in enumerate(pov_dims):
+                record[f"pov_{i}"] = member
+            for i, member in enumerate(col_headers):
+                record[f"column_{i}"] = member
+            for i, member in enumerate(row_headers):
+                record[f"row_{i}"] = member
+            out_records.append(record)
+
+    if not out_records:
+        return spark.createDataFrame([], "value STRING")
+    pdf = pd.DataFrame(out_records)
+    return spark.createDataFrame(pdf)

--- a/plugins/oracle-aidp-connectors/scripts/oracle_ai_data_platform_connectors/rest/essbase.py
+++ b/plugins/oracle-aidp-connectors/scripts/oracle_ai_data_platform_connectors/rest/essbase.py
@@ -1,0 +1,80 @@
+"""Essbase 21c REST + MDX helpers.
+
+Essbase is REST-only over HTTP Basic. The MDX endpoint accepts a query and
+returns a tabular result that maps cleanly onto a Spark DataFrame.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+
+def execute_mdx(
+    session: Any,
+    base_url: str,
+    application: str,
+    cube: str,
+    mdx_query: str,
+    *,
+    timeout: int = 120,
+) -> dict:
+    """Execute an MDX query against an Essbase cube.
+
+    Args:
+        session: ``requests.Session`` with HTTP Basic auth.
+        base_url: Essbase REST base, e.g.
+            ``https://<host>:9000/essbase/rest/v1``.
+        application: Application name (e.g. ``"Sample"``).
+        cube: Cube/database name (e.g. ``"Basic"``).
+        mdx_query: The MDX SELECT statement.
+        timeout: Per-request timeout (seconds).
+
+    Returns:
+        Parsed JSON response containing axes and cells.
+    """
+    base_url = base_url.rstrip("/")
+    url = (
+        f"{base_url}/applications/{application}/databases/{cube}/data"
+    )
+    body = {"query": mdx_query, "queryType": "MDX"}
+    response = session.post(url, json=body, timeout=timeout)
+    response.raise_for_status()
+    return response.json()
+
+
+def mdx_result_to_spark_dataframe(spark: Any, mdx_response: dict):
+    """Convert an Essbase MDX response into a Spark DataFrame.
+
+    Essbase returns axes (rows / columns / pages / pov) plus cell values.
+    The helper flattens to one row per cell with one column per axis dimension.
+    """
+    import pandas as pd
+
+    axes = mdx_response.get("axes", [])
+    cells = mdx_response.get("cells", [])
+
+    # Axes order (per Essbase REST): [ROWS, COLUMNS, PAGES, POV].
+    rows_axis = axes[0] if len(axes) > 0 else {"tuples": []}
+    cols_axis = axes[1] if len(axes) > 1 else {"tuples": []}
+
+    row_tuples = rows_axis.get("tuples", [])
+    col_tuples = cols_axis.get("tuples", [])
+
+    # cells is a flat list, ordered (row * n_cols) + col.
+    n_cols = max(len(col_tuples), 1)
+    out: list = []
+    for idx, cell in enumerate(cells):
+        row_idx = idx // n_cols
+        col_idx = idx % n_cols
+        record: dict = {"value": cell.get("value")}
+        if row_idx < len(row_tuples):
+            for i, member in enumerate(row_tuples[row_idx].get("members", [])):
+                record[f"row_{i}"] = member.get("name")
+        if col_idx < len(col_tuples):
+            for i, member in enumerate(col_tuples[col_idx].get("members", [])):
+                record[f"column_{i}"] = member.get("name")
+        out.append(record)
+
+    if not out:
+        return spark.createDataFrame([], "value STRING")
+    return spark.createDataFrame(pd.DataFrame(out))

--- a/plugins/oracle-aidp-connectors/scripts/oracle_ai_data_platform_connectors/rest/fusion.py
+++ b/plugins/oracle-aidp-connectors/scripts/oracle_ai_data_platform_connectors/rest/fusion.py
@@ -1,0 +1,261 @@
+"""Oracle Fusion REST + BICC helpers.
+
+Two distinct flows:
+- ``fetch_paged()`` for live REST calls (<= 499 rows/page hard cap per MOS 2429019.1).
+- ``trigger_bicc_extract()`` + ``read_bicc_csv_from_object_storage()`` for bulk
+  extracts that land as gzipped CSV in OCI Object Storage.
+"""
+
+from __future__ import annotations
+
+import io
+import time
+from typing import Any, Iterator, Optional
+
+# Per Oracle MOS Doc ID 2429019.1
+FUSION_PAGE_LIMIT_HARD_CAP = 499
+
+
+def fetch_paged(
+    session: Any,
+    base_url: str,
+    path: str,
+    *,
+    limit: int = FUSION_PAGE_LIMIT_HARD_CAP,
+    fields: Optional[str] = None,
+    extra_params: Optional[dict] = None,
+) -> Iterator[dict]:
+    """Yield rows from a Fusion REST resource, page by page.
+
+    Args:
+        session: A ``requests.Session`` from
+            ``oracle_ai_data_platform_connectors.auth.user_principal.http_basic_session``.
+        base_url: Fusion pod base URL (e.g.
+            ``https://my-pod.fa.us-phoenix-1.oraclecloud.com``).
+        path: Resource path beneath base_url (e.g.
+            ``/fscmRestApi/resources/11.13.18.05/invoices``).
+        limit: Page size. **Hard-capped at 499 by Fusion.** Anything higher is
+            silently truncated server-side.
+        fields: Comma-separated list of field names to project. Lets you avoid
+            pulling unneeded columns.
+        extra_params: Additional query params (e.g. ``q=...`` filters).
+
+    Yields:
+        One Python dict per row.
+    """
+    if limit > FUSION_PAGE_LIMIT_HARD_CAP:
+        limit = FUSION_PAGE_LIMIT_HARD_CAP
+
+    base_url = base_url.rstrip("/")
+    offset = 0
+    while True:
+        params = {
+            "limit": limit,
+            "offset": offset,
+            "onlyData": "true",
+        }
+        if fields:
+            params["fields"] = fields
+        if extra_params:
+            params.update(extra_params)
+
+        url = f"{base_url}{path}"
+        response = session.get(url, params=params, timeout=120)
+        response.raise_for_status()
+        payload = response.json()
+        items = payload.get("items", [])
+        if not items:
+            return
+        yield from items
+
+        if not payload.get("hasMore", False):
+            return
+        offset += limit
+
+
+def trigger_bicc_extract(
+    session: Any,
+    base_url: str,
+    offering: str,
+    *,
+    poll_interval_seconds: int = 30,
+    timeout_seconds: int = 3600,
+) -> str:
+    """Trigger a BICC extract job and wait for completion.
+
+    Args:
+        session: ``requests.Session`` with HTTP Basic auth (BICC trigger side).
+        base_url: Fusion pod base URL (same as REST).
+        offering: BICC offering ID (e.g. ``"FscmTopModelAM.AnalyticsServiceAM"``).
+        poll_interval_seconds: How often to poll status. Default 30s.
+        timeout_seconds: Give up after this many seconds. Default 1h.
+
+    Returns:
+        The OCI Object Storage prefix (relative to your BICC bucket) where
+        the extract's gzipped CSV files landed. Pass this to
+        ``read_bicc_csv_from_object_storage()`` to materialize as a Spark
+        DataFrame.
+    """
+    base_url = base_url.rstrip("/")
+    submit_path = "/biacm/api/v2/extracts/run"
+    response = session.post(
+        f"{base_url}{submit_path}",
+        json={"offeringName": offering},
+        timeout=60,
+    )
+    response.raise_for_status()
+    job_id = response.json()["jobId"]
+
+    deadline = time.time() + timeout_seconds
+    while time.time() < deadline:
+        status_response = session.get(
+            f"{base_url}/biacm/api/v2/extracts/{job_id}",
+            timeout=60,
+        )
+        status_response.raise_for_status()
+        status = status_response.json()
+        state = status.get("status", "").upper()
+        if state in ("SUCCEEDED", "COMPLETED"):
+            return status["outputPrefix"]
+        if state in ("FAILED", "CANCELLED", "ERROR"):
+            raise RuntimeError(f"BICC extract failed: {status}")
+        time.sleep(poll_interval_seconds)
+
+    raise TimeoutError(f"BICC extract did not finish in {timeout_seconds}s")
+
+
+def read_bicc_csv_from_object_storage(
+    spark: Any,
+    namespace: str,
+    bucket: str,
+    prefix: str,
+    *,
+    schema: Optional[Any] = None,
+):
+    """Read all gzipped CSV files under an OCI Object Storage prefix into Spark.
+
+    The AIDP cluster's Spark configuration must already have the OCI Object
+    Storage connector attached (`oci://` scheme) and credentials configured -
+    typically inherited from the cluster's API key profile.
+
+    Args:
+        spark: The active SparkSession.
+        namespace: OCI Object Storage namespace.
+        bucket: Bucket name where BICC dropped the extract.
+        prefix: Output prefix from ``trigger_bicc_extract``.
+        schema: Optional StructType to enforce; otherwise schema is inferred
+            (slower for large files but fine for one-shot extracts).
+
+    Returns:
+        A Spark DataFrame.
+    """
+    path = f"oci://{bucket}@{namespace}/{prefix.lstrip('/')}/*.csv.gz"
+    reader = spark.read.format("csv").option("header", "true").option(
+        "compression", "gzip"
+    )
+    if schema is not None:
+        reader = reader.schema(schema)
+    else:
+        reader = reader.option("inferSchema", "true")
+    return reader.load(path)
+
+
+def read_bicc_via_aidp_format(
+    spark: Any,
+    fusion_service_url: str,
+    username: str,
+    password: str,
+    schema: str,
+    datastore: str,
+    fusion_external_storage: str,
+):
+    """Read a Fusion BICC PVO via AIDP's built-in `aidataplatform` Spark format.
+
+    This mirrors the official Oracle AIDP sample
+    (oracle-samples/oracle-aidp-samples ->
+    ``data-engineering/ingestion/Read_Only_Ingestion_Connectors.ipynb``):
+
+        spark.read.format("aidataplatform")
+            .option("type", "FUSION_BICC")
+            .option("fusion.service.url", "<URL>")
+            .option("user.name", "<user>")
+            .option("password", "<pwd>")
+            .option("schema", "<SCHEMA>")
+            .option("fusion.external.storage", "<storage-name>")
+            .option("datastore", "<PVO name>")
+            .load()
+
+    The format handler internally:
+    1. Triggers the BICC extract via Fusion REST.
+    2. Waits for completion.
+    3. Reads the extracted CSVs from the OCI Object Storage location
+       backing ``fusion.external.storage`` (which is a pre-configured
+       AIDP external-storage profile).
+    4. Returns the result as a Spark DataFrame with the requested schema.
+
+    Args:
+        spark: Active SparkSession.
+        fusion_service_url: Fusion pod base URL
+            (e.g. ``https://my-pod.fa.us-phoenix-1.oraclecloud.com``).
+        username: Fusion user with BICC privileges
+            (e.g. ``BIA_ADMINISTRATOR_DUTY`` or equivalent role).
+        password: Fusion user password.
+        schema: Target schema (BICC offering schema name, e.g. ``ERP``).
+        datastore: PVO (Public View Object) name to extract.
+        fusion_external_storage: Name of a pre-configured AIDP external
+            storage profile pointing at the OCI Object Storage bucket
+            BICC writes to. This is set up once in the AIDP catalog by
+            an administrator; users just reference it by name.
+
+    Returns:
+        Spark DataFrame.
+    """
+    return (
+        spark.read.format("aidataplatform")
+            .option("type", "FUSION_BICC")
+            .option("fusion.service.url", fusion_service_url)
+            .option("user.name", username)
+            .option("password", password)
+            .option("schema", schema)
+            .option("fusion.external.storage", fusion_external_storage)
+            .option("datastore", datastore)
+            .load()
+    )
+
+
+def rows_to_spark_dataframe(spark: Any, rows: Iterator[dict], *, mode: str = "json_string"):
+    """Materialize an iterator of dicts as a Spark DataFrame.
+
+    Fusion REST responses commonly contain nested objects (HATEOAS links,
+    addresses, classifications) plus all-null columns. PySpark schema
+    inference can't merge ``StringType`` and ``StructType`` for the same
+    column across rows, so the default ``mode="json_string"`` packs every
+    row into a single ``row_json`` STRING column. Caller can then ``from_json``
+    selectively for the fields they need.
+
+    Args:
+        spark: SparkSession.
+        rows: iterator of dicts (e.g. from ``fetch_paged``).
+        mode: ``"json_string"`` (recommended; deterministic, robust)
+            or ``"infer"`` (legacy; may fail on nested data).
+    """
+    import json as _json
+
+    import pandas as pd
+
+    rows_list = list(rows)
+    if not rows_list:
+        # Spark needs SOMETHING - return a 0-row DataFrame with a placeholder col.
+        return spark.createDataFrame([], "placeholder STRING")
+
+    if mode == "json_string":
+        # Single-column, deterministic, type-safe across nested + null shapes.
+        json_rows = [(_json.dumps(r),) for r in rows_list]
+        return spark.createDataFrame(json_rows, schema="row_json STRING")
+
+    if mode == "infer":
+        # Legacy: try pandas-based inference. Fails on nested struct / all-null cols.
+        pdf = pd.DataFrame(rows_list)
+        return spark.createDataFrame(pdf)
+
+    raise ValueError(f"unknown mode {mode!r}; use 'json_string' or 'infer'")

--- a/plugins/oracle-aidp-connectors/scripts/oracle_ai_data_platform_connectors/streaming/__init__.py
+++ b/plugins/oracle-aidp-connectors/scripts/oracle_ai_data_platform_connectors/streaming/__init__.py
@@ -1,0 +1,13 @@
+"""Spark structured streaming helpers (OCI Streaming Kafka)."""
+
+from .kafka import (
+    build_kafka_options_sasl_plain,
+    bootstrap_for_region,
+    validate_checkpoint_path,
+)
+
+__all__ = [
+    "build_kafka_options_sasl_plain",
+    "bootstrap_for_region",
+    "validate_checkpoint_path",
+]

--- a/plugins/oracle-aidp-connectors/scripts/oracle_ai_data_platform_connectors/streaming/kafka.py
+++ b/plugins/oracle-aidp-connectors/scripts/oracle_ai_data_platform_connectors/streaming/kafka.py
@@ -1,0 +1,123 @@
+"""OCI Streaming via Spark structured streaming (Kafka-compat).
+
+Auth = SASL/PLAIN with an OCI auth token. This mirrors the official Oracle
+sample at oracle-samples/oracle-aidp-samples
+(`data-engineering/ingestion/Streaming/StreamingFromOCIStreamingService.ipynb`).
+
+Critical AIDP gotcha: streaming checkpoints must live under `/Volumes/...`.
+`/Workspace/...` (FUSE) and `oci://...` both fail silently.
+"""
+
+from __future__ import annotations
+
+from typing import Optional
+
+
+def bootstrap_for_region(region: str, cell: Optional[int] = None) -> str:
+    """Return the OCI Streaming Kafka bootstrap broker for a region.
+
+    Args:
+        region: e.g. ``us-ashburn-1``.
+        cell: Optional streaming-cell number. If provided, returns the cell-
+            prefixed form (``cell-N.streaming.<region>.oci.oraclecloud.com:9092``)
+            that the official Oracle AIDP sample uses. If None, returns the
+            generic regional form (``streaming.<region>.oci.oraclecloud.com:9092``).
+            OCI routes both correctly; pick whichever matches your pool's
+            messages-endpoint shown in the OCI Console.
+
+    Returns:
+        ``streaming.<region>.oci.oraclecloud.com:9092`` (no cell), or
+        ``cell-<N>.streaming.<region>.oci.oraclecloud.com:9092`` (with cell).
+    """
+    host_prefix = f"cell-{cell}.streaming" if cell is not None else "streaming"
+    return f"{host_prefix}.{region}.oci.oraclecloud.com:9092"
+
+
+def build_kafka_options_sasl_plain(
+    bootstrap_servers: str,
+    tenancy_name: str,
+    username: str,
+    stream_pool_ocid: str,
+    auth_token: str,
+    topic: str,
+    *,
+    starting_offsets: str = "latest",
+    max_partition_fetch_bytes: Optional[int] = 1024 * 1024,
+    max_offsets_per_trigger: Optional[int] = None,
+) -> dict:
+    """Spark Kafka options for SASL/PLAIN with an OCI auth token.
+
+    Mirrors the official Oracle AIDP sample's readStream block. Username
+    format follows OCI Streaming Kafka-compat spec for IAM-Domains tenancies:
+    ``<tenancy_name>/<username>/<stream_pool_ocid>``. For an IAM-Domains user
+    pass ``oracleidentitycloudservice/<email>`` as the ``username`` argument.
+
+    Args:
+        bootstrap_servers: Output of ``bootstrap_for_region``.
+        tenancy_name: OCI tenancy display name (NOT OCID).
+        username: OCI user (typically email, optionally prefixed with
+            ``oracleidentitycloudservice/`` for IAM-Domains).
+        stream_pool_ocid: ``ocid1.streampool.oc1...``.
+        auth_token: 1-hour OCI auth token.
+        topic: Kafka topic name (must exist in the stream pool).
+        starting_offsets: ``latest`` | ``earliest`` | offsets JSON.
+        max_partition_fetch_bytes: Optional Kafka client tuning. Default
+            1 MiB matches the official sample.
+        max_offsets_per_trigger: Optional cap on rows pulled per micro-batch.
+            ``None`` lets Spark decide; the official sample uses ``5`` for
+            slow demos.
+
+    Returns:
+        Dict ready for ``spark.readStream.format("kafka").options(**dict).load()``.
+    """
+    sasl_username = f"{tenancy_name}/{username}/{stream_pool_ocid}"
+    jaas_config = (
+        "org.apache.kafka.common.security.plain.PlainLoginModule required "
+        f'username="{sasl_username}" '
+        f'password="{auth_token}";'
+    )
+    opts: dict = {
+        "kafka.bootstrap.servers": bootstrap_servers,
+        "kafka.security.protocol": "SASL_SSL",
+        "kafka.sasl.mechanism": "PLAIN",
+        "kafka.sasl.jaas.config": jaas_config,
+        "subscribe": topic,
+        "startingOffsets": starting_offsets,
+    }
+    if max_partition_fetch_bytes is not None:
+        opts["kafka.max.partition.fetch.bytes"] = str(max_partition_fetch_bytes)
+    if max_offsets_per_trigger is not None:
+        opts["maxOffsetsPerTrigger"] = str(max_offsets_per_trigger)
+    return opts
+
+
+def validate_checkpoint_path(path: str) -> str:
+    """Validate that a Spark streaming checkpoint path is AIDP-compatible.
+
+    AIDP-compatible = ``/Volumes/<catalog>/<schema>/<volume>/...``. The
+    ``/Workspace/`` mount (FUSE) and ``oci://`` URIs both fail silently for
+    streaming checkpoints.
+
+    Returns:
+        ``path`` unchanged if valid.
+
+    Raises:
+        ValueError: If path is on /Workspace or starts with oci://.
+    """
+    p = path.strip()
+    if p.startswith("/Workspace") or p.startswith("/workspace"):
+        raise ValueError(
+            "Streaming checkpoints cannot live on /Workspace (FUSE). "
+            "Use /Volumes/<catalog>/<schema>/<volume>/_checkpoints/... "
+            "instead."
+        )
+    if p.startswith("oci://"):
+        raise ValueError(
+            "Streaming checkpoints cannot use oci:// directly. "
+            "Use /Volumes/... instead."
+        )
+    if not p.startswith("/Volumes/"):
+        raise ValueError(
+            f"Streaming checkpoint should live under /Volumes/...; got {p!r}"
+        )
+    return p

--- a/plugins/oracle-aidp-connectors/skills/aidp-alh/SKILL.md
+++ b/plugins/oracle-aidp-connectors/skills/aidp-alh/SKILL.md
@@ -1,0 +1,145 @@
+---
+name: aidp-alh
+description: Connect from an AIDP notebook to Oracle AI Lakehouse (ALH), Autonomous Data Warehouse (ADW), or Autonomous Transaction Processing (ATP) via Spark JDBC. Use when the user mentions ALH, AI Lakehouse, ADW, ATP, Autonomous Database, or wants to query a 26ai-backed Oracle Autonomous DB from Spark. Covers wallet (mTLS), IAM DB-Token, and API Key auth paths.
+---
+
+# `aidp-alh` - Oracle AI Lakehouse / ADW / ATP via Spark JDBC
+
+This skill covers the entire Oracle Autonomous Database family - ALH, ADW, ATP - because they are all Oracle 26ai under the hood. Same JDBC driver (`oracle.jdbc.OracleDriver`), same URL pattern (`jdbc:oracle:thin:@tcps://...:1522/...`), same TNS service-name shape (`_high`/`_medium`/`_low`), same wallet flow, same IAM DB-Token flow.
+
+If the user names ATP or ADW specifically, just use this skill - substitute the env-var prefix (`ATP_*` / `ADW_*`) for `ALH_*` and proceed identically.
+
+## When to use
+- User wants to read or write an ALH, ADW, or ATP table from an AIDP notebook.
+- User mentions: "ALH", "AI Lakehouse", "ADW", "Autonomous Data Warehouse", "ATP", "Autonomous Transaction Processing", "Autonomous Database", "26ai lakehouse", "lakehouse external catalog".
+- User has an Autonomous DB wallet, an Autonomous DB connection string, or an externally-cataloged Autonomous DB in AIDP.
+
+## When NOT to use
+- For ExaCS / on-prem Oracle -> use [`aidp-exacs`](../aidp-exacs/SKILL.md).
+
+## Prerequisites in the AIDP notebook
+1. The Oracle JDBC driver (`ojdbc11.jar` or `ojdbc8.jar`) must be on the cluster classpath. AIDP `tpcds` cluster ships it; if not, attach via Cluster -> Libraries.
+2. Add the helper package to `sys.path` (one-time, paste at the top of your notebook):
+   ```python
+   import sys
+   sys.path.insert(0, "/Workspace/Shared/oracle_ai_data_platform_connectors/scripts")
+   ```
+   (Adjust the path to wherever you've uploaded this plugin's `scripts/` dir, or pip-install the package once it's published.)
+3. Have one of: an ALH wallet ZIP (Option A), DB-token compartment OCID + API key (Option B), or admin OCI config (Option C).
+
+Background: ALH is plain Oracle 26ai under the hood. The `oracle.jdbc.OracleDriver`, the URL pattern (`jdbc:oracle:thin:@tcps://...:1522/...`), and the TNS service-name shape (`_high`/`_medium`/`_low`) all transfer 1:1 from ATP. If you've used ATP from AIDP before, this looks identical.
+
+## Auth: pick one
+
+### Option A - Wallet (mTLS, recommended default)
+
+```python
+import os
+from oracle_ai_data_platform_connectors.auth import write_wallet_to_tmp
+from oracle_ai_data_platform_connectors.jdbc import (
+    build_oracle_jdbc_url, spark_jdbc_options_wallet,
+)
+
+# Write wallet to a unique /tmp directory (NEVER /Workspace - FUSE breaks the JDBC driver's reads)
+tns_admin = write_wallet_to_tmp(
+    wallet="/path/to/alh-wallet.zip",      # or pass bytes from OCI Vault
+)
+
+url = build_oracle_jdbc_url(
+    tns_alias=os.environ["ALH_TNS_SERVICE"],   # e.g. "alh_high"
+    tns_admin=tns_admin,
+)
+
+opts = spark_jdbc_options_wallet(
+    url=url,
+    user=os.environ["ALH_USER"],
+    password=os.environ["ALH_PASSWORD"],
+)
+df = spark.read.format("jdbc").options(opts).option("dbtable", "MY_SCHEMA.MY_TABLE").load()
+df.show(5)
+```
+
+### Option B - IAM DB-Token (validated against ATP via IMFA IoT, 3/3 successful)
+
+```python
+import os
+from oracle_ai_data_platform_connectors.auth import generate_db_token
+from oracle_ai_data_platform_connectors.jdbc import (
+    build_oracle_jdbc_url, spark_jdbc_options_dbtoken,
+)
+
+token_dir = generate_db_token(
+    compartment_ocid=os.environ["ALH_COMPARTMENT_OCID"],
+)
+
+url = build_oracle_jdbc_url(
+    tns_alias=os.environ["ALH_TNS_SERVICE"],
+    tns_admin=os.environ["ALH_WALLET_PATH"],
+)
+opts = spark_jdbc_options_dbtoken(url=url, token_dir=token_dir)
+df = spark.read.format("jdbc").options(opts).option("dbtable", "MY_TABLE").load()
+```
+
+For long-running jobs, do not assume executor-side DB-token refresh is available.
+Use a platform-supported credential pattern, keep jobs within the token TTL, or
+only use `refresh_on_executors` after confirming every executor can resolve OCI
+auth/config and the explicit executor-local token directory matches the JDBC
+`oracle.jdbc.tokenLocation` option.
+
+### Option C - API Key + inline OCI config (catalog-sync side only)
+
+The catalog-sync metadata harvest from ALH into the AIDP external catalog uses OCI control-plane APIs, not JDBC. For that side use:
+
+```python
+from oracle_ai_data_platform_connectors.auth import from_inline_pem
+config = from_inline_pem(
+    user_ocid=os.environ["OCI_USER_OCID"],
+    tenancy_ocid=os.environ["OCI_TENANCY_OCID"],
+    fingerprint=os.environ["OCI_FINGERPRINT"],
+    private_key_pem=os.environ["OCI_PRIVATE_KEY_PEM"],
+    region=os.environ["OCI_REGION"],
+)
+# pass `config` to oci.<service>Client(config=config) - never write the PEM to disk
+```
+
+## Run the query
+
+Standard Spark JDBC. For large reads, partition the read:
+
+```python
+df = (
+    spark.read.format("jdbc").options(opts)
+        .option("dbtable", "(SELECT id, x, y FROM big_table) t")
+        .option("partitionColumn", "id")
+        .option("lowerBound", "1")
+        .option("upperBound", "10000000")
+        .option("numPartitions", "16")
+        .load()
+)
+```
+
+For writeback, confirm the target table and write mode with the user first.
+Prefer append or a new target table unless the user explicitly approves
+replacement:
+
+```python
+(df.write.format("jdbc").options(opts)
+   .option("dbtable", "MY_SCHEMA.TARGET_TABLE")
+   .mode("append")
+   .save())
+```
+
+## Gotchas
+- Wallet must live under `/tmp`. `/Workspace` is FUSE-mounted; the JDBC driver process can't read it reliably (`Errno 107`).
+- `os.chmod` is a no-op on FUSE. The helper uses `os.open(..., O_WRONLY|O_CREAT, 0o666)` so the JDBC driver process (different UID) can read the wallet/token.
+- `oracle.jdbc.timezoneAsRegion=false` - set in helper defaults; avoids the well-known TZ region warning.
+- External catalog refresh uses `CREATE EXTERNAL CATALOG ... OPTIONS('wallet.content'=base64, 'user.name'=..., 'password'=..., 'wallet.password'=...)`. Same DB credentials as Option A.
+- TNS service name - confirm via the wallet's `tnsnames.ora`. Not always `alh_high`.
+- Instance Principal / Resource Principal are blocked in AIDP notebooks today (IMDS unreachable, RP tokens not provided). Don't try `InstancePrincipalsSecurityTokenSigner()`.
+
+## References
+- Helpers: [scripts/oracle_ai_data_platform_connectors/jdbc/oracle.py](../../scripts/oracle_ai_data_platform_connectors/jdbc/oracle.py)
+- Wallet helper: [scripts/oracle_ai_data_platform_connectors/auth/wallet.py](../../scripts/oracle_ai_data_platform_connectors/auth/wallet.py)
+- AIDP notebook auth limits: instance principal and resource principal are not
+  currently usable from standard Workbench notebooks; use API key plus inline
+  OCI config or a supported connector credential pattern instead.

--- a/plugins/oracle-aidp-connectors/skills/aidp-aws-s3/SKILL.md
+++ b/plugins/oracle-aidp-connectors/skills/aidp-aws-s3/SKILL.md
@@ -1,0 +1,109 @@
+---
+name: aidp-aws-s3
+description: Read and write AWS S3 (`s3a://`) from an AIDP notebook. Use when the user mentions S3, AWS S3 bucket, s3a, or has AWS access keys. Auth is access key + secret key via the Hadoop S3A connector. boto3 is also available for non-Spark management operations (list, copy).
+---
+
+# `aidp-aws-s3` - AWS S3 via the S3A connector
+
+Read or write `s3a://<bucket>/<key>` paths from AIDP Spark using AWS access keys. Optional `boto3` path for management operations (list, copy, head).
+
+## When to use
+- AIDP needs to consume or land data in AWS S3.
+- Mentioned: "S3", "s3a", "AWS bucket".
+
+## When NOT to use
+- For OCI Object Storage -> [`aidp-object-storage`](../aidp-object-storage/SKILL.md).
+- For Azure ADLS Gen2 -> [`aidp-azure-adls`](../aidp-azure-adls/SKILL.md).
+
+## Cluster prerequisite - runtime-load BOTH `hadoop-aws` and `aws-java-sdk-bundle`
+
+The AIDP `tpcds` cluster does NOT have `org.apache.hadoop.fs.s3a.S3AFileSystem` pre-installed (verified live 2026-04-27). Both `hadoop-aws-<ver>.jar` (~1 MB) AND `aws-java-sdk-bundle-<ver>.jar` (~280 MB) must be runtime-loaded. Match `hadoop-aws` to the cluster's exact Hadoop version (`spark._jvm.org.apache.hadoop.util.VersionInfo.getVersion()` - typically `3.3.4` for Spark 3.5.0). Mismatch produces `NoSuchMethodError` deep in `org.apache.hadoop.fs.s3a`.
+
+Beyond the standard runtime-load + DriverManager pattern, S3A also requires telling Hadoop's Configuration which classloader to use - Hadoop's `FileSystem.get()` uses `Configuration.getClassLoader()`, not the JVM thread context loader.
+
+Before downloading or classloading these JARs, confirm the Maven URLs, Hadoop
+version match, and checksums if available. For shared or production clusters,
+prefer administrator-managed cluster libraries or approved JARs in a
+user-managed Volume.
+
+## Spark read (S3A, runtime-loaded driver)
+
+```python
+import os, urllib.request
+from py4j.java_gateway import java_import
+
+# 1. Confirm cluster's Hadoop version + match hadoop-aws jar
+HADOOP_VER = spark._jvm.org.apache.hadoop.util.VersionInfo.getVersion()
+print("hadoop:", HADOOP_VER)  # e.g. 3.3.4
+
+JARS = {
+    f"/tmp/hadoop-aws-{HADOOP_VER}.jar":
+        f"https://repo1.maven.org/maven2/org/apache/hadoop/hadoop-aws/{HADOOP_VER}/hadoop-aws-{HADOOP_VER}.jar",
+    "/tmp/aws-java-sdk-bundle-1.12.262.jar":
+        "https://repo1.maven.org/maven2/com/amazonaws/aws-java-sdk-bundle/1.12.262/aws-java-sdk-bundle-1.12.262.jar",
+}
+for path, url in JARS.items():
+    if not os.path.exists(path):
+        urllib.request.urlretrieve(url, path)
+
+# 2. Build URLClassLoader covering BOTH jars + set on Hadoop Configuration
+gw = spark._sc._gateway
+URLArr = gw.new_array(spark._jvm.java.net.URL, len(JARS))
+for i, p in enumerate(JARS):
+    URLArr[i] = spark._jvm.java.io.File(p).toURI().toURL()
+sysCL = spark._jvm.java.lang.ClassLoader.getSystemClassLoader()
+ucl = spark._jvm.java.net.URLClassLoader(URLArr, sysCL)
+
+hconf = spark._jsc.hadoopConfiguration()
+hconf.setClassLoader(ucl)  # CRITICAL - Hadoop FileSystem lookup uses this, not the thread context
+
+# 3. Configure S3A credentials + endpoint
+hconf.set("fs.s3a.access.key", os.environ["S3_ACCESS_KEY"])
+hconf.set("fs.s3a.secret.key", os.environ["S3_SECRET_KEY"])
+hconf.set("fs.s3a.endpoint", "s3.amazonaws.com")  # or s3.<region>.amazonaws.com
+hconf.set("fs.s3a.aws.credentials.provider",
+          "org.apache.hadoop.fs.s3a.SimpleAWSCredentialsProvider")
+hconf.set("fs.s3a.impl", "org.apache.hadoop.fs.s3a.S3AFileSystem")
+
+# 4. Distribute the jars to executors (driver-only registration won't work for cluster reads)
+for p in JARS:
+    spark._jsc.addJar(p)
+
+# 5. Read - works for csv/json/parquet/delta
+df = spark.read.option("header", "true").csv(
+    f"s3a://{os.environ['S3_BUCKET']}/{os.environ['S3_FILE']}"
+)
+df.show()
+```
+
+Live-validated 2026-04-27: 2 rows from `s3a://test-data-sep3-2025/csv/sample.csv` via this pattern.
+
+## boto3 fallback (management ops, not data plane)
+
+```python
+import boto3, os
+
+s3 = boto3.client(
+    "s3",
+    aws_access_key_id     = os.environ["S3_ACCESS_KEY"],
+    aws_secret_access_key = os.environ["S3_SECRET_KEY"],
+    region_name           = os.environ.get("S3_REGION", "us-east-1"),
+)
+
+resp = s3.list_objects_v2(Bucket=os.environ["S3_BUCKET"], Prefix="")
+for obj in resp.get("Contents", []):
+    print(obj["Key"])
+```
+
+## Gotchas
+- Use `s3a://` (the Hadoop driver), not `s3://` or `s3n://`. The latter two are deprecated and may not be present in the cluster.
+- `aws-java-sdk-bundle` version drift - pin to the version `hadoop-aws` was built against. Lab clusters often need this jar installed; the symptom of mismatch is `NoSuchMethodError` deep in `org.apache.hadoop.fs.s3a` when listing/reading.
+- `Configuration.setClassLoader` is required after runtime-load - Hadoop's `FileSystem.get()` calls `Configuration.getClassByName()` which uses the Configuration's classloader (not the JVM thread context). Without `hconf.setClassLoader(ucl)`, you get `ClassNotFoundException: Class org.apache.hadoop.fs.s3a.S3AFileSystem not found` even though you just registered the jar.
+- Secrets in env vars only. Never hard-code keys in notebooks. Source from `.env`/OCI Vault.
+- Region - `boto3.client('s3', region_name=...)` is required for non-default regions; for the Spark path the bucket region is auto-discovered, but you may need `fs.s3a.endpoint=s3.<region>.amazonaws.com` for non-us-east-1 if listings fail.
+- `boto3` is NOT pre-installed on AIDP cluster and PyPI mirror is typically unreachable. For management ops (list, copy, head), drive from local rather than cluster.
+- Egress cost & latency - S3 reads from AIDP cross-cloud. For heavy ETL, copy to OCI Object Storage once and read locally.
+
+## References
+- Official sample: [oracle-samples/oracle-aidp-samples -> `data-engineering/ingestion/Ingest_from_Multi_Cloud.ipynb`](https://github.com/oracle-samples/oracle-aidp-samples/blob/main/data-engineering/ingestion/Ingest_from_Multi_Cloud.ipynb)
+- Hadoop AWS docs: <https://hadoop.apache.org/docs/stable/hadoop-aws/tools/hadoop-aws/>

--- a/plugins/oracle-aidp-connectors/skills/aidp-azure-adls/SKILL.md
+++ b/plugins/oracle-aidp-connectors/skills/aidp-azure-adls/SKILL.md
@@ -1,0 +1,74 @@
+---
+name: aidp-azure-adls
+description: Read and write Azure Data Lake Storage Gen2 (`abfss://`) from an AIDP notebook. Use when the user mentions ADLS, Azure Data Lake, abfss, or wants to ingest from a multi-cloud Azure source. Auth is OAuth client-credentials (Service Principal client_id + secret + tenant).
+---
+
+# `aidp-azure-adls` - Azure ADLS Gen2 via OAuth client-credentials
+
+Read or write `abfss://<container>@<storage_account>.dfs.core.windows.net/...` paths from AIDP Spark using a Service Principal.
+
+## When to use
+- AIDP needs to consume or land data in Azure ADLS Gen2.
+- Mentioned: "ADLS", "abfss", "Azure Data Lake".
+
+## When NOT to use
+- For OCI Object Storage -> [`aidp-object-storage`](../aidp-object-storage/SKILL.md).
+- For AWS S3 -> [`aidp-aws-s3`](../aidp-aws-s3/SKILL.md).
+
+## One-time auth setup
+
+Configure the Spark Hadoop connector with Service-Principal credentials. Do this once per session/job:
+
+```python
+import os
+
+storage_account = os.environ["ADLS_STORAGE_ACCOUNT"]   # account name only, no .dfs...
+client_id       = os.environ["ADLS_CLIENT_ID"]          # SP application (client) id
+client_secret   = os.environ["ADLS_CLIENT_SECRET"]      # SP secret value
+tenant          = os.environ["ADLS_TENANT"]             # Azure AD tenant id (GUID)
+
+base = f"fs.azure.account"
+host = f"{storage_account}.dfs.core.windows.net"
+
+spark.conf.set(f"{base}.auth.type.{host}",                 "OAuth")
+spark.conf.set(f"{base}.oauth.provider.type.{host}",       "org.apache.hadoop.fs.azurebfs.oauth2.ClientCredsTokenProvider")
+spark.conf.set(f"{base}.oauth2.client.id.{host}",          client_id)
+spark.conf.set(f"{base}.oauth2.client.secret.{host}",      client_secret)
+spark.conf.set(f"{base}.oauth2.client.endpoint.{host}",    f"https://login.microsoftonline.com/{tenant}/oauth2/token")
+```
+
+## Read
+
+```python
+container = os.environ["ADLS_CONTAINER"]
+data_file = os.environ["ADLS_DATA_FILE"]   # e.g. "data/2025/january/orders.csv"
+
+df = (spark.read
+      .format("csv")
+      .option("header", True)
+      .load(f"abfss://{container}@{storage_account}.dfs.core.windows.net/{data_file}"))
+df.show()
+```
+
+## Write (e.g. land into a managed Delta table)
+
+Confirm the target table and write mode with the user before writing. Prefer
+append or a new target table unless the user explicitly approves replacement.
+
+```python
+(df.write
+   .mode("append")
+   .format("delta")
+   .saveAsTable("default.default.data_from_adls"))
+```
+
+## Gotchas
+- Service Principal must have RBAC on the storage account. Assign `Storage Blob Data Contributor` (or Reader for read-only) on the container or the account.
+- Hierarchical Namespace must be enabled on the storage account for `abfss://` to work (ADLS Gen2 = HNS-on storage account).
+- Secrets in env vars - never hard-code in notebooks. Source from a `.env` file gitignored, or from OCI Vault via `oracle_ai_data_platform_connectors.auth.secrets.get(name)`.
+- Endpoint URL - `login.microsoftonline.com/<tenant>/oauth2/token` is the v1 endpoint and is what the `ClientCredsTokenProvider` expects. Don't use the v2 endpoint here.
+- `abfss://` not `abfs://` - always use the TLS variant.
+
+## References
+- Official sample: [oracle-samples/oracle-aidp-samples -> `data-engineering/ingestion/Ingest_from_Multi_Cloud.ipynb`](https://github.com/oracle-samples/oracle-aidp-samples/blob/main/data-engineering/ingestion/Ingest_from_Multi_Cloud.ipynb)
+- Hadoop Azure docs: <https://hadoop.apache.org/docs/stable/hadoop-azure/abfs.html>

--- a/plugins/oracle-aidp-connectors/skills/aidp-connectors-bootstrap/SKILL.md
+++ b/plugins/oracle-aidp-connectors/skills/aidp-connectors-bootstrap/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: aidp-connectors-bootstrap
+description: First-time setup. Use when the user wants to install or upload the AIDP Spark connectors helper package into an Oracle AI Data Platform Workbench workspace, or has just installed this plugin and asks "how do I set this up", "first-time setup", "install the helpers", or "bootstrap AIDP connectors".
+---
+
+# `aidp-connectors-bootstrap` - first-time setup of the helper package in AIDP
+
+## When to use
+- The user just installed the plugin and asks "how do I set this up?", "what's the first step?", "install the helpers".
+- The user runs a connector skill for the first time and gets `ModuleNotFoundError: No module named 'oracle_ai_data_platform_connectors'`.
+- The user explicitly asks to upload the helper package to AIDP.
+
+## Outcome of running this skill
+- `/Workspace/Shared/oracle_ai_data_platform_connectors/scripts/oracle_ai_data_platform_connectors/` exists in the user's AIDP workspace, populated from the plugin's local `scripts/` directory.
+- The user has run `examples/00_bootstrap_helpers.ipynb` once and it printed `BOOTSTRAP OK`.
+- From that point on, connector skills can import the helper package. Individual connectors may still need credentials, network routes, connector JARs, catalog permissions, buckets, volumes, or source-specific setup.
+
+## What Cline should do
+
+### Step 1 - locate the bundled `scripts/` directory
+
+The helper package is bundled with this plugin. Resolve it from the active
+skill directory:
+
+```bash
+HELPERS_DIR="$SKILL_DIR/../../scripts/oracle_ai_data_platform_connectors"
+test -f "$HELPERS_DIR/__init__.py"
+```
+
+Confirm the destination workspace and upload path with the user before copying
+anything into Workbench.
+
+### Step 2 - create the destination directory in AIDP
+
+If Oracle AIDP Workbench MCP tools are available in the current Cline session,
+use the host-provided directory and file upload tools to create:
+
+```
+/Workspace/Shared/oracle_ai_data_platform_connectors
+/Workspace/Shared/oracle_ai_data_platform_connectors/scripts
+```
+
+(If the workspace_id isn't already known from the conversation, ask the user.)
+
+If no AIDP upload tools are available, give the user the local `HELPERS_DIR`
+path and ask them to upload that code-only package through the Workbench UI.
+
+### Step 3 - upload the package files
+
+For each `.py` file under `$HELPERS_DIR`, upload to the matching path under
+`/Workspace/Shared/oracle_ai_data_platform_connectors/scripts/` using the
+available Workbench file upload tool or the user-approved manual process.
+
+The package layout to preserve:
+```
+oracle_ai_data_platform_connectors/
++-- __init__.py
++-- auth/{__init__,wallet,dbtoken,oci_config,user_principal,secrets}.py
++-- jdbc/{__init__,oracle,runtime_load}.py
++-- rest/{__init__,fusion,epm,essbase}.py
++-- streaming/{__init__,kafka}.py
+```
+
+### Step 4 - push the bootstrap notebook to AIDP and run it
+
+Upload `$SKILL_DIR/../../examples/00_bootstrap_helpers.ipynb` to
+`Shared/connectors-tests/00_bootstrap_helpers.ipynb` only after the user
+approves the path. Then run it in the user's chosen notebook session. The final
+cell prints `BOOTSTRAP OK` if everything works.
+
+### Step 5 - confirm
+
+Tell the user:
+- Where the helpers landed.
+- That connector skills can now import the helper package.
+- The next step is to pick a connector (for example `aidp-alh` or
+  `aidp-oracle-db`) and supply that connector's env vars, Vault secrets,
+  network access, and connector-specific prerequisites.
+
+## Alternative: ask the user to install via PyPI (v1.0+)
+
+Once the package is published to PyPI, this skill should pivot to telling the user to run `%pip install oracle-ai-data-platform-connectors` in any AIDP cell instead of uploading. Until v1.0 ships, the Workspace-upload path above is the only way.
+
+## What NOT to do
+- Do not upload anything to `/Workspace/Shared/` without confirming the path with the user (in case they have an existing convention).
+- Do not write secrets, .env contents, or PEM keys anywhere in `/Workspace/Shared/`. The helper package is code-only.
+- Do not skip the sanity-import notebook - it's how you (and the user) confirm the upload worked, not just that files exist.
+
+## References
+- Bootstrap notebook: [`examples/00_bootstrap_helpers.ipynb`](../../examples/00_bootstrap_helpers.ipynb)
+- Plugin README install section: [`README.md`](../../README.md)

--- a/plugins/oracle-aidp-connectors/skills/aidp-connectors-overview/SKILL.md
+++ b/plugins/oracle-aidp-connectors/skills/aidp-connectors-overview/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: aidp-connectors-overview
+description: Help the user pick the right connector skill for their data source from an AIDP notebook. Use as a router when the user mentions multiple sources, isn't sure which connector applies, or asks "how do I connect to X from AIDP". Covers 23 data sources - Oracle Autonomous DB family (ALH/ADW/ATP), generic Oracle DB, ExaCS, PeopleSoft, Siebel, Fusion ERP/BICC, EPM Cloud, Essbase, OCI Streaming, Object Storage, Iceberg, plus PostgreSQL, MySQL/HeatWave, SQL Server, Hive, Snowflake, Azure ADLS, AWS S3, Salesforce, generic REST, custom JDBC, Excel.
+---
+
+# `aidp-connectors-overview` - pick the right connector skill
+
+## When to use
+- The user is exploring options ("how do I connect to Oracle from AIDP?", "which connector should I use?").
+- The user mentions multiple Oracle sources at once.
+- The user describes a source by capability (e.g. "OLAP cube", "structured streaming") rather than naming the product directly.
+
+## When NOT to use
+- The user has already named their target product (ALH, ATP, Fusion, etc.) - invoke the matching `aidp-<product>` skill directly.
+
+## How to route
+
+Before any connector skill works, the helper package must be importable from the
+user's AIDP workspace. If the user hasn't done this yet, or you see
+`ModuleNotFoundError: oracle_ai_data_platform_connectors` in any prior cell,
+invoke [`aidp-connectors-bootstrap`](../aidp-connectors-bootstrap/SKILL.md)
+first. It explains how to upload the bundled code-only helper package and run a
+sanity-import notebook.
+
+Otherwise, pick the right skill from this table and invoke that skill. Don't re-write its content here.
+
+### Oracle / OCI sources
+
+| User says... | Use skill |
+|---|---|
+| "ALH", "AI Lakehouse", "ADW", "ATP", "Autonomous Database", "26ai" | [`aidp-alh`](../aidp-alh/SKILL.md) - Autonomous DB family (wallet / IAM DB-Token / API key) |
+| "Oracle Database", "generic Oracle DB", "on-prem Oracle", "Oracle 19c / 21c", "Base DB", "Oracle on Compute", non-Autonomous Oracle | [`aidp-oracle-db`](../aidp-oracle-db/SKILL.md) - generic Oracle DB via plain user/password on TCP 1521 |
+| "ExaCS", "Exadata", "Exadata Cloud", "private-subnet Oracle DB" | [`aidp-exacs`](../aidp-exacs/SKILL.md) |
+| "PeopleSoft", "PSFT", "PS HCM", "FSCM", "Campus Solutions" | [`aidp-peoplesoft`](../aidp-peoplesoft/SKILL.md) |
+| "Siebel", "Siebel CRM", "S_CONTACT", "S_ORG_EXT" | [`aidp-siebel`](../aidp-siebel/SKILL.md) |
+| "Fusion ERP", "Fusion HCM", "Fusion REST", "FA REST", "Cloud ERP API" | [`aidp-fusion-rest`](../aidp-fusion-rest/SKILL.md) |
+| "BICC", "BI Cloud Connector", "Fusion bulk extract", >50k rows from Fusion | [`aidp-fusion-bicc`](../aidp-fusion-bicc/SKILL.md) |
+| "EPM Cloud", "EPBCS", "Hyperion Planning", "Planning app", "exportdataslice" | [`aidp-epm-cloud`](../aidp-epm-cloud/SKILL.md) |
+| "Essbase", "Essbase 21c", "MDX", "OLAP cube", "cube REST" | [`aidp-essbase`](../aidp-essbase/SKILL.md) |
+| "OCI Streaming", "Kafka on OCI", "stream pool", "structured streaming Kafka" | [`aidp-streaming-kafka`](../aidp-streaming-kafka/SKILL.md) |
+| "OCI Object Storage", "oci://", "external volume", "external table on bucket" | [`aidp-object-storage`](../aidp-object-storage/SKILL.md) |
+| "Iceberg", "Apache Iceberg", "time travel", "snapshots", "schema evolution" | [`aidp-iceberg`](../aidp-iceberg/SKILL.md) |
+
+### External RDBMS / Hadoop (non-Oracle)
+
+| User says... | Use skill |
+|---|---|
+| "PostgreSQL", "Postgres", "psql" | [`aidp-postgresql`](../aidp-postgresql/SKILL.md) |
+| "MySQL", "HeatWave", "MDS", "MySQL Database Service" | [`aidp-mysql`](../aidp-mysql/SKILL.md) |
+| "SQL Server", "MSSQL", "Azure SQL", "TDS" | [`aidp-sqlserver`](../aidp-sqlserver/SKILL.md) |
+| "Hive", "HiveServer2", "HS2", "HCatalog", non-Kerberos Hive | [`aidp-hive`](../aidp-hive/SKILL.md) |
+
+### SaaS
+
+| User says... | Use skill |
+|---|---|
+| "Salesforce", "SFDC", "Sales Cloud", "Service Cloud", "sObject", "SOQL", "Account / Opportunity / Lead" | [`aidp-salesforce`](../aidp-salesforce/SKILL.md) |
+
+### Multi-cloud + escape hatches
+
+| User says... | Use skill |
+|---|---|
+| "Snowflake", "sfUrl", "sfWarehouse" | [`aidp-snowflake`](../aidp-snowflake/SKILL.md) |
+| "ADLS", "Azure Data Lake", "abfss" | [`aidp-azure-adls`](../aidp-azure-adls/SKILL.md) |
+| "S3", "AWS S3", "s3a" | [`aidp-aws-s3`](../aidp-aws-s3/SKILL.md) |
+| "Generic REST", "manifest URL", "manifest.path", REST endpoint with manifest schema | [`aidp-rest-generic`](../aidp-rest-generic/SKILL.md) |
+| "Custom JDBC", "ClickHouse", "DuckDB", "DB2", "SAP HANA", any DB without a dedicated skill | [`aidp-jdbc-custom`](../aidp-jdbc-custom/SKILL.md) |
+| ".xlsx", "Excel", "spreadsheet ingestion" | [`aidp-excel`](../aidp-excel/SKILL.md) |
+
+## What's blocked at the AIDP platform level (so you don't try)
+- Instance Principal - IMDS (`169.254.169.254`) is unreachable from AIDP notebooks; signer either fails or runs in AIDP's service tenancy, not the customer's.
+- Resource Principal - AIDP sets `AIDP_AUTH=resource_principal` but does NOT provide `OCI_RESOURCE_PRINCIPAL_RPST` / `OCI_RESOURCE_PRINCIPAL_PRIVATE_PEM`, so `get_resource_principals_signer()` raises.
+
+If the user wants either of those, point them at API Key + inline OCI config (`oracle_ai_data_platform_connectors.auth.from_inline_pem`) instead. The AIDP team is aware; pending Oracle action.
+
+## Cross-cutting AIDP gotchas (every connector inherits these)
+1. Credentials live under `/tmp/` - never `/Workspace/`. The latter is FUSE-mounted; intermittent disconnects + `os.chmod` no-op.
+2. Files written for the JDBC driver process must be world-readable up-front via `os.open(..., O_WRONLY|O_CREAT, 0o666)`.
+3. Spark streaming checkpoints must live under `/Volumes/<catalog>/<schema>/<volume>/...`, never `/Workspace/`, never `oci://`.
+4. Refresh the AIDP session token before interactive notebook validation: `oci session authenticate --profile AIDP_SESSION --region us-ashburn-1`.
+
+## References
+- Plugin README: [../../README.md](../../README.md)
+- Bundled helper package: [../../scripts/oracle_ai_data_platform_connectors](../../scripts/oracle_ai_data_platform_connectors)
+- Example notebooks: [../../examples](../../examples)

--- a/plugins/oracle-aidp-connectors/skills/aidp-epm-cloud/SKILL.md
+++ b/plugins/oracle-aidp-connectors/skills/aidp-epm-cloud/SKILL.md
@@ -1,0 +1,73 @@
+---
+name: aidp-epm-cloud
+description: Run a Planning data-slice export against Oracle EPM Cloud (Planning / EPBCS) and materialize as a Spark DataFrame in an AIDP notebook. Use when the user mentions EPM Cloud, EPBCS, Hyperion Planning, planning app, MDX export, or wants Planning data in Spark. HTTP Basic auth with identity-domain-prefixed username.
+---
+
+# `aidp-epm-cloud` - EPM Cloud Planning REST -> Spark
+
+## When to use
+- User wants to pull a Planning data slice (POV x columns x rows) from EPM Cloud into Spark.
+- User mentions: "EPM Cloud", "EPBCS", "Hyperion Planning", "planning app", "exportdataslice", "MDX export".
+
+## When NOT to use
+- For Essbase 21c on-prem MDX -> use [`aidp-essbase`](../aidp-essbase/SKILL.md).
+- For Fusion ERP / HCM -> use [`aidp-fusion-rest`](../aidp-fusion-rest/SKILL.md).
+
+## Prerequisites in the AIDP notebook
+1. `pip install requests pandas` (usually pre-installed).
+2. Helpers on `sys.path`.
+3. EPM pod URL + credentials in the form ``tenancy.user@domain``.
+
+## Auth: HTTP Basic
+
+```python
+import os
+from oracle_ai_data_platform_connectors.auth import http_basic_session
+from oracle_ai_data_platform_connectors.rest.epm import (
+    list_applications, export_data_slice, slice_to_long_dataframe,
+)
+
+# EPM_USERNAME MUST be in identity-domain form: tenancy.user@domain
+# e.g. epmloaner622.first.last@oracle.com
+session = http_basic_session(
+    username=os.environ["EPM_USERNAME"],
+    password=os.environ["EPM_PASSWORD"],
+    base_url=os.environ["EPM_BASE_URL"],
+)
+
+# Pre-flight: confirm credentials work and the app is reachable
+apps = list_applications(session, os.environ["EPM_BASE_URL"])
+print("applications:", [a["name"] for a in apps])
+
+# Run the export
+slice_response = export_data_slice(
+    session=session,
+    base_url=os.environ["EPM_BASE_URL"],
+    application=os.environ["EPM_APPLICATION"],
+    plan_type=os.environ["EPM_PLAN_TYPE"],
+    grid_definition={
+        "suppressMissingBlocks": True,
+        "suppressMissingRows": True,
+        "pov": {
+            "dimensions": ["HSP_View", "Year", "Scenario", "Version", "Entity", "Product"],
+            "members": [["BaseData"], ["FY26"], ["Actual"], ["Working"], ["Total Entity"], ["P_TP"]]
+        },
+        "columns": [{"dimensions": ["Period"], "members": [["Jan", "Feb", "Mar", "Apr", "May", "Jun"]]}],
+        "rows":    [{"dimensions": ["Account"], "members": [["IChildren(PL)"]]}],
+    },
+)
+
+df = slice_to_long_dataframe(spark, slice_response)
+df.show(10)
+print("cells:", df.count())
+```
+
+## Gotchas
+- Username MUST include the identity-domain prefix. `tenancy.user@domain` (e.g. `epmloaner622.first.last@oracle.com`). The bare `first.last@oracle.com` returns 401.
+- POV members must be leaf-level. EPM returns 400 / empty if you pass a parent member without `IChildren()` / `ILvl0Descendants()`.
+- `#Missing` cells - empty Planning blocks come back as the literal string `"#Missing"`. Helper preserves this in the `value` column; cast to numeric and filter as needed.
+- 401 vs 403 - 401 = auth fail (re-check Basic creds). 403 = permission denied (different code path; don't retry).
+
+## References
+- Helpers: [scripts/oracle_ai_data_platform_connectors/rest/epm.py](../../scripts/oracle_ai_data_platform_connectors/rest/epm.py)
+- EPM Planning REST docs: https://docs.oracle.com/en/cloud/saas/planning-budgeting-cloud/pbcrr/

--- a/plugins/oracle-aidp-connectors/skills/aidp-essbase/SKILL.md
+++ b/plugins/oracle-aidp-connectors/skills/aidp-essbase/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: aidp-essbase
+description: Run an MDX query against an Oracle Essbase 21c cube and materialize the result as a Spark DataFrame in an AIDP notebook. Use when the user mentions Essbase, MDX, Essbase 21c, OLAP cube, or wants to read cube data into Spark. Auth is HTTP Basic.
+---
+
+# `aidp-essbase` - Essbase 21c MDX -> Spark
+
+## When to use
+- User wants to run an MDX SELECT against an Essbase 21c cube and load the result into Spark.
+- User mentions: "Essbase", "MDX", "OLAP cube", "Essbase REST", "21c cube".
+
+## When NOT to use
+- For EPM Cloud Planning (cloud-hosted) -> use [`aidp-epm-cloud`](../aidp-epm-cloud/SKILL.md).
+
+## Prerequisites in the AIDP notebook
+1. `pip install requests pandas`.
+2. Helpers on `sys.path`.
+3. Essbase REST URL + Basic credentials.
+4. Network reachability AIDP -> Essbase host (often on a private subnet - confirm `nc -zv <host> 9000`).
+
+## Auth: HTTP Basic
+
+Essbase 21c REST API expects `Authorization: Basic base64(user:pass)`. The JET UI redirects to IDCS OAuth, but the REST surface is Basic-only - passing an OCI session JWT as Bearer fails (different identity provider). Username is the Essbase service-admin (e.g. `Oacadmin1`).
+
+If your Essbase host uses an internal CA chain not trusted by the AIDP cluster (e.g. `cealinfra.com`), pass `verify_tls=False` to the session helper. Live-validated against `https://ess21c.cealinfra.com/`.
+
+```python
+import os, urllib3
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)  # internal CA
+from oracle_ai_data_platform_connectors.auth import http_basic_session
+from oracle_ai_data_platform_connectors.rest.essbase import (
+    execute_mdx, mdx_result_to_spark_dataframe,
+)
+
+session = http_basic_session(
+    username=os.environ["ESSBASE_USER"],
+    password=os.environ["ESSBASE_PASSWORD"],
+    base_url=os.environ["ESSBASE_BASE_URL"],
+    verify_tls=False,   # set True for trusted public CAs
+)
+
+mdx_query = """
+SELECT
+  {[Measures].[Sales]} ON COLUMNS,
+  {[Product].[Product Family].Members} ON ROWS
+FROM [Sample.Basic]
+WHERE ([Year].[2026], [Scenario].[Actual])
+"""
+
+response = execute_mdx(
+    session=session,
+    base_url=os.environ["ESSBASE_BASE_URL"],
+    application=os.environ["ESSBASE_APPLICATION"],
+    cube=os.environ["ESSBASE_CUBE"],
+    mdx_query=mdx_query,
+)
+
+df = mdx_result_to_spark_dataframe(spark, response)
+df.show(20)
+print("cells:", df.count())
+```
+
+## Gotchas
+- MDX braces `{...}` are required around member sets - bare `[Product].[Product Family].Members` returns 400.
+- WHERE slicer for POV - if you skip dimensions in `WHERE`, Essbase uses dimension defaults, which may be parents (returns aggregated/empty data depending on aggregation).
+- Network - Essbase 21c is typically deployed on a private host (port 9000 / 9001). Confirm reachability before chasing MDX errors.
+- `#Missing` cells - empty cube intersections return the literal `"#Missing"`. Helper preserves; cast as needed.
+- HTTP 200 with empty result - Essbase returns 200 even when MDX matches nothing. Always check `df.count() == 0` rather than relying on the HTTP status.
+
+## References
+- Helpers: [scripts/oracle_ai_data_platform_connectors/rest/essbase.py](../../scripts/oracle_ai_data_platform_connectors/rest/essbase.py)
+- Essbase 21c REST docs: https://docs.oracle.com/en/database/other-databases/essbase/21/essoa/

--- a/plugins/oracle-aidp-connectors/skills/aidp-exacs/SKILL.md
+++ b/plugins/oracle-aidp-connectors/skills/aidp-exacs/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: aidp-exacs
+description: Connect from an AIDP notebook to Oracle Exadata Cloud Service (ExaCS) via Spark JDBC. Use when the user mentions ExaCS, Exadata, Exadata Cloud, RAC SCAN listener, or has a private-subnet Oracle DB. Auth is plain user/password on TCP 1521 with server-enforced AES256 Native Network Encryption (live-validated against Oracle 23ai). Wallet TCPS and IAM DB-Token are not supported by AIDP notebooks for ExaCS.
+---
+
+# `aidp-exacs` - Oracle Exadata Cloud Service via Spark JDBC
+
+## When to use
+- User wants to read or write an ExaCS PDB from an AIDP notebook.
+- User mentions: "ExaCS", "Exadata Cloud", "RAC SCAN listener", "private-subnet Oracle DB".
+
+## When NOT to use
+- For Oracle AI Lakehouse / ADW / ATP (Autonomous DB family) -> use [`aidp-alh`](../aidp-alh/SKILL.md).
+
+## Critical infrastructure prerequisites
+
+ExaCS sits in a customer private subnet; AIDP runs in its own VCN. Two pieces must be in place before any JDBC will work - neither is configurable from a notebook:
+
+1. VCN routing AIDP->ExaCS (PE/RCE through PAGW). Workspaces created without private connectivity can't reach customer DBs.
+2. Workspace `scanDetails` - required for RAC clusters. Without it, the SCAN listener's redirect to a node-local IP (`10.x.x.x`) is unreachable from the executor -> `ORA-17820`. Configure once via the AIDP workspace REST API or console:
+
+   ```json
+   networkConfigurationDetails: {
+     "subnetId": "ocid1.subnet.oc1.iad.aaaa...",
+     "scanDetails": [
+       {"fqdn": "<scan-host>.clientsubnet.dns.oraclevcn.com", "port": "1521"}
+     ]
+   }
+   ```
+
+   This activates PE-ARCH 3c (RCE with SCAN Proxy) - the PAGW translates RAC node-redirect IPs to Class-E NAT addresses so the JDBC redirect lands on the right tunnel.
+
+Smoke-test connectivity from a notebook before chasing JDBC errors:
+
+```python
+import socket, ipaddress
+ip = socket.gethostbyname(SCAN_HOST)            # should be Class-E (255.x) or RFC-1918 - never public
+with socket.create_connection((SCAN_HOST, 1521), timeout=15): pass
+```
+
+## Auth: plain user/password on TCP 1521 + server-enforced NNE (live-validated)
+
+This is the only supported auth path for ExaCS from AIDP notebooks. Wallet/TCPS and IAM DB-Token are not workable in the AIDP notebook environment for ExaCS clusters and have been intentionally removed from this skill.
+
+ExaCS deployments commonly enforce Oracle Native Network Encryption (NNE) server-side:
+`SQLNET.ENCRYPTION_SERVER=REQUIRED` + `SQLNET.ENCRYPTION_TYPES_SERVER=AES256`. The Oracle thin
+driver complies automatically - no client-side `oracle.net.encryption_*` options needed. The
+encrypted session can be verified after connect via `v$session_connect_info.network_service_banner`
+(see snippet below).
+
+```python
+import os
+from oracle_ai_data_platform_connectors.jdbc import (
+    build_oracle_jdbc_url, spark_jdbc_options_password,
+)
+
+url = build_oracle_jdbc_url(
+    host=os.environ["EXACS_HOST"],            # SCAN FQDN or host
+    port=int(os.environ.get("EXACS_PORT", "1521")),
+    service_name=os.environ["EXACS_SERVICE_NAME"],
+    use_tcps=False,                           # plain TCP - encryption is via NNE, not TLS
+)
+opts = spark_jdbc_options_password(
+    url=url,
+    user=os.environ["EXACS_USER"],
+    password=os.environ["EXACS_PASSWORD"],
+)
+df = (spark.read.format("jdbc").options(opts)
+        .option("dbtable", os.environ["EXACS_TABLE_FOR_TEST"]).load())
+df.show(5)
+```
+
+SYS / SYSDBA logon (admin scripts only; not for app workloads):
+
+```python
+opts["oracle.jdbc.internal_logon"] = "sysdba"
+```
+
+Verify in-transit encryption is active (run once per environment):
+
+```python
+enc_q = ("SELECT network_service_banner FROM v$session_connect_info "
+         "WHERE sid = SYS_CONTEXT('USERENV','SID')")
+banners = (spark.read.format("jdbc").options(opts)
+             .option("query", enc_q).load().collect())
+for r in banners:
+    print(r[0])
+# Expect lines including:
+#   AES256 Encryption service adapter for Linux: Version ...
+#   Crypto-checksumming service for Linux: Version ...
+```
+
+## Gotchas
+
+- `scanDetails` is the #1 cause of ORA-17820. If the JDBC URL points at the SCAN listener on a RAC cluster but the workspace doesn't have the SCAN FQDN registered, the redirect fails silently. See "Critical infrastructure prerequisites" above.
+- Port 1521 is NOT plain unencrypted. With NNE configured server-side, port-1521 TCP is AES256 encrypted on the wire. Confirm via `v$session_connect_info` after the first connect - don't assume.
+- No IMDS access from AIDP notebooks - Instance Principal / Resource Principal flows that work elsewhere on OCI compute fail here. Use API Key + inline PEM if you need OCI SDK calls.
+- No wallet/TCPS or IAM DB-Token paths for ExaCS in this skill. Customer ExaCS deployments do not commonly expose TCPS listeners and AIDP notebooks do not support IAM DB-Token against ExaCS. The AIDP notebook environment connects via Native Network Encryption on plain TCP 1521. If you need wallet+TCPS or IAM DB-Token to an Autonomous DB, use the [`aidp-alh`](../aidp-alh/SKILL.md) skill instead.
+- Driver class name - `oracle.jdbc.OracleDriver` is canonical. The legacy alias `oracle.jdbc.driver.OracleDriver` also works but is deprecated.
+
+## References
+- Helpers: [scripts/oracle_ai_data_platform_connectors/jdbc/oracle.py](../../scripts/oracle_ai_data_platform_connectors/jdbc/oracle.py)
+- Live-validated reference notebook (the source of the Option A pattern): [`exacs_intransit_encryption_demo.ipynb`](https://github.com/ahmedawan-oracle/oracle-ai-data-platform-workbench-spark-connectors) on workspace `exacs-private-test` - proves AES256 NNE end-to-end on a customer ExaCS cluster running Oracle 23ai.
+- AIDP private endpoint design (PE-ARCH 1a-3c, SCAN Proxy): see workspace memory `oci_private_endpoint_design.md`.

--- a/plugins/oracle-aidp-connectors/skills/aidp-exacs/SKILL.md
+++ b/plugins/oracle-aidp-connectors/skills/aidp-exacs/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: aidp-exacs
-description: Connect from an AIDP notebook to Oracle Exadata Cloud Service (ExaCS) via Spark JDBC. Use when the user mentions ExaCS, Exadata, Exadata Cloud, RAC SCAN listener, or has a private-subnet Oracle DB. Auth is plain user/password on TCP 1521 with server-enforced AES256 Native Network Encryption (live-validated against Oracle 23ai). Wallet TCPS and IAM DB-Token are not supported by AIDP notebooks for ExaCS.
+description: Connect from an AIDP notebook to Oracle Exadata Cloud Service (ExaCS) via Spark JDBC. Use when the user mentions ExaCS, Exadata, Exadata Cloud, RAC SCAN listener, or has a private-subnet Oracle DB. Auth is plain user/password on TCP 1521 with server-enforced AES256 Native Network Encryption. Wallet TCPS and IAM DB-Token are not supported by AIDP notebooks for ExaCS.
 ---
 
 # `aidp-exacs` - Oracle Exadata Cloud Service via Spark JDBC
@@ -38,7 +38,7 @@ ip = socket.gethostbyname(SCAN_HOST)            # should be Class-E (255.x) or R
 with socket.create_connection((SCAN_HOST, 1521), timeout=15): pass
 ```
 
-## Auth: plain user/password on TCP 1521 + server-enforced NNE (live-validated)
+## Auth: plain user/password on TCP 1521 + server-enforced NNE
 
 This is the only supported auth path for ExaCS from AIDP notebooks. Wallet/TCPS and IAM DB-Token are not workable in the AIDP notebook environment for ExaCS clusters and have been intentionally removed from this skill.
 
@@ -100,5 +100,4 @@ for r in banners:
 
 ## References
 - Helpers: [scripts/oracle_ai_data_platform_connectors/jdbc/oracle.py](../../scripts/oracle_ai_data_platform_connectors/jdbc/oracle.py)
-- Live-validated reference notebook (the source of the Option A pattern): [`exacs_intransit_encryption_demo.ipynb`](https://github.com/ahmedawan-oracle/oracle-ai-data-platform-workbench-spark-connectors) on workspace `exacs-private-test` - proves AES256 NNE end-to-end on a customer ExaCS cluster running Oracle 23ai.
-- AIDP private endpoint design (PE-ARCH 1a-3c, SCAN Proxy): see workspace memory `oci_private_endpoint_design.md`.
+- AIDP private endpoint patterns: PE-ARCH 1a-3c and SCAN Proxy designs for private ExaCS connectivity.

--- a/plugins/oracle-aidp-connectors/skills/aidp-excel/SKILL.md
+++ b/plugins/oracle-aidp-connectors/skills/aidp-excel/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: aidp-excel
+description: Read Excel (.xlsx, .xls) files into a Spark DataFrame from an AIDP notebook. Use when the user mentions Excel, .xlsx, .xls, or has spreadsheet files in a Volume / Object Storage bucket. Two paths - the `com.crealytics.spark.excel` Spark format (cluster jar required) and a `pandas -> CSV -> spark.read.csv` fallback that needs no jars.
+---
+
+# `aidp-excel` - Excel (.xlsx) ingestion
+
+Two ways to land Excel data in Spark: the native Spark Excel format (faster, parallel) or a pandas-mediated CSV path (no cluster setup).
+
+## When to use
+- User has `.xlsx` / `.xls` files in a Volume or Object Storage bucket.
+- Mentioned: "Excel", ".xlsx", "spreadsheet ingestion".
+
+## When NOT to use
+- For CSV files -> just use [`aidp-object-storage`](../aidp-object-storage/SKILL.md). Spark reads CSV natively.
+
+## Option C - Pure-stdlib parser (no openpyxl, no JARs)
+
+The plugin ships a stdlib-only `.xlsx` reader. No `openpyxl`. No Crealytics JAR. Works on AIDP clusters that have neither PyPI access nor Maven access for the Crealytics dependency closure.
+
+```python
+import os
+from oracle_ai_data_platform_connectors.excel import read_xlsx_stdlib
+
+xlsx_path = os.environ["EXCEL_PATH"]
+header, *body = read_xlsx_stdlib(xlsx_path)
+df = spark.createDataFrame(body, schema=header)
+df.show()
+```
+
+Limitations: read-only (no stdlib path to write .xlsx), first sheet only by default (pass `sheet_path="xl/worksheets/sheet2.xml"` for others), best-effort cell type coercion. Good for ingestion of small-to-medium workbooks; for big files (>50 MB) prefer Option A's `com.crealytics.spark.excel` JAR for parallel reads.
+
+The implementation is at [scripts/oracle_ai_data_platform_connectors/excel.py](../../scripts/oracle_ai_data_platform_connectors/excel.py).
+
+## Option A - `com.crealytics.spark.excel` format
+
+### Cluster prerequisite
+Upload the Crealytics Spark Excel jar (and its Apache POI dependencies) to a Volume and attach via the cluster Library tab:
+
+| JAR | Maven coordinates |
+|---|---|
+| spark-excel | `com.crealytics:spark-excel_2.12:3.5.0_0.20.4` (matches Spark 3.5; pick the `_<spark-ver>_<release>` matching your cluster) |
+| poi | bundled with spark-excel; if missing, add `org.apache.poi:poi-ooxml:5.2.5` and transitive deps |
+
+```python
+import os
+
+excel_path = os.environ["EXCEL_PATH"]   # e.g. /Volumes/default/default/uploads/data.xlsx
+
+df = (spark.read
+      .format("com.crealytics.spark.excel")
+      .option("header", "true")
+      .option("inferSchema", "true")
+      .option("dataAddress", "'Sheet1'!A1")    # optional - default is first sheet, A1
+      .load(excel_path))
+df.show()
+```
+
+Strengths: parallel reads on large workbooks; predicate pushdown.
+
+## Option B - pandas -> CSV -> Spark (no jars)
+
+```python
+import os, pandas as pd
+
+excel_path = os.environ["EXCEL_PATH"]
+csv_path   = excel_path.replace(".xlsx", ".csv")
+
+# Read with pandas (single-threaded, in-driver)
+pdf = pd.read_excel(excel_path)
+
+# Convert to CSV in the same Volume / Object Storage path
+pdf.to_csv(csv_path, index=False)
+print(pdf.head())
+
+# Re-read as Spark for distributed downstream work
+df = spark.read.csv(csv_path, header=True, inferSchema=True)
+df.show()
+```
+
+Strengths: no cluster JAR install. Tradeoff: driver-side single-threaded read; OOM risk for files >500 MB.
+
+## Gotchas
+- `com.crealytics.spark.excel` jar version must match the cluster's Spark version. A 3.4 jar on a 3.5 cluster errors out at format registration time.
+- `dataAddress` for multi-sheet files - `"'Sheet 2'!A1"` (note quotes around sheet name with spaces).
+- `inferSchema=true` is slow for big files - pre-declare schema with `.schema(...)` for production jobs.
+- Encoding / merged cells - pandas handles most quirks; the Spark Excel jar can choke on merged-cell headers. If you see misaligned columns, prefer Option B.
+- Excel files in `oci://` - both options work; pass `oci://bucket@ns/path/file.xlsx` directly, or pre-stage to `/Volumes/...` for repeated reads.
+
+## References
+- Official sample: [oracle-samples/oracle-aidp-samples -> `data-engineering/ingestion/Read_excel_data/read_excel.ipynb`](https://github.com/oracle-samples/oracle-aidp-samples/blob/main/data-engineering/ingestion/Read_excel_data/read_excel.ipynb)
+- Crealytics Spark Excel: <https://github.com/crealytics/spark-excel>

--- a/plugins/oracle-aidp-connectors/skills/aidp-fusion-bicc/SKILL.md
+++ b/plugins/oracle-aidp-connectors/skills/aidp-fusion-bicc/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: aidp-fusion-bicc
+description: Pull a Fusion BICC bulk extract into a Spark DataFrame from an AIDP notebook. Use when the user mentions BICC, Fusion bulk extract, BI Cloud Connector, PVO, or needs >50k rows from Fusion. The recommended path uses AIDP's built-in `spark.read.format("aidataplatform")` connector (matches the official Oracle AIDP sample). HTTP Basic auth.
+---
+
+# `aidp-fusion-bicc` - Fusion BICC bulk extract -> Spark
+
+Mirrors the official Oracle AIDP sample at [oracle-samples/oracle-aidp-samples -> `data-engineering/ingestion/Read_Only_Ingestion_Connectors.ipynb`](https://github.com/oracle-samples/oracle-aidp-samples/blob/main/data-engineering/ingestion/Read_Only_Ingestion_Connectors.ipynb), which routes BICC through AIDP's built-in `aidataplatform` format handler.
+
+## When to use
+- User wants a bulk extract from Fusion (millions of rows, daily snapshots, full-table loads).
+- User mentions: "BICC", "Fusion bulk extract", "BI Cloud Connector", "PVO extract".
+- Live REST paging would be too slow (>50k rows or daily refresh).
+
+## When NOT to use
+- For small/live REST queries -> use [`aidp-fusion-rest`](../aidp-fusion-rest/SKILL.md).
+
+## Prerequisites in the AIDP notebook
+1. AIDP-side prep (one-time, by an administrator): an `EXTERNAL STORAGE` profile registered in the AIDP catalog pointing at the OCI Object Storage bucket BICC writes to. The user references it by name via `fusion.external.storage` - they don't supply OCI credentials in the notebook.
+2. Fusion-side requirement: the Fusion user must have a BICC-administrator role (e.g. `BIA_ADMINISTRATOR_DUTY`). A regular Fusion REST user (Finance Manager persona) gets a 302 to IDCS instead of BICC JSON - confirmed live.
+3. The PVO (Public View Object) name and its source schema (e.g. `ERP`).
+4. Helpers on `sys.path`.
+
+## Auth: HTTP Basic (Recommended path = AIDP `aidataplatform` format)
+
+### Option A - AIDP built-in connector (recommended; matches official sample)
+
+```python
+import os
+from oracle_ai_data_platform_connectors.rest.fusion import read_bicc_via_aidp_format
+
+df = read_bicc_via_aidp_format(
+    spark=spark,
+    fusion_service_url=os.environ["FUSION_BICC_BASE_URL"],
+    username=os.environ["FUSION_BICC_USER"],            # MUST have BICC privileges
+    password=os.environ["FUSION_BICC_PASSWORD"],
+    schema=os.environ["FUSION_BICC_SCHEMA"],            # e.g. "ERP"
+    datastore=os.environ["FUSION_BICC_PVO"],            # the PVO name
+    fusion_external_storage=os.environ["FUSION_BICC_EXTERNAL_STORAGE"],
+)
+df.show(5)
+print("rows:", df.count())
+```
+
+The AIDP format handler does the BICC trigger, polling, manifest read, and OCI Object Storage CSV materialization internally - the user just gets a Spark DataFrame.
+
+Equivalent verbatim invocation (same as the official Oracle sample):
+
+```python
+df = (
+    spark.read.format("aidataplatform")
+        .option("type", "FUSION_BICC")
+        .option("fusion.service.url", os.environ["FUSION_BICC_BASE_URL"])
+        .option("user.name", os.environ["FUSION_BICC_USER"])
+        .option("password", os.environ["FUSION_BICC_PASSWORD"])
+        .option("schema", os.environ["FUSION_BICC_SCHEMA"])
+        .option("fusion.external.storage", os.environ["FUSION_BICC_EXTERNAL_STORAGE"])
+        .option("datastore", os.environ["FUSION_BICC_PVO"])
+        .load()
+)
+```
+
+### Option B - Custom REST trigger + manual Object Storage read (fallback)
+
+Only use this when the AIDP `aidataplatform` connector isn't available on the cluster, when you need a custom polling cadence, or when you want to inspect the `MANIFEST.MF` directly. NOT validated against the official sample - endpoint paths and response schema are best-effort and may need adjustment per Fusion version.
+
+```python
+import os
+from oracle_ai_data_platform_connectors.auth import http_basic_session
+from oracle_ai_data_platform_connectors.rest.fusion import (
+    trigger_bicc_extract, read_bicc_csv_from_object_storage,
+)
+
+session = http_basic_session(
+    username=os.environ["FUSION_BICC_USER"],
+    password=os.environ["FUSION_BICC_PASSWORD"],
+    base_url=os.environ["FUSION_BICC_BASE_URL"],
+)
+prefix = trigger_bicc_extract(
+    session=session,
+    base_url=os.environ["FUSION_BICC_BASE_URL"],
+    offering=os.environ["FUSION_BICC_OFFERING"],
+    poll_interval_seconds=30,
+    timeout_seconds=3600,
+)
+df = read_bicc_csv_from_object_storage(
+    spark=spark,
+    namespace=os.environ["OCI_NAMESPACE"],
+    bucket=os.environ["OCI_BUCKET_BICC"],
+    prefix=prefix,
+)
+print("rows:", df.count())
+```
+
+## Gotchas
+- BICC privileges - Fusion user must hold a BICC-admin role. Without it, `/biacm/api/v[12]/*` endpoints 302-redirect to IDCS OAuth (HTTP Basic isn't honored). This is the most common validation failure. Confirmed behavior on a demo pod: every BICC endpoint redirected for a finance-manager persona without BICC privileges.
+- `fusion.external.storage` is a catalog-managed name, not a URL. Set it up once via AIDP Catalog UI (or `oci aidataplatform` CLI), then reference by name. The user never types OCI namespace/bucket in the notebook for Option A.
+- `schema` and `datastore` - these are BICC concepts: `schema` = offering schema (`ERP`, `HCM`, etc.); `datastore` = PVO name (e.g. `FscmTopModelAM.AnalyticsServiceAM`). Get them from the BICC console under "Configure Cloud Extract".
+- First extract is slow - BICC builds a full snapshot. Subsequent runs are incremental. Plan for >5 min on the first call.
+- Schema inference is slow on big CSVs (Option B path). Option A's connector knows the schema in advance from the BICC metadata.
+
+## References
+- Helpers: [scripts/oracle_ai_data_platform_connectors/rest/fusion.py](../../scripts/oracle_ai_data_platform_connectors/rest/fusion.py)
+- Official Oracle AIDP sample: [Read_Only_Ingestion_Connectors.ipynb](https://github.com/oracle-samples/oracle-aidp-samples/blob/main/data-engineering/ingestion/Read_Only_Ingestion_Connectors.ipynb)
+- BICC docs: https://docs.oracle.com/en/cloud/saas/applications-common/24a/oafsm/

--- a/plugins/oracle-aidp-connectors/skills/aidp-fusion-rest/SKILL.md
+++ b/plugins/oracle-aidp-connectors/skills/aidp-fusion-rest/SKILL.md
@@ -1,0 +1,61 @@
+---
+name: aidp-fusion-rest
+description: Pull data from Oracle Fusion ERP / HCM / SCM REST APIs into a Spark DataFrame from an AIDP notebook. Use when the user mentions Fusion ERP, Fusion REST API, FA REST, Cloud ERP, or wants live data from a Fusion pod. HTTP Basic auth only. For volumes >499 rows/page or bulk extracts, route to aidp-fusion-bicc.
+---
+
+# `aidp-fusion-rest` - Fusion ERP / HCM / SCM REST -> Spark
+
+## When to use
+- User wants to pull a small-to-medium volume of records from Fusion REST APIs (`/fscmRestApi/`, `/hcmRestApi/`, etc.) into a Spark DataFrame.
+- User mentions: "Fusion ERP", "Fusion REST", "FA REST", "Cloud ERP API".
+- Total expected rows fit comfortably in memory (<= ~50k); for >499 rows the helper auto-pages, but for bulk -> BICC is faster.
+
+## When NOT to use
+- For bulk extracts (>50k rows, daily snapshots) -> use [`aidp-fusion-bicc`](../aidp-fusion-bicc/SKILL.md). Fusion's REST surface is hard-capped at 499 rows/page (MOS Doc ID 2429019.1) - pulling millions paginated is slow.
+- For EPM Cloud Planning -> use [`aidp-epm-cloud`](../aidp-epm-cloud/SKILL.md).
+- For Essbase MDX -> use [`aidp-essbase`](../aidp-essbase/SKILL.md).
+
+## Prerequisites in the AIDP notebook
+1. `pip install requests pandas` (usually already on the cluster).
+2. Helpers on `sys.path`.
+3. Fusion pod URL + HTTP Basic credentials.
+
+## Auth: HTTP Basic
+
+```python
+import os
+from oracle_ai_data_platform_connectors.auth import http_basic_session
+from oracle_ai_data_platform_connectors.rest.fusion import (
+    fetch_paged, rows_to_spark_dataframe,
+)
+
+session = http_basic_session(
+    username=os.environ["FUSION_USER"],
+    password=os.environ["FUSION_PASSWORD"],
+    base_url=os.environ["FUSION_BASE_URL"],
+)
+
+rows = fetch_paged(
+    session=session,
+    base_url=os.environ["FUSION_BASE_URL"],
+    path="/fscmRestApi/resources/11.13.18.05/invoices",
+    fields="InvoiceId,InvoiceNumber,InvoiceAmount,InvoiceDate",
+    extra_params={"q": "InvoiceDate >= '2026-01-01'"},
+)
+
+df = rows_to_spark_dataframe(spark, rows)
+df.show(5)
+print("rows:", df.count())
+```
+
+## Gotchas
+- 499 row/page hard cap - Fusion silently truncates `limit=500+` to 499. Helper enforces this automatically.
+- `onlyData=true` - helper sets this so only the actual fields come back, not Fusion's HATEOAS link envelope. Saves bandwidth.
+- `q=` filter syntax is Fusion-specific (`q=InvoiceDate >= '2026-01-01' AND Status = 'PAID'`). Quote string values in single quotes.
+- Nested struct columns - Fusion responses contain nested objects (links, addresses). `rows_to_spark_dataframe()` defaults to `mode="json_string"` which packs each row into a single `row_json` column. Use `from_json` downstream to project specific fields.
+- Network - Fusion pods are public (`*.fa.<region>.oraclecloud.com`); no AIDP VCN routing needed.
+
+## References
+- Helpers: [scripts/oracle_ai_data_platform_connectors/rest/fusion.py](../../scripts/oracle_ai_data_platform_connectors/rest/fusion.py)
+- Auth helpers: [scripts/oracle_ai_data_platform_connectors/auth/user_principal.py](../../scripts/oracle_ai_data_platform_connectors/auth/user_principal.py)
+- Fusion REST API catalog: https://docs.oracle.com/en/cloud/saas/applications-common/24a/farws/index.html

--- a/plugins/oracle-aidp-connectors/skills/aidp-hive/SKILL.md
+++ b/plugins/oracle-aidp-connectors/skills/aidp-hive/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: aidp-hive
+description: Read or write Apache Hive from an AIDP notebook via the AIDP `aidataplatform` Spark format handler. Use when the user mentions Hive, HiveServer2, HS2, HCatalog, or has a Hive metastore host/port. Auth is host/port + user/password. Read-write.
+---
+
+# `aidp-hive` - Apache Hive via AIDP `aidataplatform`
+
+## When to use
+- User wants to read or write a Hive table from an AIDP notebook.
+- User mentions: "Hive", "HiveServer2", "HS2", "HCatalog", "Hive metastore", a Hive database/table name.
+
+## When NOT to use
+- For Oracle Big Data Service (BDS) HiveServer2 with Kerberos auth via Spark JDBC -> use a custom skill (we removed `aidp-bds-hive` from v0.4 scope; revisit if your customer needs Kerberos specifically). The current `aidp-hive` skill covers non-Kerberos Hive (LDAP / SASL-PLAIN / NoAuth) via the `aidataplatform` format handler.
+- For Iceberg-on-Hive-style metadata where data lives on `oci://` -> [`aidp-iceberg`](../aidp-iceberg/SKILL.md).
+
+## Prerequisites in the AIDP notebook
+1. Helpers on `sys.path` (run `aidp-connectors-bootstrap` first).
+2. Network: cluster must reach the HS2 host on the configured port (typically 10000). If your Hive lives in a customer VCN, ensure VCN peering is in place - the cluster pod CIDR has no implicit route to user VCNs.
+3. Env vars / OCI Vault secrets:
+   - `HIVE_HOST` (HiveServer2 hostname)
+   - `HIVE_PORT` (typically `10000`)
+   - `HIVE_USER`, `HIVE_PASSWORD`
+   - `HIVE_SCHEMA` (Hive database name)
+   - `HIVE_TABLE` (Hive table name)
+
+## Read
+
+```python
+import os
+from oracle_ai_data_platform_connectors.aidataplatform import (
+    AIDP_FORMAT, aidataplatform_options,
+)
+
+opts = aidataplatform_options(
+    type="HIVE",
+    host=os.environ["HIVE_HOST"],
+    port=int(os.environ.get("HIVE_PORT", "10000")),
+    user=os.environ["HIVE_USER"],
+    password=os.environ["HIVE_PASSWORD"],
+    schema=os.environ["HIVE_SCHEMA"],
+    table=os.environ["HIVE_TABLE"],
+)
+df = spark.read.format(AIDP_FORMAT).options(opts).load()
+df.show(10)
+```
+
+## Write
+
+```python
+opts = aidataplatform_options(
+    type="HIVE",
+    host=os.environ["HIVE_HOST"],
+    port=int(os.environ.get("HIVE_PORT", "10000")),
+    user=os.environ["HIVE_USER"],
+    password=os.environ["HIVE_PASSWORD"],
+    schema=os.environ["HIVE_SCHEMA"],
+    table=os.environ["HIVE_TARGET_TABLE"],
+    extra={"write.mode": "APPEND"},   # CREATE | APPEND | OVERWRITE
+)
+df.write.format(AIDP_FORMAT).options(opts).save()
+```
+
+## Pushdown SQL
+
+```python
+opts = aidataplatform_options(
+    type="HIVE",
+    host=os.environ["HIVE_HOST"],
+    port=int(os.environ.get("HIVE_PORT", "10000")),
+    user=os.environ["HIVE_USER"],
+    password=os.environ["HIVE_PASSWORD"],
+    extra={
+        "pushdown.sql": (
+            "SELECT customer_id, SUM(amount) AS total "
+            "FROM sales_db.transactions "
+            "WHERE event_dt >= '2025-01-01' "
+            "GROUP BY customer_id"
+        ),
+    },
+)
+df = spark.read.format(AIDP_FORMAT).options(opts).load()
+df.show(10)
+```
+
+## Gotchas
+- No `database.name` option - Hive uses `schema` directly to identify the Hive database (e.g. `default`, `sales_db`). Don't pass `database_name`.
+- Network reachability is the most common failure. Smoke-test from the cluster: `socket.create_connection((host, port), timeout=8)`. If this fails, it's a network problem, not an auth problem - VCN peering / NSG / DNS, in that order.
+- No Kerberos on this skill. This connector handler uses LDAP / SASL-PLAIN / NoAuth. If your Hive cluster only accepts Kerberos, you need a Spark-native JDBC path with a keytab (out of scope for v0.5 - file an issue).
+- Write modes - `CREATE` (fail if exists), `APPEND`, `OVERWRITE`. Default is `CREATE`.
+- Partitioned tables. When writing to a partitioned Hive table, `OVERWRITE` overwrites all partitions touched by the DataFrame's distinct partition keys; existing partitions not touched are preserved.
+
+## References
+- Helper: [scripts/oracle_ai_data_platform_connectors/aidataplatform.py](../../scripts/oracle_ai_data_platform_connectors/aidataplatform.py)
+- Official sample: [oracle-samples/oracle-aidp-samples -> `data-engineering/ingestion/Read_Write_External_Ecosystem_Connectors/Hive.ipynb`](https://github.com/oracle-samples/oracle-aidp-samples/blob/main/data-engineering/ingestion/Read_Write_External_Ecosystem_Connectors/Hive.ipynb)

--- a/plugins/oracle-aidp-connectors/skills/aidp-iceberg/SKILL.md
+++ b/plugins/oracle-aidp-connectors/skills/aidp-iceberg/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: aidp-iceberg
+description: Read and write Apache Iceberg tables backed by OCI Object Storage from an AIDP notebook. Use when the user mentions Iceberg, Apache Iceberg, time travel, snapshots, schema evolution, partition evolution, or wants ACID transactions on data lake files. Uses the Iceberg Hadoop catalog on `oci://` - auth is implicit via the workspace IAM identity.
+---
+
+# `aidp-iceberg` - Apache Iceberg on OCI Object Storage
+
+Manage Iceberg tables (ACID, time travel, schema evolution, partition pruning) backed by OCI Object Storage as the warehouse. The Iceberg Hadoop catalog stores all metadata in the same bucket as data - no external metastore.
+
+## When to use
+- Iceberg tables on OCI Object Storage.
+- Mentioned: "Iceberg", "time travel", "snapshots", "schema evolution".
+
+## When NOT to use
+- For raw CSV/Parquet/JSON files in `oci://` (no transactions / time-travel) -> [`aidp-object-storage`](../aidp-object-storage/SKILL.md).
+- For Iceberg tables on AWS / Azure -> adapt this skill's catalog config; the Hadoop catalog is portable but the bucket URI changes.
+
+## One-time catalog registration
+
+```python
+OCI_NAMESPACE = "<namespace>"
+BUCKET_NAME   = "<bucket>"
+WAREHOUSE     = f"oci://{BUCKET_NAME}@{OCI_NAMESPACE}/iceberg-warehouse"
+CATALOG_NAME  = "oci_catalog"
+
+spark.conf.set(f"spark.sql.catalog.{CATALOG_NAME}",            "org.apache.iceberg.spark.SparkCatalog")
+spark.conf.set(f"spark.sql.catalog.{CATALOG_NAME}.type",       "hadoop")
+spark.conf.set(f"spark.sql.catalog.{CATALOG_NAME}.warehouse",  WAREHOUSE)
+```
+
+After this, all SQL referring to `oci_catalog.<db>.<table>` is Iceberg-managed.
+
+## Create database + table
+
+```python
+DB    = "demo_db"
+TABLE = "employees"
+FQN   = f"{CATALOG_NAME}.{DB}.{TABLE}"
+
+spark.sql(f"CREATE DATABASE IF NOT EXISTS {CATALOG_NAME}.{DB}")
+spark.sql(f"""
+    CREATE TABLE {FQN} (
+        employee_id   INT,
+        employee_name STRING,
+        salary        DOUBLE,
+        department    STRING,
+        hire_date     DATE
+    )
+    USING iceberg
+    PARTITIONED BY (department)
+""")
+```
+
+## Insert (each call is one ACID transaction = one snapshot)
+
+```python
+import pandas as pd
+from datetime import date
+
+pdf = pd.DataFrame([
+    (101, "John Doe",       75000.0, "Engineering", date(2022, 1, 15)),
+    (102, "Jane Smith",     85000.0, "Sales",       date(2021, 3, 20)),
+], columns=["employee_id", "employee_name", "salary", "department", "hire_date"])
+
+spark.createDataFrame(pdf).writeTo(FQN).append()
+```
+
+## Schema evolution (no rewrite)
+
+```python
+spark.sql(f"ALTER TABLE {FQN} ADD COLUMN location STRING")
+# Old rows show NULL for the new column; no errors.
+```
+
+## Time travel
+
+```python
+snaps = spark.sql(f"""
+    SELECT snapshot_id, committed_at, operation
+    FROM {FQN}.snapshots
+    ORDER BY committed_at
+""").collect()
+first = snaps[0].snapshot_id
+spark.sql(f"SELECT * FROM {FQN} VERSION AS OF {first}").show()
+```
+
+## Inspect physical files
+
+```python
+spark.sql(f"""
+    SELECT file_path, file_format, record_count, file_size_in_bytes
+    FROM {FQN}.files
+""").show(truncate=False)
+```
+
+## Gotchas
+- Auth is implicit - same as [`aidp-object-storage`](../aidp-object-storage/SKILL.md). The workspace IAM identity reads/writes Object Storage. No keys.
+- Hadoop catalog stores metadata IN the bucket. Snapshots, schema versions, manifests all sit under `<warehouse>/<db>/<table>/metadata/`. There is no Hive metastore, no Glue, no JDBC catalog.
+- `USING iceberg` is required in CREATE TABLE; otherwise Spark uses the default V1 file source and you lose ACID.
+- Time-travel requires the snapshot ID - keeping a long retention helps. Iceberg expires snapshots based on table properties (`history.expire.max-snapshot-age-ms`); set this if long-term time travel matters.
+- Partition pruning kicks in for queries with predicates on the partition column (`department` in the example). Without that predicate Iceberg still reads all files but in parallel.
+
+## References
+- Official sample: [oracle-samples/oracle-aidp-samples -> `data-engineering/ingestion/Ingest_into_iceberg_hadoop_catalog_oci_native.ipynb`](https://github.com/oracle-samples/oracle-aidp-samples/blob/main/data-engineering/ingestion/Ingest_into_iceberg_hadoop_catalog_oci_native.ipynb)
+- Apache Iceberg docs: <https://iceberg.apache.org/docs/latest/spark-getting-started/>

--- a/plugins/oracle-aidp-connectors/skills/aidp-jdbc-custom/SKILL.md
+++ b/plugins/oracle-aidp-connectors/skills/aidp-jdbc-custom/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: aidp-jdbc-custom
+description: Connect to ANY database that has a JDBC driver from an AIDP notebook using Spark's native `format("jdbc")`. Use when the user mentions a DB without a dedicated AIDP connector - SQLite, ClickHouse, DuckDB, generic JDBC URL - or wants to use a custom JDBC driver they uploaded. Auth is driver-specific.
+---
+
+# `aidp-jdbc-custom` - Generic JDBC escape hatch
+
+The catch-all skill for any DB with a JDBC driver. Skips the AIDP `aidataplatform` format and uses native Spark JDBC. Useful for DBs like SQLite, ClickHouse, DuckDB, IBM DB2, SAP HANA, or any niche driver the user has uploaded.
+
+## When to use
+- The DB doesn't have a dedicated `aidp-*` skill in this plugin.
+- User has a `.jar` JDBC driver they want to use.
+- Mentioned: "custom JDBC", "JDBC driver", "any JDBC".
+
+## When NOT to use
+- For Postgres / MySQL / SQL Server / Oracle -> use the dedicated skill. The `aidataplatform` format gives the connector pushdown and connection pooling that this skill doesn't.
+- For Snowflake -> [`aidp-snowflake`](../aidp-snowflake/SKILL.md). The Spark connector is much better than raw JDBC.
+
+## Two ways to load a non-bundled JDBC driver
+
+### Option A - Runtime-load (fast path; requires approval)
+
+The plugin ships a helper that loads a JDBC JAR into a running Spark session via Java's URLClassLoader + DriverManager. It works without admin access and without restarting the kernel.
+
+Before downloading or classloading a third-party JAR, confirm the Maven URL,
+version pin, and checksum if available. For durable production notebooks,
+prefer the cluster Library tab or a user-managed Volume with approved JARs.
+
+```python
+import os
+from oracle_ai_data_platform_connectors.jdbc import (
+    add_jdbc_jar_at_runtime, download_jdbc_jar,
+)
+
+# Download once (Maven Central is reachable from AIDP clusters)
+jar = download_jdbc_jar(
+    maven_url="https://repo1.maven.org/maven2/org/xerial/sqlite-jdbc/3.46.0.0/sqlite-jdbc-3.46.0.0.jar",
+    target_path="/tmp/sqlite-jdbc-3.46.0.0.jar",
+    # sha256="...",
+)
+
+# Register with the running Spark session
+add_jdbc_jar_at_runtime(spark, jar_path=jar, driver_class="org.sqlite.JDBC")
+
+# Now standard Spark JDBC works
+df = (spark.read.format("jdbc")
+      .option("url",      "jdbc:sqlite::memory:")
+      .option("driver",   "org.sqlite.JDBC")
+      .option("dbtable",  "(SELECT 1 AS c1, 2 AS c2, 3 AS c3)")
+      .option("fetchsize","1000")
+      .load())
+df.show()
+```
+
+The helper is implemented at [scripts/oracle_ai_data_platform_connectors/jdbc/runtime_load.py](../../scripts/oracle_ai_data_platform_connectors/jdbc/runtime_load.py) - internally it builds a URLClassLoader rooted at the existing thread context loader, calls `DriverManager.registerDriver`, and sets the JVM thread context class loader so Spark's `Utils.classForName` resolves the driver class.
+
+### Option B - Cluster Library tab (durable, requires admin)
+
+For frequently-used drivers, upload the JAR to a Volume and attach via the cluster Library tab. This persists across cluster restarts. Requires cluster admin access. After attach + restart:
+
+```python
+# Driver class is now on the system classpath; no runtime trick needed.
+df = (spark.read.format("jdbc")
+      .option("url", JDBC_URL).option("driver", DRIVER)
+      .option("dbtable", TABLE).load())
+```
+
+## Generic template
+
+```python
+df = (spark.read.format("jdbc")
+      .option("url",      "jdbc:<vendor>://<host>:<port>/<db>")
+      .option("driver",   "<full.class.Name>")
+      .option("user",     os.environ["CUST_DB_USER"])
+      .option("password", os.environ["CUST_DB_PASSWORD"])
+      .option("dbtable",  os.environ["CUST_DB_TABLE"])
+      .option("fetchsize", "10000")
+      .load())
+```
+
+## Common driver classes
+
+| DB | Driver class | URL prefix |
+|---|---|---|
+| SQLite | `org.sqlite.JDBC` | `jdbc:sqlite:` |
+| ClickHouse | `com.clickhouse.jdbc.ClickHouseDriver` | `jdbc:clickhouse://` |
+| DuckDB | `org.duckdb.DuckDBDriver` | `jdbc:duckdb:` |
+| IBM DB2 | `com.ibm.db2.jcc.DB2Driver` | `jdbc:db2://` |
+| SAP HANA | `com.sap.db.jdbc.Driver` | `jdbc:sap://` |
+| Vertica | `com.vertica.jdbc.Driver` | `jdbc:vertica://` |
+
+## Gotchas
+- No predicate pushdown beyond what Spark JDBC infers. This skill is the escape hatch, not the optimized path.
+- `dbtable` accepts a subquery - wrap in parens to filter at the source: `option("dbtable", "(SELECT * FROM big_table WHERE date > '2025-01-01') t")`.
+- `fetchsize=10000` is a good default; smaller values create driver chatter, larger values risk OOM on the executor.
+- Partitioning - for parallel reads, use `option("partitionColumn", ...).option("lowerBound", ...).option("upperBound", ...).option("numPartitions", N)`. Without these the read is single-partition and serial.
+- Driver JAR mismatch - symptom is `ClassNotFoundException: <driver class>`. Re-check that the JAR is attached to the running cluster (not just uploaded to a Volume).
+
+## References
+- Official sample: [oracle-samples/oracle-aidp-samples -> `data-engineering/ingestion/Connect_Using_Custom_JDBC_Driver.ipynb`](https://github.com/oracle-samples/oracle-aidp-samples/blob/main/data-engineering/ingestion/Connect_Using_Custom_JDBC_Driver.ipynb)
+- Spark JDBC docs: <https://spark.apache.org/docs/latest/sql-data-sources-jdbc.html>

--- a/plugins/oracle-aidp-connectors/skills/aidp-mysql/SKILL.md
+++ b/plugins/oracle-aidp-connectors/skills/aidp-mysql/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: aidp-mysql
+description: Read or write MySQL or OCI MySQL HeatWave from an AIDP notebook via the AIDP `aidataplatform` Spark format handler. Use when the user mentions MySQL, HeatWave, MySQL Database Service, MDS, or has a MySQL host/port. Auth is host/port + user/password.
+---
+
+# `aidp-mysql` - MySQL / OCI MySQL HeatWave via AIDP `aidataplatform`
+
+Covers both on-prem / generic MySQL (`type=MYSQL`) and OCI MySQL HeatWave (`type=MYSQL_HEATWAVE`). The option shape is identical; only the `type` differs. For most workloads pick `MYSQL` and the connector will route correctly. Choose `MYSQL_HEATWAVE` to get HeatWave-aware optimizations (the AIDP connector pushes down compatible ops to the HeatWave accelerator).
+
+## When to use
+- Read or write MySQL or OCI HeatWave from an AIDP notebook.
+- Mentioned: "MySQL", "HeatWave", "MDS", "MySQL Database Service".
+
+## When NOT to use
+- For Postgres -> [`aidp-postgresql`](../aidp-postgresql/SKILL.md).
+- For SQL Server -> [`aidp-sqlserver`](../aidp-sqlserver/SKILL.md).
+
+## Read
+```python
+import os
+from oracle_ai_data_platform_connectors.aidataplatform import (
+    AIDP_FORMAT, aidataplatform_options,
+)
+
+opts = aidataplatform_options(
+    type=os.environ.get("MYSQL_TYPE", "MYSQL"),  # or "MYSQL_HEATWAVE"
+    host=os.environ["MYSQL_HOST"],
+    port=int(os.environ.get("MYSQL_PORT", "3306")),
+    user=os.environ["MYSQL_USER"],
+    password=os.environ["MYSQL_PASSWORD"],
+    schema=os.environ["MYSQL_SCHEMA"],   # MySQL schema = database name
+    table=os.environ["MYSQL_TABLE"],
+)
+df = spark.read.format(AIDP_FORMAT).options(opts).load()
+df.show(5)
+```
+
+## Write
+```python
+opts = aidataplatform_options(
+    type="MYSQL",
+    host=os.environ["MYSQL_HOST"],
+    port=int(os.environ.get("MYSQL_PORT", "3306")),
+    user=os.environ["MYSQL_USER"],
+    password=os.environ["MYSQL_PASSWORD"],
+    schema=os.environ["MYSQL_SCHEMA"],
+    table=os.environ["MYSQL_TARGET_TABLE"],
+    extra={"write.mode": "CREATE"},
+)
+df.write.format(AIDP_FORMAT).options(opts).save()
+```
+
+## Gotchas
+- `schema` = MySQL database name. MySQL conflates "schema" and "database"; pass the database name as `schema`.
+- HeatWave routing - pass `type=MYSQL_HEATWAVE` to enable HeatWave-aware predicate pushdown. The MySQL DB Service still works under `type=MYSQL`; you only get HeatWave acceleration with the explicit type.
+- Default port 3306 for MySQL / HeatWave; OCI HeatWave Lakehouse exposes port 33060 (XAPI) - use `MYSQL_PORT=33060` for that case.
+- Network reachability - same constraint as PostgreSQL: must be reachable from the AIDP cluster's VCN.
+
+## References
+- Helper: [scripts/oracle_ai_data_platform_connectors/aidataplatform.py](../../scripts/oracle_ai_data_platform_connectors/aidataplatform.py)
+- Official sample (MYSQL): [oracle-samples/oracle-aidp-samples -> `data-engineering/ingestion/Read_Write_External_Ecosystem_Connectors.ipynb`](https://github.com/oracle-samples/oracle-aidp-samples/blob/main/data-engineering/ingestion/Read_Write_External_Ecosystem_Connectors.ipynb)
+- Official sample (MYSQL_HEATWAVE): [oracle-samples/oracle-aidp-samples -> `data-engineering/ingestion/Read_Only_Ingestion_Connectors.ipynb`](https://github.com/oracle-samples/oracle-aidp-samples/blob/main/data-engineering/ingestion/Read_Only_Ingestion_Connectors.ipynb)

--- a/plugins/oracle-aidp-connectors/skills/aidp-object-storage/SKILL.md
+++ b/plugins/oracle-aidp-connectors/skills/aidp-object-storage/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: aidp-object-storage
+description: Read and write OCI Object Storage natively from an AIDP notebook using the `oci://` URI scheme. Use when the user mentions OCI Object Storage, "oci://", external volumes, external tables backed by Object Storage, CSV/Parquet/JSON/Delta files in a bucket, or wants to land data in OCI buckets. Auth is implicit via the workspace's IAM identity - no keys in the notebook.
+---
+
+# `aidp-object-storage` - OCI Object Storage native (`oci://`)
+
+Read and write Object Storage data directly from Spark. The AIDP cluster's IAM identity is used automatically - no `OCI_CONFIG`, no API keys, no inline PEM.
+
+## When to use
+- Land or read CSV / Parquet / JSON / Avro / Delta files in an OCI bucket from Spark.
+- Register an External Volume (`/Volumes/...`) backed by an OCI bucket.
+- Define an External Table (`USING CSV/PARQUET/...`) over an `oci://` path.
+- Mentioned: "oci://", "Object Storage bucket", "external volume", "external table".
+
+## When NOT to use
+- For Iceberg tables on OCI Object Storage -> use [`aidp-iceberg`](../aidp-iceberg/SKILL.md).
+- For AWS S3 -> use [`aidp-aws-s3`](../aidp-aws-s3/SKILL.md).
+- For Azure ADLS Gen2 -> use [`aidp-azure-adls`](../aidp-azure-adls/SKILL.md).
+
+## URI form
+```
+oci://<bucket>@<namespace>/<path>
+```
+The namespace is the tenancy's Object Storage namespace (OCI Console > Object Storage > Bucket Details).
+
+## Direct read/write
+```python
+import os
+
+oci_path = (
+    f"oci://{os.environ['OCI_BUCKET']}@{os.environ['OCI_NAMESPACE']}/"
+    f"{os.environ['OCI_OBJECT_PREFIX'].rstrip('/')}/sample-output"
+)
+
+# Write only after confirming bucket, namespace, prefix, and save mode.
+df.write.mode("errorifexists").option("header", True).format("csv").save(oci_path)
+
+# Read
+df_read = spark.read.option("header", True).format("csv").load(oci_path)
+df_read.show()
+```
+
+Same pattern with `format("parquet")`, `format("json")`, `format("delta")`.
+
+## External Volume (DDL)
+Mount a bucket once, reference by Volume path forever:
+
+```sql
+CREATE EXTERNAL VOLUME IF NOT EXISTS default.default.ext_volume
+LOCATION 'oci://my-bucket@mynamespace/';
+```
+Then:
+```python
+volume_path = "/Volumes/default/default/ext_volume/folder/file"
+df.write.format("csv").option("header", True).save(volume_path)
+spark.read.option("header", True).format("csv").load(volume_path).show()
+```
+Only drop a volume after the user confirms the catalog, schema, and volume:
+`DROP VOLUME default.default.ext_volume`.
+
+## External Table (DDL)
+Register a table whose data lives in `oci://`:
+
+```sql
+CREATE TABLE IF NOT EXISTS default.default.ext_table (name STRING, age INT)
+USING CSV
+OPTIONS (path='oci://my-bucket@mynamespace/folder/file', delimiter=',', header='true');
+```
+Query like any Spark table:
+```python
+spark.sql("SELECT * FROM default.default.ext_table").show()
+```
+Only drop a table after the user confirms the catalog, schema, and table:
+`DROP TABLE default.default.ext_table`.
+
+## Gotchas
+- Auth is implicit - the AIDP cluster's IAM identity is used. The user never types OCI keys. If reads fail with 404/403, the workspace identity lacks bucket privileges; fix in OCI IAM.
+- Namespace != tenancy name. The Object Storage namespace is a separate, immutable string. Find it in `OCI Console > Profile > Tenancy: <tenancy_name>` - the `object_storage_namespace` field.
+- External volume path is `/Volumes/<catalog>/<schema>/<volume>/...`, NOT `oci://...`. Once a volume is registered, address files via the Volume path.
+- External table `path` option uses `oci://` directly, not the Volume path. Both work; choose based on whether you want a re-mountable abstraction (Volume) or a simple direct reference (Table).
+- `/Workspace/...` is NOT for data. It's a FUSE-mounted file system intended for notebooks/configs. For data files use `oci://` or `/Volumes/...`.
+
+## References
+- Official sample: [oracle-samples/oracle-aidp-samples -> `getting-started/Access_Object_Storage_Data.ipynb`](https://github.com/oracle-samples/oracle-aidp-samples/blob/main/getting-started/Access_Object_Storage_Data.ipynb)

--- a/plugins/oracle-aidp-connectors/skills/aidp-oracle-db/SKILL.md
+++ b/plugins/oracle-aidp-connectors/skills/aidp-oracle-db/SKILL.md
@@ -1,0 +1,126 @@
+---
+name: aidp-oracle-db
+description: Read or write an Oracle Database (Compute / Base DB / on-prem / Oracle 19c, 21c, 23ai, 26ai non-Autonomous) from an AIDP notebook via the AIDP `aidataplatform` Spark format handler. Use when the user mentions Oracle Database, generic Oracle DB, on-prem Oracle, plain Oracle JDBC, port 1521, non-Autonomous Oracle. Read-write. Auth is host/port + database name + user/password.
+---
+
+# `aidp-oracle-db` - Generic Oracle Database via AIDP `aidataplatform`
+
+For non-Autonomous Oracle DBs - Oracle on Compute, Base DB, on-prem, customer-managed Oracle 19c/21c/23ai/26ai. Auth is plain user/password over TCP 1521.
+
+## When to use
+- User wants to read or write a non-Autonomous Oracle Database from an AIDP notebook.
+- User mentions: "Oracle Database", "generic Oracle DB", "on-prem Oracle", "Oracle 19c", "Oracle 21c", "Oracle 23ai non-Autonomous", "Base DB", "Oracle on Compute".
+- User has a host/port + plain user/password (no wallet, no IAM DB-Token).
+
+## When NOT to use
+- For Autonomous DB family (ALH/ADW/ATP) -> [`aidp-alh`](../aidp-alh/SKILL.md). Autonomous always uses TCPS + wallet (or IAM DB-Token) - `aidp-oracle-db` won't work.
+- For Exadata Cloud Service -> [`aidp-exacs`](../aidp-exacs/SKILL.md). ExaCS has its own NNE pattern.
+- For PeopleSoft / Siebel - those run on Oracle DB but have their own dedicated skills with the right schema defaults.
+
+## Prerequisites in the AIDP notebook
+1. Helpers on `sys.path` (run `aidp-connectors-bootstrap` first).
+2. Network: cluster must reach the Oracle DB host on the listener port (typically 1521). For private DBs in customer VCNs, VCN peering is required.
+3. Env vars / OCI Vault secrets:
+   - `ORADB_HOST`, `ORADB_PORT` (typically `1521`)
+   - `ORADB_DATABASE_NAME` (Oracle SID or service name)
+   - `ORADB_USER`, `ORADB_PASSWORD`
+   - `ORADB_SCHEMA`, `ORADB_TABLE`
+
+## Read (inline options)
+
+```python
+import os
+from oracle_ai_data_platform_connectors.aidataplatform import (
+    AIDP_FORMAT, aidataplatform_options,
+)
+
+opts = aidataplatform_options(
+    type="ORACLE_DB",
+    host=os.environ["ORADB_HOST"],
+    port=int(os.environ.get("ORADB_PORT", "1521")),
+    database_name=os.environ["ORADB_DATABASE_NAME"],
+    user=os.environ["ORADB_USER"],
+    password=os.environ["ORADB_PASSWORD"],
+    schema=os.environ["ORADB_SCHEMA"],
+    table=os.environ["ORADB_TABLE"],
+)
+df = spark.read.format(AIDP_FORMAT).options(opts).load()
+df.show(10)
+```
+
+## Write (inline options)
+
+```python
+opts = aidataplatform_options(
+    type="ORACLE_DB",
+    host=os.environ["ORADB_HOST"],
+    port=int(os.environ.get("ORADB_PORT", "1521")),
+    database_name=os.environ["ORADB_DATABASE_NAME"],
+    user=os.environ["ORADB_USER"],
+    password=os.environ["ORADB_PASSWORD"],
+    schema=os.environ["ORADB_SCHEMA"],
+    table=os.environ["ORADB_TARGET_TABLE"],
+    extra={"write.mode": "APPEND"},   # CREATE | APPEND | OVERWRITE
+)
+df.write.format(AIDP_FORMAT).options(opts).save()
+```
+
+## Read via existing external catalog (`catalog.id`)
+
+If your AIDP workspace already has the Oracle DB registered as an external catalog, drop the host/port/credentials entirely and reference the catalog by id:
+
+```python
+opts = aidataplatform_options(
+    type="ORACLE_DB",
+    schema=os.environ["ORADB_SCHEMA"],
+    table=os.environ["ORADB_TABLE"],
+    extra={"catalog.id": os.environ["ORADB_CATALOG_ID"]},
+)
+df = spark.read.format(AIDP_FORMAT).options(opts).load()
+df.show(10)
+```
+
+Or use three-part naming via `spark.table()`:
+
+```python
+df = spark.table(f"{os.environ['ORADB_CATALOG_ID']}.{os.environ['ORADB_SCHEMA']}.{os.environ['ORADB_TABLE']}")
+df.show(10)
+# Confirm the target table and write mode before saving.
+df.write.mode("append").saveAsTable(
+    f"{os.environ['ORADB_CATALOG_ID']}.{os.environ['ORADB_SCHEMA']}.{os.environ['ORADB_TARGET_TABLE']}"
+)
+```
+
+## Pushdown SQL
+
+```python
+opts = aidataplatform_options(
+    type="ORACLE_DB",
+    host=os.environ["ORADB_HOST"],
+    port=int(os.environ.get("ORADB_PORT", "1521")),
+    database_name=os.environ["ORADB_DATABASE_NAME"],
+    user=os.environ["ORADB_USER"],
+    password=os.environ["ORADB_PASSWORD"],
+    extra={
+        "pushdown.sql": (
+            "SELECT department_id, COUNT(*) AS headcount, SUM(salary) AS total "
+            "FROM HR.EMPLOYEES "
+            "WHERE hire_date >= DATE '2024-01-01' "
+            "GROUP BY department_id"
+        ),
+    },
+)
+df = spark.read.format(AIDP_FORMAT).options(opts).load()
+df.show()
+```
+
+## Gotchas
+- `database.name` is the Oracle SID or service name, not the schema. Easy mix-up.
+- Plain user/password only. Wallets and IAM DB-Tokens are Autonomous-DB-only - for those, use `aidp-alh`.
+- Network reachability is the most common failure. From the cluster: `socket.create_connection((host, 1521), timeout=8)`. Failure = network problem (NSG / route table / DNS), not auth.
+- Write modes - `CREATE` (fail if exists), `APPEND`, `OVERWRITE`. Use `MERGE` only via `pushdown.sql` (`MERGE INTO ... WHEN MATCHED ...`) or three-part `saveAsTable` with `write.merge.keys`.
+- NLS settings. Default Oracle dates can come back with timezone surprises. Set `extra={"oracle.jdbc.timezoneAsRegion": "false"}` if you see TZ drift.
+
+## References
+- Helper: [scripts/oracle_ai_data_platform_connectors/aidataplatform.py](../../scripts/oracle_ai_data_platform_connectors/aidataplatform.py)
+- Official sample: [oracle-samples/oracle-aidp-samples -> `data-engineering/ingestion/Read_Write_Oracle_Ecosystem_Connectors/Oracle_Database.ipynb`](https://github.com/oracle-samples/oracle-aidp-samples/blob/main/data-engineering/ingestion/Read_Write_Oracle_Ecosystem_Connectors/Oracle_Database.ipynb)

--- a/plugins/oracle-aidp-connectors/skills/aidp-peoplesoft/SKILL.md
+++ b/plugins/oracle-aidp-connectors/skills/aidp-peoplesoft/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: aidp-peoplesoft
+description: Read from Oracle PeopleSoft into a Spark DataFrame in an AIDP notebook via the AIDP `aidataplatform` Spark format handler. Use when the user mentions PeopleSoft, PSFT, HCM, FSCM, Campus Solutions, or has a PeopleSoft host/port. Auth is host/port + database name + user/password. Read-only.
+---
+
+# `aidp-peoplesoft` - Oracle PeopleSoft via AIDP `aidataplatform`
+
+## When to use
+- User wants to ingest PeopleSoft data (HCM, FSCM, Campus Solutions, ELM, CRM) into a Spark DataFrame from an AIDP notebook.
+- User mentions: "PeopleSoft", "PSFT", "PS HCM", "Campus Solutions".
+
+## When NOT to use
+- For Oracle Autonomous DB family (ALH/ADW/ATP) -> [`aidp-alh`](../aidp-alh/SKILL.md).
+- For generic Oracle DB on Compute / Base DB / on-prem -> [`aidp-oracle-db`](../aidp-oracle-db/SKILL.md).
+- For Oracle Siebel -> [`aidp-siebel`](../aidp-siebel/SKILL.md).
+
+## Prerequisites in the AIDP notebook
+1. Helpers on `sys.path` (run `aidp-connectors-bootstrap` first).
+2. Env vars / OCI Vault secrets:
+   - `PSFT_HOST` (PeopleSoft DB host)
+   - `PSFT_PORT` (typically `1521` for the underlying Oracle DB)
+   - `PSFT_DATABASE_NAME` (Oracle SID / service)
+   - `PSFT_USER`, `PSFT_PASSWORD`
+   - `PSFT_SCHEMA` (typically `SYSADM`)
+   - `PSFT_TABLE` (PeopleSoft record table, e.g. `PS_JOB`, `PS_VOUCHER`)
+
+## Read
+
+```python
+import os
+from oracle_ai_data_platform_connectors.aidataplatform import (
+    AIDP_FORMAT, aidataplatform_options,
+)
+
+opts = aidataplatform_options(
+    type="ORACLE_PEOPLESOFT",
+    host=os.environ["PSFT_HOST"],
+    port=int(os.environ["PSFT_PORT"]),
+    database_name=os.environ["PSFT_DATABASE_NAME"],
+    user=os.environ["PSFT_USER"],
+    password=os.environ["PSFT_PASSWORD"],
+    schema=os.environ.get("PSFT_SCHEMA", "SYSADM"),
+    table=os.environ["PSFT_TABLE"],
+)
+df = spark.read.format(AIDP_FORMAT).options(opts).load()
+df.show(10)
+```
+
+## Pushdown SQL
+
+Push a complete source query at the database - connector skips schema/table option building and runs the SQL verbatim. Useful for joins, filters, derived columns where you don't want Spark to fetch the full table.
+
+```python
+opts = aidataplatform_options(
+    type="ORACLE_PEOPLESOFT",
+    host=os.environ["PSFT_HOST"],
+    port=int(os.environ["PSFT_PORT"]),
+    database_name=os.environ["PSFT_DATABASE_NAME"],
+    user=os.environ["PSFT_USER"],
+    password=os.environ["PSFT_PASSWORD"],
+    extra={
+        "pushdown.sql": (
+            "SELECT EMPLID, EFFDT, DEPTID, JOBCODE "
+            "FROM SYSADM.PS_JOB "
+            "WHERE EFF_STATUS = 'A' AND EFFDT >= DATE '2025-01-01'"
+        ),
+    },
+)
+df = spark.read.format(AIDP_FORMAT).options(opts).load()
+df.show(10)
+```
+
+## Gotchas
+- Connector is read-only. PeopleSoft is treated as a source-of-truth system; writes back must go through PeopleSoft's own application APIs, not Spark.
+- Underlying Oracle DB. Most PeopleSoft installs run on Oracle DB; the connector hits the DB directly. Network reachability rules from `aidp-oracle-db` apply - cluster pod CIDR needs L3 path to the PeopleSoft DB host.
+- `SYSADM` schema is the standard PeopleSoft owner. Ensure the connector user has `SELECT` privs on the PS_* tables you need - PeopleSoft tables are not granted to PUBLIC by default.
+- Read row count before pulling - PeopleSoft fact tables can have hundreds of millions of rows. Always include a `WHERE` filter via `pushdown.sql` for production.
+
+## References
+- Helper: [scripts/oracle_ai_data_platform_connectors/aidataplatform.py](../../scripts/oracle_ai_data_platform_connectors/aidataplatform.py)
+- Official sample: [oracle-samples/oracle-aidp-samples -> `data-engineering/ingestion/Read_Only_Ingestion_Connectors/Oracle_PeopleSoft.ipynb`](https://github.com/oracle-samples/oracle-aidp-samples/blob/main/data-engineering/ingestion/Read_Only_Ingestion_Connectors/Oracle_PeopleSoft.ipynb)

--- a/plugins/oracle-aidp-connectors/skills/aidp-postgresql/SKILL.md
+++ b/plugins/oracle-aidp-connectors/skills/aidp-postgresql/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: aidp-postgresql
+description: Read or write PostgreSQL from an AIDP notebook via the AIDP `aidataplatform` Spark format handler. Use when the user mentions PostgreSQL, Postgres, "psql", or has a Postgres host/port to connect to. HTTP-style auth - host/port + user/password.
+---
+
+# `aidp-postgresql` - PostgreSQL via AIDP `aidataplatform`
+
+## When to use
+- User wants to read or write a PostgreSQL database from an AIDP notebook.
+- Mentioned: "PostgreSQL", "Postgres", "psql".
+
+## When NOT to use
+- For MySQL / HeatWave -> [`aidp-mysql`](../aidp-mysql/SKILL.md).
+- For SQL Server -> [`aidp-sqlserver`](../aidp-sqlserver/SKILL.md).
+- For arbitrary JDBC-only DBs -> [`aidp-jdbc-custom`](../aidp-jdbc-custom/SKILL.md).
+
+## Read
+
+### Option A: Spark native JDBC (recommended for SSL/Neon/RDS/most production)
+The AIDP `aidataplatform` format with `type=POSTGRESQL` silently ignores SSL options - Postgres rejects with `[PostgreSQL]connection is insecure (try using sslmode=require)`. For SSL-required Postgres targets (Neon, RDS, Aiven, most production deployments) use Spark native JDBC with URL-embedded `sslmode=require`. The cluster has no `org.postgresql.Driver` pre-installed; runtime-load it the same way `aidp-jdbc-custom` does.
+
+Before downloading or classloading the PostgreSQL JDBC JAR, confirm the Maven
+URL, version pin, and checksum if available. For shared or production clusters,
+prefer administrator-managed cluster libraries or approved JARs in a
+user-managed Volume.
+
+```python
+import os
+from oracle_ai_data_platform_connectors.jdbc import (
+    add_jdbc_jar_at_runtime, download_jdbc_jar,
+)
+
+jar = download_jdbc_jar(
+    maven_url="https://repo1.maven.org/maven2/org/postgresql/postgresql/42.7.4/postgresql-42.7.4.jar",
+    target_path="/tmp/postgresql-42.7.4.jar",
+    # sha256="...",
+)
+add_jdbc_jar_at_runtime(spark, jar_path=jar, driver_class="org.postgresql.Driver")
+
+# Now read - note sslmode=require URL-embedded
+JDBC_URL = (
+    f"jdbc:postgresql://{os.environ['PG_HOST']}:{os.environ.get('PG_PORT','5432')}"
+    f"/{os.environ['PG_DB']}?sslmode=require"
+)
+df = (spark.read.format("jdbc")
+      .option("url", JDBC_URL)
+      .option("driver", "org.postgresql.Driver")
+      .option("user", os.environ["PG_USER"])
+      .option("password", os.environ["PG_PASSWORD"])
+      .option("dbtable", f"{os.environ.get('PG_SCHEMA','public')}.{os.environ['PG_TABLE']}")
+      .load())
+df.show(5)
+```
+
+### Option B: AIDP `aidataplatform` format (only for non-SSL Postgres - rare)
+Use this only if your Postgres explicitly accepts non-TLS connections (most managed Postgres services don't).
+
+```python
+import os
+from oracle_ai_data_platform_connectors.aidataplatform import (
+    AIDP_FORMAT, aidataplatform_options,
+)
+
+opts = aidataplatform_options(
+    type="POSTGRESQL",
+    host=os.environ["PG_HOST"],
+    port=int(os.environ.get("PG_PORT", "5432")),
+    user=os.environ["PG_USER"],
+    password=os.environ["PG_PASSWORD"],
+    schema=os.environ.get("PG_SCHEMA", "public"),
+    table=os.environ["PG_TABLE"],
+)
+df = spark.read.format(AIDP_FORMAT).options(opts).load()
+df.show(5)
+```
+
+## Write
+```python
+opts = aidataplatform_options(
+    type="POSTGRESQL",
+    host=os.environ["PG_HOST"],
+    port=int(os.environ.get("PG_PORT", "5432")),
+    user=os.environ["PG_USER"],
+    password=os.environ["PG_PASSWORD"],
+    schema=os.environ.get("PG_SCHEMA", "public"),
+    table=os.environ["PG_TARGET_TABLE"],
+    extra={"write.mode": "CREATE"},   # CREATE | APPEND | OVERWRITE
+)
+df.write.format(AIDP_FORMAT).options(opts).save()
+```
+
+## Gotchas
+- SSL - AIDP `aidataplatform` POSTGRESQL handler silently ignores SSL options (`ssl`, `sslmode`, `jdbc.ssl.enabled`, `encrypt`). For any production / managed Postgres (Neon, RDS, Aiven, etc.) use Option A (Spark native JDBC) with URL-embedded `sslmode=require`. Verified live 2026-04-27 against Neon serverless 17.8.
+- No bundled driver - the cluster does NOT have `org.postgresql.Driver` pre-installed for native Spark JDBC. Use the runtime-load helper in Option A after approval, or attach an approved cluster library. The aidataplatform format has its own bundled driver and works without runtime-load.
+- Network reachability - Postgres must be reachable from the AIDP cluster's NAT egress IP. Public-internet endpoints (Neon, Supabase, RDS public) work via the cluster's NAT path. Self-hosted Postgres in user-managed VCNs typically does NOT work - the cluster's pod CIDR has no route to user VCNs without explicit VCN peering. Smoke-test with a Python socket: `socket.create_connection((host, 5432), timeout=8)`.
+- `schema` is the Postgres logical schema (e.g. `public`), not the database name. The database name is a separate `PG_DB` env var that goes into the JDBC URL.
+- Write modes - `CREATE` (fail if exists), `APPEND`, `OVERWRITE`. Default is `CREATE`.
+
+## References
+- Helper: [scripts/oracle_ai_data_platform_connectors/aidataplatform.py](../../scripts/oracle_ai_data_platform_connectors/aidataplatform.py)
+- Official sample: [oracle-samples/oracle-aidp-samples -> `data-engineering/ingestion/Read_Write_External_Ecosystem_Connectors.ipynb`](https://github.com/oracle-samples/oracle-aidp-samples/blob/main/data-engineering/ingestion/Read_Write_External_Ecosystem_Connectors.ipynb)

--- a/plugins/oracle-aidp-connectors/skills/aidp-rest-generic/SKILL.md
+++ b/plugins/oracle-aidp-connectors/skills/aidp-rest-generic/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: aidp-rest-generic
+description: Pull data from any REST API into a Spark DataFrame using the AIDP `aidataplatform` Generic REST connector. Use when the user has a non-Fusion / non-EPM / non-Essbase REST endpoint with a `manifest.url` describing the schema. Auth is HTTP Basic with derived properties driving query parameters.
+---
+
+# `aidp-rest-generic` - Generic REST via AIDP `aidataplatform` (`type=GENERIC_REST`)
+
+Read from arbitrary REST APIs as a Spark DataFrame. The connector requires a server-published manifest (a small JSON describing each API endpoint, parameters, and response schema) so it knows how to parse responses without a custom integration.
+
+## When to use
+- Any REST endpoint that exposes a manifest URL (custom enterprise APIs commonly do).
+- Mentioned: "Generic REST", "manifest URL", "REST connector".
+
+## When NOT to use
+- For Fusion ERP/HCM/SCM REST -> [`aidp-fusion-rest`](../aidp-fusion-rest/SKILL.md). Different shape (no manifest; <=499/page paging).
+- For Fusion BICC bulk extracts -> [`aidp-fusion-bicc`](../aidp-fusion-bicc/SKILL.md).
+- For EPM Cloud Planning -> [`aidp-epm-cloud`](../aidp-epm-cloud/SKILL.md).
+- For Essbase -> [`aidp-essbase`](../aidp-essbase/SKILL.md).
+
+## Read
+
+```python
+import os
+from oracle_ai_data_platform_connectors.aidataplatform import (
+    AIDP_FORMAT, aidataplatform_options,
+)
+
+opts = aidataplatform_options(
+    type="GENERIC_REST",
+    user=os.environ["REST_USER"],
+    password=os.environ["REST_PASSWORD"],
+    schema=os.environ.get("REST_SCHEMA", "default"),
+    extra={
+        "base.url":     os.environ["REST_BASE_URL"],   # e.g. http://api.internal/v1
+        "manifest.url": os.environ["REST_MANIFEST_URL"], # e.g. http://api.internal/v1/manifest
+        "auth.type":    "basic",
+        "api":          os.environ["REST_API"],         # e.g. "getOrdersByOrderID"
+        # Any number of derived.property.<name> values feed into the API call:
+        "derived.property.orderNo": os.environ.get("REST_ORDER_NO", "12345"),
+    },
+)
+df = spark.read.format(AIDP_FORMAT).options(opts).load()
+df.show(5)
+```
+
+## Manifest contract
+
+The manifest describes:
+- `apis` - the named API operations (e.g. `getOrdersByOrderID`)
+- `parameters` - what the connector should send (path/query/body)
+- `responseSchema` - the Spark schema the connector should infer
+
+If you don't have a manifest URL, this connector won't work - fall back to the requests-based pattern in [`aidp-fusion-rest`](../aidp-fusion-rest/SKILL.md) and adapt for your API.
+
+## Multiple derived properties
+
+Pass each as a separate `extra={}` key:
+
+```python
+extra={
+    "base.url":     "...",
+    "manifest.url": "...",
+    "auth.type":    "basic",
+    "api":          "searchOrders",
+    "derived.property.fromDate":  "2025-01-01",
+    "derived.property.toDate":    "2025-12-31",
+    "derived.property.status":    "OPEN",
+}
+```
+
+## Manifest from a workspace / volume path (`manifest.path`)
+
+If the manifest is a static file you've uploaded to your AIDP workspace or a Volume - instead of being served over HTTP - use `manifest.path` instead of `manifest.url`. Same shape, different source. Useful when the manifest is hand-authored or version-pinned alongside your notebook.
+
+```python
+opts = aidataplatform_options(
+    type="GENERIC_REST",
+    user=os.environ["REST_USER"],
+    password=os.environ["REST_PASSWORD"],
+    schema="default",
+    extra={
+        "base.url":      os.environ["REST_BASE_URL"],
+        "manifest.path": "/Volumes/myvol/manifests/orders_api.json",
+        "auth.type":     "basic",
+        "api":           "searchOrders",
+        "derived.property.status": "OPEN",
+    },
+)
+df = spark.read.format(AIDP_FORMAT).options(opts).load()
+```
+
+The path can be:
+- `/Volumes/<catalog>/<schema>/<volume>/path/to/manifest.json` (AIDP Volume)
+- `/Workspace/Shared/.../manifest.json` (workspace file - works but FUSE-flaky)
+
+Volume paths are the preferred location.
+
+## Gotchas
+- `auth.type=basic` only. If the API uses OAuth / API key headers / mTLS, this connector won't help - use the Python `requests` path.
+- Manifest must be reachable from the AIDP cluster's VCN. Egress restrictions apply.
+- Schema `schema` option is the AIDP/Spark logical schema for the resulting DataFrame, not a server-side one. Use `default` if unsure.
+- Paging is handled by the connector based on the manifest. If the manifest declares `maxPageSize`, the connector batches automatically.
+
+## References
+- Helper: [scripts/oracle_ai_data_platform_connectors/aidataplatform.py](../../scripts/oracle_ai_data_platform_connectors/aidataplatform.py)
+- Official sample: [oracle-samples/oracle-aidp-samples -> `data-engineering/ingestion/Read_Only_Ingestion_Connectors.ipynb`](https://github.com/oracle-samples/oracle-aidp-samples/blob/main/data-engineering/ingestion/Read_Only_Ingestion_Connectors.ipynb)

--- a/plugins/oracle-aidp-connectors/skills/aidp-salesforce/SKILL.md
+++ b/plugins/oracle-aidp-connectors/skills/aidp-salesforce/SKILL.md
@@ -1,0 +1,83 @@
+---
+name: aidp-salesforce
+description: Read from Salesforce into a Spark DataFrame in an AIDP notebook via the AIDP `aidataplatform` Spark format handler. Use when the user mentions Salesforce, SFDC, Sales Cloud, Service Cloud, Account, Opportunity, Lead, sObject, SOQL. Auth is host/port + user/password. Read-only.
+---
+
+# `aidp-salesforce` - Salesforce via AIDP `aidataplatform`
+
+## When to use
+- User wants to ingest Salesforce data (Account, Opportunity, Lead, Contact, custom sObjects) into a Spark DataFrame from an AIDP notebook.
+- User mentions: "Salesforce", "SFDC", "Sales Cloud", "Service Cloud", "sObject", "SOQL", a Salesforce object name (Account, Opportunity, etc.).
+
+## When NOT to use
+- For arbitrary REST APIs with a custom manifest -> [`aidp-rest-generic`](../aidp-rest-generic/SKILL.md).
+- For Oracle CX/CRM -> [`aidp-siebel`](../aidp-siebel/SKILL.md) (Siebel) or Fusion CX via [`aidp-fusion-rest`](../aidp-fusion-rest/SKILL.md).
+
+## Prerequisites in the AIDP notebook
+1. Helpers on `sys.path` (run `aidp-connectors-bootstrap` first).
+2. Env vars / OCI Vault secrets:
+   - `SFDC_HOST` (Salesforce login host, e.g. `login.salesforce.com` or `<my-domain>.my.salesforce.com`)
+   - `SFDC_PORT` (typically `443`)
+   - `SFDC_DATABASE_NAME` (org name / database identifier; for most tenants this is just the org name)
+   - `SFDC_USER` (Salesforce username - typically `<email>`)
+   - `SFDC_PASSWORD` (password concatenated with security token: `<password><security-token>`)
+   - `SFDC_SCHEMA` (typically `SFORCE` for the connector)
+   - `SFDC_TABLE` (sObject API name, e.g. `Account`, `Opportunity`, `Custom_Object__c`)
+
+## Read
+
+```python
+import os
+from oracle_ai_data_platform_connectors.aidataplatform import (
+    AIDP_FORMAT, aidataplatform_options,
+)
+
+opts = aidataplatform_options(
+    type="SFORCE",
+    host=os.environ["SFDC_HOST"],
+    port=int(os.environ.get("SFDC_PORT", "443")),
+    database_name=os.environ["SFDC_DATABASE_NAME"],
+    user=os.environ["SFDC_USER"],
+    password=os.environ["SFDC_PASSWORD"],
+    schema=os.environ.get("SFDC_SCHEMA", "SFORCE"),
+    table=os.environ["SFDC_TABLE"],   # e.g. "Account", "Opportunity"
+)
+df = spark.read.format(AIDP_FORMAT).options(opts).load()
+df.show(10)
+```
+
+## Pushdown SQL
+
+Use `pushdown.sql` to push a SOQL-like query at the source - useful for filtering on indexed fields, joins via relationship paths, or LIMIT semantics.
+
+```python
+opts = aidataplatform_options(
+    type="SFORCE",
+    host=os.environ["SFDC_HOST"],
+    port=int(os.environ.get("SFDC_PORT", "443")),
+    database_name=os.environ["SFDC_DATABASE_NAME"],
+    user=os.environ["SFDC_USER"],
+    password=os.environ["SFDC_PASSWORD"],
+    extra={
+        "pushdown.sql": (
+            "SELECT Id, Name, AnnualRevenue, BillingCountry "
+            "FROM Account "
+            "WHERE AnnualRevenue > 1000000 AND BillingCountry = 'United States'"
+        ),
+    },
+)
+df = spark.read.format(AIDP_FORMAT).options(opts).load()
+df.show(10)
+```
+
+## Gotchas
+- `type` is `SFORCE`, not `SALESFORCE`. Easy to get wrong if you're following the human-readable name. The connector type literally says `SFORCE`.
+- Password requires the security token appended. Salesforce username/password auth needs `<password><security-token>` concatenated as a single string. The security token is reset each time the user changes their password - emailed to the user.
+- API limits. Salesforce enforces per-org daily API call quotas. Bulk reads count against the quota. Use `pushdown.sql` with selective filters and field projection to minimize calls.
+- Connector is read-only. Salesforce writes (create/update sObjects) need to go through the Salesforce REST/Bulk API or the Composite API directly.
+- Custom objects end in `__c` (e.g. `Project__c`). Custom fields end in `__c` too - always include the trailing `__c` in `pushdown.sql`.
+- Field-level security. The connector user inherits Salesforce profile + permission sets. Fields hidden by FLS won't appear in the result.
+
+## References
+- Helper: [scripts/oracle_ai_data_platform_connectors/aidataplatform.py](../../scripts/oracle_ai_data_platform_connectors/aidataplatform.py)
+- Official sample: [oracle-samples/oracle-aidp-samples -> `data-engineering/ingestion/Read_Only_Ingestion_Connectors/Salesforce.ipynb`](https://github.com/oracle-samples/oracle-aidp-samples/blob/main/data-engineering/ingestion/Read_Only_Ingestion_Connectors/Salesforce.ipynb)

--- a/plugins/oracle-aidp-connectors/skills/aidp-siebel/SKILL.md
+++ b/plugins/oracle-aidp-connectors/skills/aidp-siebel/SKILL.md
@@ -1,0 +1,82 @@
+---
+name: aidp-siebel
+description: Read from Oracle Siebel CRM into a Spark DataFrame in an AIDP notebook via the AIDP `aidataplatform` Spark format handler. Use when the user mentions Siebel, Siebel CRM, S_CONTACT, S_ORG_EXT, or has a Siebel host/port. Auth is host/port + database name + user/password. Read-only.
+---
+
+# `aidp-siebel` - Oracle Siebel CRM via AIDP `aidataplatform`
+
+## When to use
+- User wants to ingest Siebel CRM data (contacts, accounts, opportunities, service requests) into a Spark DataFrame from an AIDP notebook.
+- User mentions: "Siebel", "Siebel CRM", "S_CONTACT", "S_ORG_EXT", "S_OPTY", Siebel base tables.
+
+## When NOT to use
+- For Oracle Autonomous DB family (ALH/ADW/ATP) -> [`aidp-alh`](../aidp-alh/SKILL.md).
+- For Oracle PeopleSoft -> [`aidp-peoplesoft`](../aidp-peoplesoft/SKILL.md).
+- For generic Oracle DB -> [`aidp-oracle-db`](../aidp-oracle-db/SKILL.md).
+
+## Prerequisites in the AIDP notebook
+1. Helpers on `sys.path` (run `aidp-connectors-bootstrap` first).
+2. Env vars / OCI Vault secrets:
+   - `SIEBEL_HOST`, `SIEBEL_PORT` (typically `1521`)
+   - `SIEBEL_DATABASE_NAME` (Oracle SID / service)
+   - `SIEBEL_USER`, `SIEBEL_PASSWORD`
+   - `SIEBEL_SCHEMA` (typically `SIEBEL`)
+   - `SIEBEL_TABLE` (a Siebel base table, e.g. `S_CONTACT`, `S_ORG_EXT`)
+
+## Read
+
+```python
+import os
+from oracle_ai_data_platform_connectors.aidataplatform import (
+    AIDP_FORMAT, aidataplatform_options,
+)
+
+opts = aidataplatform_options(
+    type="ORACLE_SIEBEL",
+    host=os.environ["SIEBEL_HOST"],
+    port=int(os.environ["SIEBEL_PORT"]),
+    database_name=os.environ["SIEBEL_DATABASE_NAME"],
+    user=os.environ["SIEBEL_USER"],
+    password=os.environ["SIEBEL_PASSWORD"],
+    schema=os.environ.get("SIEBEL_SCHEMA", "SIEBEL"),
+    table=os.environ["SIEBEL_TABLE"],
+)
+df = spark.read.format(AIDP_FORMAT).options(opts).load()
+df.show(10)
+```
+
+## Pushdown SQL
+
+Use `pushdown.sql` to run a complete source query - push joins, filters, and aggregations to the Siebel DB instead of pulling whole base tables into Spark.
+
+```python
+opts = aidataplatform_options(
+    type="ORACLE_SIEBEL",
+    host=os.environ["SIEBEL_HOST"],
+    port=int(os.environ["SIEBEL_PORT"]),
+    database_name=os.environ["SIEBEL_DATABASE_NAME"],
+    user=os.environ["SIEBEL_USER"],
+    password=os.environ["SIEBEL_PASSWORD"],
+    extra={
+        "pushdown.sql": (
+            "SELECT C.ROW_ID, C.LAST_NAME, C.FST_NAME, O.NAME AS ACCOUNT "
+            "FROM SIEBEL.S_CONTACT C "
+            "JOIN SIEBEL.S_ORG_EXT O ON C.PR_HELD_POSTN_ID = O.ROW_ID "
+            "WHERE C.STATUS_CD = 'Active'"
+        ),
+    },
+)
+df = spark.read.format(AIDP_FORMAT).options(opts).load()
+df.show(10)
+```
+
+## Gotchas
+- Connector is read-only. Siebel data should be written back through Siebel's EAI/REST channels, not Spark. The connector is intentionally one-way.
+- Underlying Oracle DB. Siebel runs on Oracle DB; network reachability rules from `aidp-oracle-db` apply.
+- `SIEBEL` schema owner. Standard Siebel install owns all base tables (`S_*`) under the `SIEBEL` schema. The connector user needs `SELECT` privs.
+- Soft-delete columns. Siebel uses `ROW_ID` keys and `LAST_UPD` for incremental ingest. Filter with `WHERE LAST_UPD > :since` via `pushdown.sql` for delta loads.
+- Audit columns. `CREATED`, `CREATED_BY`, `LAST_UPD`, `LAST_UPD_BY` are populated by triggers on every row - useful for change tracking.
+
+## References
+- Helper: [scripts/oracle_ai_data_platform_connectors/aidataplatform.py](../../scripts/oracle_ai_data_platform_connectors/aidataplatform.py)
+- Official sample: [oracle-samples/oracle-aidp-samples -> `data-engineering/ingestion/Read_Only_Ingestion_Connectors/Oracle_Siebel.ipynb`](https://github.com/oracle-samples/oracle-aidp-samples/blob/main/data-engineering/ingestion/Read_Only_Ingestion_Connectors/Oracle_Siebel.ipynb)

--- a/plugins/oracle-aidp-connectors/skills/aidp-snowflake/SKILL.md
+++ b/plugins/oracle-aidp-connectors/skills/aidp-snowflake/SKILL.md
@@ -1,0 +1,110 @@
+---
+name: aidp-snowflake
+description: Read or write Snowflake from an AIDP notebook via Spark using the Snowflake Spark connector. Use when the user mentions Snowflake, Snowflake warehouse, sfUrl, sfUser, or wants to migrate from Snowflake. Auth is sfUser + sfPassword over the Snowflake Spark connector (`net.snowflake.spark.snowflake`).
+---
+
+# `aidp-snowflake` - Snowflake via the Snowflake Spark connector
+
+Bridge AIDP Spark to Snowflake using the official Snowflake Spark connector. Useful for migration off Snowflake or for cross-warehouse joins where Snowflake holds the source of truth.
+
+## When to use
+- Reading or writing a Snowflake warehouse from AIDP.
+- Mentioned: "Snowflake", "sfUrl", "sfWarehouse".
+
+## When NOT to use
+- For a generic JDBC-only DB (no Spark connector available) -> [`aidp-jdbc-custom`](../aidp-jdbc-custom/SKILL.md).
+
+## Cluster prerequisite - install the connector JARs
+
+The Snowflake Spark connector is not in the AIDP cluster image by default. Two ways to get it in.
+
+### Option A - Runtime-load (fast path; requires approval)
+
+The plugin's `add_spark_connector_at_runtime` helper downloads + registers both JARs in the running Spark session.
+
+Before downloading or classloading these JARs, confirm the Maven URLs, pinned
+versions, and checksums if available. For shared or production clusters, prefer
+administrator-managed cluster libraries or approved JARs in a user-managed
+Volume.
+
+```python
+from oracle_ai_data_platform_connectors.jdbc import (
+    add_spark_connector_at_runtime, download_jdbc_jar,
+)
+
+jars = [
+    download_jdbc_jar(
+        maven_url="https://repo1.maven.org/maven2/net/snowflake/"
+                  "spark-snowflake_2.12/3.1.1/spark-snowflake_2.12-3.1.1.jar",
+        target_path="/tmp/spark-snowflake_2.12-3.1.1.jar",
+        # sha256="...",
+    ),
+    download_jdbc_jar(
+        maven_url="https://repo1.maven.org/maven2/net/snowflake/"
+                  "snowflake-jdbc/3.19.0/snowflake-jdbc-3.19.0.jar",
+        target_path="/tmp/snowflake-jdbc-3.19.0.jar",
+        # sha256="...",
+    ),
+]
+add_spark_connector_at_runtime(
+    spark,
+    jar_paths=jars,
+    verify_classes=[
+        "net.snowflake.spark.snowflake.DefaultSource",
+        "net.snowflake.client.jdbc.SnowflakeDriver",
+    ],
+    register_jdbc_driver_class="net.snowflake.client.jdbc.SnowflakeDriver",
+)
+```
+
+The helper does three things in one call: builds a `URLClassLoader` covering both JARs and sets it as the thread context CL (so Spark's `ServiceLoader` finds the `snowflake` format), registers the JDBC driver with `DriverManager` (for any code path that goes through `getConnection`), and calls `SparkContext.addJar` on each JAR (so executors fetch them - required because Snowflake reads partition across executors). All without a kernel restart.
+
+### Option B - Cluster Library tab (durable, requires admin)
+
+Upload both JARs to a Volume and attach via the cluster Library tab. Persists across cluster restarts. Requires admin access. After restart, skip the runtime-load helper.
+
+Pin the versions - newer Snowflake connector / JDBC may not be compatible with the cluster's Spark version. The pair tested on Spark 3.5.0 / Scala 2.12 is `spark-snowflake_2.12-3.1.1` + `snowflake-jdbc-3.19.0`.
+
+## Read
+
+```python
+import os
+
+snowflake_options = {
+    "sfUrl":       os.environ["SNOW_URL"],         # e.g. xy12345.us-east-1.snowflakecomputing.com
+    "sfUser":      os.environ["SNOW_USER"],
+    "sfPassword":  os.environ["SNOW_PASSWORD"],
+    "sfDatabase":  os.environ.get("SNOW_DATABASE", "DATAFLOW"),
+    "sfSchema":    os.environ.get("SNOW_SCHEMA",   "DF_SCHEMA"),
+    "sfWarehouse": os.environ.get("SNOW_WAREHOUSE", "COMPUTE_WH"),
+}
+
+df = (spark.read
+      .format("snowflake")
+      .options(snowflake_options)
+      .option("dbtable", os.environ["SNOW_TABLE"])
+      .load())
+df.show(5)
+```
+
+## Write
+
+```python
+(df.write
+   .format("snowflake")
+   .options(snowflake_options)
+   .option("dbtable", os.environ["SNOW_TARGET_TABLE"])
+   .mode("append")
+   .save())
+```
+
+## Gotchas
+- No Spark JDBC fallback in this skill. The Snowflake JDBC alone (no Spark connector) doesn't push down predicates and is much slower. Use the Spark connector.
+- Network reachability - Snowflake is public over TLS; the AIDP cluster needs egress. If your cluster is in a strict NSG, allow outbound HTTPS to `*.snowflakecomputing.com`.
+- Auth - only password auth shown here. Snowflake key-pair auth (RSA) and OAuth are also supported by the connector but require additional `pem_private_key` / `sfAuthenticator` options not covered in this skill.
+- `dbtable` is the simplest spec. For complex pushdown use `query` instead - `option("query", "SELECT ... FROM ... WHERE ...")` runs the query in Snowflake and only ships the result.
+- Case sensitivity - Snowflake folds unquoted names to UPPERCASE. If a Spark write fails with "table not found" on a lowercase target, quote the name in `dbtable`.
+
+## References
+- Official sample: [oracle-samples/oracle-aidp-samples -> `data-engineering/ingestion/Connect_Using_Custom_JDBC_Driver.ipynb`](https://github.com/oracle-samples/oracle-aidp-samples/blob/main/data-engineering/ingestion/Connect_Using_Custom_JDBC_Driver.ipynb)
+- Snowflake Spark connector docs: <https://docs.snowflake.com/en/user-guide/spark-connector>

--- a/plugins/oracle-aidp-connectors/skills/aidp-sqlserver/SKILL.md
+++ b/plugins/oracle-aidp-connectors/skills/aidp-sqlserver/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: aidp-sqlserver
+description: Read or write Microsoft SQL Server from an AIDP notebook via the AIDP `aidataplatform` Spark format handler. Use when the user mentions SQL Server, MSSQL, Azure SQL Database, or has a TDS host/port. Auth is host/port + database + user/password.
+---
+
+# `aidp-sqlserver` - Microsoft SQL Server via AIDP `aidataplatform`
+
+## When to use
+- Read or write a Microsoft SQL Server (or Azure SQL Database) from an AIDP notebook.
+- Mentioned: "SQL Server", "MSSQL", "Azure SQL", "TDS".
+
+## When NOT to use
+- For Postgres -> [`aidp-postgresql`](../aidp-postgresql/SKILL.md).
+- For MySQL -> [`aidp-mysql`](../aidp-mysql/SKILL.md).
+
+## Read
+```python
+import os
+from oracle_ai_data_platform_connectors.aidataplatform import (
+    AIDP_FORMAT, aidataplatform_options,
+)
+
+opts = aidataplatform_options(
+    type="SQLSERVER",
+    host=os.environ["MSSQL_HOST"],
+    port=int(os.environ.get("MSSQL_PORT", "1433")),
+    user=os.environ["MSSQL_USER"],
+    password=os.environ["MSSQL_PASSWORD"],
+    schema=os.environ.get("MSSQL_SCHEMA", "dbo"),
+    table=os.environ["MSSQL_TABLE"],
+)
+df = spark.read.format(AIDP_FORMAT).options(opts).load()
+df.show(5)
+```
+
+## Write
+```python
+opts = aidataplatform_options(
+    type="SQLSERVER",
+    host=os.environ["MSSQL_HOST"],
+    port=int(os.environ.get("MSSQL_PORT", "1433")),
+    database_name=os.environ["MSSQL_DATABASE"],   # required on write
+    user=os.environ["MSSQL_USER"],
+    password=os.environ["MSSQL_PASSWORD"],
+    schema=os.environ.get("MSSQL_SCHEMA", "dbo"),
+    table=os.environ["MSSQL_TARGET_TABLE"],
+    extra={"write.mode": "CREATE"},
+)
+df.write.format(AIDP_FORMAT).options(opts).save()
+```
+
+## Gotchas
+- `database.name` is required on write but not strictly on read. If a read fails with "object not found", supply `database_name=` too - some SQL Server installs require it for the connector to disambiguate.
+- Schema vs database: SQL Server has both. `schema` here is the SQL-Server schema (typically `dbo`); `database.name` is the catalog (e.g. `master`, `AdventureWorks`).
+- TDS port 1433 by default. Azure SQL Database exposes port 1433 over public TLS; AIDP must reach it via its egress route.
+- Azure SQL uses the same `SQLSERVER` type. Use the fully-qualified host (`<srv>.database.windows.net`) and the SQL-auth user (NOT Active Directory; AIDP doesn't broker AAD tokens).
+
+## References
+- Helper: [scripts/oracle_ai_data_platform_connectors/aidataplatform.py](../../scripts/oracle_ai_data_platform_connectors/aidataplatform.py)
+- Official sample: [oracle-samples/oracle-aidp-samples -> `data-engineering/ingestion/Read_Write_External_Ecosystem_Connectors.ipynb`](https://github.com/oracle-samples/oracle-aidp-samples/blob/main/data-engineering/ingestion/Read_Write_External_Ecosystem_Connectors.ipynb)

--- a/plugins/oracle-aidp-connectors/skills/aidp-streaming-kafka/SKILL.md
+++ b/plugins/oracle-aidp-connectors/skills/aidp-streaming-kafka/SKILL.md
@@ -1,0 +1,105 @@
+---
+name: aidp-streaming-kafka
+description: Consume an OCI Streaming stream from an AIDP notebook via Spark structured streaming (Kafka-compat). Use when the user mentions OCI Streaming, Kafka on OCI, stream pool, structured streaming, or wants to read Kafka messages into Spark. Auth is SASL/PLAIN with an OCI auth token. Pattern matches the official Oracle AIDP sample.
+---
+
+# `aidp-streaming-kafka` - OCI Streaming via Spark structured streaming
+
+Mirrors the official Oracle AIDP sample at [oracle-samples/oracle-aidp-samples -> `data-engineering/ingestion/Streaming/StreamingFromOCIStreamingService.ipynb`](https://github.com/oracle-samples/oracle-aidp-samples/blob/main/data-engineering/ingestion/Streaming/StreamingFromOCIStreamingService.ipynb).
+
+## When to use
+- User wants to consume an OCI Streaming stream (Kafka-compat) from an AIDP notebook.
+- User mentions: "OCI Streaming", "Kafka on OCI", "stream pool", "structured streaming", "Kafka topic".
+
+## When NOT to use
+- For batch reads of files in OCI Object Storage -> standard `spark.read.format("csv"|"parquet").load("oci://...")` is fine without this skill.
+- For other Kafka deployments (Confluent, MSK) - same Spark Kafka API works; just point `bootstrap.servers` at the right broker and skip the OCI-specific username format.
+
+## Prerequisites in the AIDP notebook
+1. Spark Kafka connector on the cluster (`spark-sql-kafka-0-10_<scala>:<spark>` - AIDP's `tpcds` cluster has this).
+2. Helpers on `sys.path`.
+3. OCI Streaming stream pool OCID + region.
+4. An OCI auth token (Profile -> Auth tokens -> Generate Token in the OCI console). 1-hour TTL - refresh before any job that runs longer than that.
+5. A Volumes-mounted checkpoint location (`/Volumes/<catalog>/<schema>/<volume>/_checkpoints/...`). Do NOT use `/Workspace/...` - the streaming engine fails silently. The helper's `validate_checkpoint_path()` raises a clear `ValueError` if you try.
+
+## Auth: SASL/PLAIN with OCI auth token
+
+```python
+import os
+from oracle_ai_data_platform_connectors.streaming import (
+    bootstrap_for_region, build_kafka_options_sasl_plain,
+    validate_checkpoint_path,
+)
+
+# Bootstrap. Either generic-regional (default) or cell-prefixed (matches OCI
+# Console's "messages-endpoint" shape - pick whichever your stream pool shows):
+bootstrap = bootstrap_for_region(os.environ["OCI_REGION"])              # streaming.<region>...:9092
+# bootstrap = bootstrap_for_region(os.environ["OCI_REGION"], cell=1)    # cell-1.streaming.<region>...:9092
+
+opts = build_kafka_options_sasl_plain(
+    bootstrap_servers=bootstrap,
+    tenancy_name=os.environ["OCI_TENANCY_NAME"],     # display name, NOT OCID
+    username=os.environ["OCI_USERNAME"],             # OCI user; for IAM-Domains
+                                                     # use "oracleidentitycloudservice/<email>"
+    stream_pool_ocid=os.environ["OCI_STREAM_POOL_OCID"],
+    auth_token=os.environ["OCI_AUTH_TOKEN"],         # 1h TTL - refresh before long jobs
+    topic=os.environ["KAFKA_TOPIC"],
+    starting_offsets="latest",                       # or "earliest" for backfill
+    # Optional tuning (matches the official sample):
+    max_partition_fetch_bytes=1024 * 1024,
+    max_offsets_per_trigger=5,                       # cap rows per micro-batch (demo-friendly)
+)
+
+raw = spark.readStream.format("kafka").options(opts).load()
+
+# Validate checkpoint path BEFORE starting (saves you from silent FUSE failures)
+checkpoint = validate_checkpoint_path(os.environ["KAFKA_CHECKPOINT_VOLUME"])
+sink_path  = os.environ["KAFKA_SINK_VOLUME"]   # e.g. /Volumes/default/default/streaming/kafkaStreamingSink
+
+# Match the official sample: write to a Delta sink under /Volumes/.
+query = (
+    raw.writeStream
+       .queryName("OCIStreamingSource")
+       .format("delta")
+       .option("checkpointLocation", checkpoint)
+       .start(sink_path)
+)
+query.awaitTermination(timeout=120)
+print("input rows in last batch:", (query.lastProgress or {}).get("numInputRows"))
+```
+
+For an inline test against an existing topic with `print`-style output:
+
+```python
+out_df = raw.selectExpr("CAST(key AS STRING) AS k", "CAST(value AS STRING) AS v",
+                        "topic", "partition", "offset")
+q = (out_df.writeStream.format("memory").queryName("kafka_test")
+            .option("checkpointLocation", checkpoint)
+            .trigger(processingTime="5 seconds").start())
+q.awaitTermination(timeout=60)
+spark.sql("SELECT * FROM kafka_test").show()
+q.stop()
+```
+
+## Username format (the most common gotcha)
+
+OCI Streaming's Kafka SASL username is `<tenancy_name>/<user>/<stream_pool_ocid>`. The middle segment depends on tenancy type:
+
+| Tenancy | `username` argument |
+|---|---|
+| Legacy IAM | `<email>` |
+| IAM Domains (modern) | `oracleidentitycloudservice/<email>` |
+
+If you `oci iam user list` shows the user with `oracleidentitycloudservice/...` prefix, use the prefixed form.
+
+## Gotchas
+- Checkpoint path - must be `/Volumes/...`. The `validate_checkpoint_path()` helper raises a `ValueError` if you pass `/Workspace/...` or `oci://...`. This is the #1 cause of "stream runs but no data appears" complaints in AIDP.
+- Auth token TTL = 1 hour. For longer runs, plan to checkpoint, stop the stream, refresh the token, restart from checkpoint. RP-based Kafka SASL (`com.oracle.bmc.auth.sasl.ResourcePrincipalsLoginModule`) is blocked at the AIDP platform level (RP tokens not provided).
+- Username format - tenancy *name* (display name), NOT tenancy OCID. IAM-Domains users need the `oracleidentitycloudservice/` prefix.
+- Streaming jobs run forever. The AIDP workflow timeout doesn't apply once a streaming query is started. Set `Max Concurrent Runs = 1` on the wrapping job.
+- Bootstrap host - the OCI Console's stream-pool detail page shows a "messages-endpoint" like `https://cell-1.streaming.<region>.oci.oraclecloud.com`. Either form (`streaming.<region>...` or `cell-N.streaming.<region>...`) works for the Kafka layer.
+
+## References
+- Helpers: [scripts/oracle_ai_data_platform_connectors/streaming/kafka.py](../../scripts/oracle_ai_data_platform_connectors/streaming/kafka.py)
+- Official Oracle AIDP sample: [StreamingFromOCIStreamingService.ipynb](https://github.com/oracle-samples/oracle-aidp-samples/blob/main/data-engineering/ingestion/Streaming/StreamingFromOCIStreamingService.ipynb)
+- OCI Streaming Kafka compat docs: https://docs.oracle.com/en-us/iaas/Content/Streaming/Tasks/kafkacompatibility_topic-Configuration.htm


### PR DESCRIPTION
## Oracle AIDP Connectors Plugin

Adds an Oracle AI Data Platform Workbench connector plugin for building Spark notebook snippets that read from Oracle, OCI, external databases, SaaS APIs, object stores, and Excel files.

This is a bundled-skills package. It does not register MCP servers, contact Oracle services, run notebooks, upload helper code, or write credentials at install time. The bundled helper Python package, example notebooks, and `.env.example` checklist are passive assets users can import or upload when they are already working inside a Workbench workspace.

## Cline Primitives

- Skills: bundles router, bootstrap, and connector skills for ALH/ADW/ATP, Oracle Database, ExaCS, PeopleSoft, Siebel, Fusion REST/BICC, EPM Cloud, Essbase, OCI Streaming, OCI Object Storage, Iceberg, PostgreSQL, MySQL/HeatWave, SQL Server, Hive, Snowflake, custom JDBC, AWS S3, Azure ADLS Gen2, generic REST, Salesforce, and Excel.
- Skill guidance: adds Oracle AIDP safety guidance for data-source writes, helper uploads, credentials, shared workspace paths, broad queries, runtime JAR downloads/classloading, and private query results.
- Bundled assets: includes the `oracle_ai_data_platform_connectors` helper package, 26 example notebooks, and `.env.example` as a variable-name checklist for connector setup.

## Requirements

Workflows may require an Oracle AI Data Platform Workbench workspace, Spark notebook session, network reachability to the source system, source credentials, connector jars or built-in AIDP connector support, OCI Vault or environment-backed secrets, and the bundled helper package under `scripts/oracle_ai_data_platform_connectors/` made importable by the notebook.

Users should treat `.env.example` as a checklist only. Filled values belong in the user's environment, OCI Vault, notebook-scoped state, or another user-owned secret store, not in committed plugin files or shared notebooks.

## Trust Boundaries

Installation is passive. Live connector workflows can expose private schemas, table samples, REST responses, notebooks, query results, and credentials. Cline should ask before uploading helper files or notebooks to Workbench, downloading or classloading JDBC jars, running broad reads, writing tables or buckets, refreshing external-catalog metadata, and storing credentials.
