### PR TITLE
feat: add oracledb plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Each plugin lives in `plugins/<slug>`. The directory name is the install keyword
 | `linear` | Linear SDK scripting skill for issue, project, team, cycle, and comment workflows. |
 | `mac-notify` | macOS notifications when a Cline run completes. |
 | `nanobanana` | Image generation through OpenRouter and Gemini image models. |
+| `oracledb` | Oracle Database tools for SQL, schema, query-plan, session, object-health, and tablespace diagnostics. |
 | `speak` | Speaks completed Cline replies with ElevenLabs text to speech. |
 | `typescript-lsp` | TypeScript language service `goto_definition` support. |
 | `weather-metrics` | Demo weather tool plus runtime metrics hooks. |

--- a/plugins/oracledb/LICENSE.oracledb
+++ b/plugins/oracledb/LICENSE.oracledb
@@ -1,0 +1,16 @@
+Apache License
+Version 2.0, January 2004
+
+Copyright 2026 Google LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this material except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/plugins/oracledb/README.md
+++ b/plugins/oracledb/README.md
@@ -1,0 +1,27 @@
+# Oracle Database Plugin
+
+Oracle Database tools and skills for querying, schema inspection, query-plan analysis, session monitoring, object health checks, and tablespace diagnostics.
+
+This plugin registers Cline tools backed by the Oracle Database prebuilt connector from `@toolbox-sdk/server`. Installation adds the pinned Toolbox dependency but does not connect to any database or execute SQL. Tool calls use the package-local Toolbox binary; if dependencies are missing, the tools fail with a reinstall message rather than downloading code at runtime.
+
+## Requirements
+
+Set these environment variables before starting Cline:
+
+- `ORACLE_CONNECTION_STRING`
+- `ORACLE_USERNAME`
+- `ORACLE_PASSWORD`
+- `ORACLE_WALLET` optional
+- `ORACLE_USE_OCI` optional
+
+Basic queries require `CREATE SESSION`. Session, storage, and SQL-resource diagnostics may require read privileges on Oracle dynamic performance and data dictionary views.
+
+## Trust Boundaries
+
+Oracle query results, schemas, execution plans, session data, and tablespace diagnostics can contain private operational data. The plugin rule asks for bounded reads by default and explicit approval before SQL that can mutate data, metadata, privileges, sessions, or database state.
+
+`oracle_execute_sql` is read-only by default. Side-effecting SQL goes through `oracle_execute_mutation_sql`, which requires an explicit confirmation field after user approval.
+
+## Attribution
+
+The Oracle Database workflow is based on Oracle Database agent skill material licensed under Apache-2.0. See `LICENSE.oracledb`.

--- a/plugins/oracledb/index.ts
+++ b/plugins/oracledb/index.ts
@@ -1,0 +1,412 @@
+import { spawn } from "node:child_process"
+import { existsSync } from "node:fs"
+import { dirname, join } from "node:path"
+import { fileURLToPath } from "node:url"
+import { createTool, type AgentPlugin } from "@cline/sdk"
+
+const PLUGIN_NAME = "oracledb"
+const pluginDir = dirname(fileURLToPath(import.meta.url))
+const MUTATION_CONFIRMATION = "I approve running this Oracle mutation SQL"
+
+type JsonRecord = Record<string, unknown>
+
+type ToolboxResult = {
+	ok: boolean
+	tool: string
+	stdout: string
+	stderr?: string
+	exitCode?: number | null
+	error?: string
+}
+
+const safetyRule = [
+	"Oracle Database tools are active. Treat database schemas, query results, execution plans, session data, and storage diagnostics as private user data.",
+	"Before running SQL that can mutate data or metadata, including DML, DDL, PL/SQL blocks, grants, session kills, maintenance commands, or writes through stored procedures, explain the target database, affected objects, and expected effect, then wait for explicit approval.",
+	"Prefer bounded read-only queries first. Add row limits or filters for exploration, avoid dumping sensitive data, and summarize large result sets.",
+	"Never write Oracle passwords, wallet contents, connection strings with secrets, or private keys into chat, committed files, shared logs, or generated scripts. Use environment variables or user-managed secret stores.",
+	"Diagnostic tools may require elevated privileges on V$ and DBA_ views. If a permission error occurs, explain the missing privilege instead of suggesting broad DBA access by default.",
+].join("\n")
+
+function isRecord(value: unknown): value is JsonRecord {
+	return value !== null && typeof value === "object" && !Array.isArray(value)
+}
+
+function cleanInput(input: unknown): JsonRecord {
+	if (!isRecord(input)) {
+		return {}
+	}
+	const output: JsonRecord = {}
+	for (const [key, value] of Object.entries(input)) {
+		if (value === undefined || value === null || value === "") {
+			continue
+		}
+		output[key] = value
+	}
+	return output
+}
+
+function missingOracleEnv(): string[] {
+	return ["ORACLE_CONNECTION_STRING", "ORACLE_USERNAME", "ORACLE_PASSWORD"].filter(
+		(key) => !process.env[key]?.trim(),
+	)
+}
+
+function localToolboxCommand(): string | undefined {
+	const localBin = join(
+		pluginDir,
+		"node_modules",
+		".bin",
+		process.platform === "win32" ? "toolbox.cmd" : "toolbox",
+	)
+	if (existsSync(localBin)) {
+		return localBin
+	}
+	return undefined
+}
+
+function truncate(text: string, maxLength = 20000): string {
+	if (text.length <= maxLength) {
+		return text
+	}
+	return `${text.slice(0, maxLength)}\n...[truncated ${text.length - maxLength} chars]`
+}
+
+function minimalOracleEnv(): NodeJS.ProcessEnv {
+	const allowed = [
+		"ORACLE_CONNECTION_STRING",
+		"ORACLE_USERNAME",
+		"ORACLE_PASSWORD",
+		"ORACLE_WALLET",
+		"ORACLE_USE_OCI",
+		"TNS_ADMIN",
+		"NLS_LANG",
+		"PATH",
+		"HOME",
+		"USERPROFILE",
+		"SystemRoot",
+		"TEMP",
+		"TMP",
+		"LD_LIBRARY_PATH",
+		"DYLD_LIBRARY_PATH",
+	]
+	const env: NodeJS.ProcessEnv = {}
+	for (const key of allowed) {
+		const value = process.env[key]
+		if (value?.trim()) {
+			env[key] = value
+		}
+	}
+	return env
+}
+
+function escapeRegExp(value: string): string {
+	return value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")
+}
+
+function redactSensitive(text: string): string {
+	let redacted = text
+	for (const key of [
+		"ORACLE_PASSWORD",
+		"ORACLE_CONNECTION_STRING",
+		"ORACLE_USERNAME",
+		"ORACLE_WALLET",
+	]) {
+		const value = process.env[key]
+		if (value?.trim()) {
+			redacted = redacted.replace(new RegExp(escapeRegExp(value), "g"), `[redacted ${key}]`)
+		}
+	}
+	return redacted
+		.replace(/-----BEGIN [^-]+PRIVATE KEY-----[\s\S]*?-----END [^-]+PRIVATE KEY-----/g, "[redacted private key]")
+		.replace(/(password\s*[=:]\s*)([^;\s)]+)/gi, "$1[redacted]")
+		.replace(/(pwd\s*[=:]\s*)([^;\s)]+)/gi, "$1[redacted]")
+}
+
+function safeText(chunks: Buffer[]): string {
+	return redactSensitive(truncate(Buffer.concat(chunks).toString("utf8")))
+}
+
+function firstSqlKeyword(sql: string): string {
+	return sql
+		.replace(/^\s*\/\*[\s\S]*?\*\//, "")
+		.replace(/^\s*--.*$/m, "")
+		.trim()
+		.split(/\s+/, 1)[0]
+		?.toUpperCase() ?? ""
+}
+
+function isReadOnlySql(sql: string): boolean {
+	const keyword = firstSqlKeyword(sql)
+	if (!["SELECT", "WITH"].includes(keyword)) {
+		return false
+	}
+	return !/\b(INSERT|UPDATE|DELETE|MERGE|DROP|ALTER|CREATE|TRUNCATE|GRANT|REVOKE|CALL|EXEC|EXECUTE|BEGIN|DECLARE|COMMIT|ROLLBACK|ANALYZE|FLASHBACK)\b/i.test(sql)
+}
+
+function invokeToolbox(tool: string, input: JsonRecord): Promise<ToolboxResult> {
+	const missing = missingOracleEnv()
+	if (missing.length > 0) {
+		return Promise.resolve({
+			ok: false,
+			tool,
+			stdout: "",
+			error: `Missing required Oracle environment variables: ${missing.join(", ")}`,
+		})
+	}
+
+	const command = localToolboxCommand()
+	if (!command) {
+		return Promise.resolve({
+			ok: false,
+			tool,
+			stdout: "",
+			error: "The Oracle Database Toolbox dependency is not installed. Reinstall this plugin so its package dependencies are installed before using Oracle tools.",
+		})
+	}
+
+	const env = minimalOracleEnv()
+	const args = [
+		"--log-level",
+		"error",
+		"--prebuilt",
+		"oracledb",
+		"invoke",
+		tool,
+		"--user-agent-metadata",
+		"cline-plugin-oracledb",
+		JSON.stringify(input),
+	]
+
+	return new Promise((resolve) => {
+		const child = spawn(command, args, {
+			cwd: pluginDir,
+			env,
+			shell: process.platform === "win32",
+			stdio: ["ignore", "pipe", "pipe"],
+		})
+		const stdout: Buffer[] = []
+		const stderr: Buffer[] = []
+		const timeout = setTimeout(() => {
+			child.kill()
+			resolve({
+				ok: false,
+				tool,
+				stdout: safeText(stdout),
+				stderr: safeText(stderr),
+				error: "Oracle Database tool timed out after 60 seconds.",
+			})
+		}, 60000)
+
+		child.stdout?.on("data", (chunk) => stdout.push(Buffer.from(chunk)))
+		child.stderr?.on("data", (chunk) => stderr.push(Buffer.from(chunk)))
+		child.on("error", (error) => {
+			clearTimeout(timeout)
+			resolve({
+				ok: false,
+				tool,
+				stdout: safeText(stdout),
+				stderr: safeText(stderr),
+				error: error.message,
+			})
+		})
+		child.on("close", (exitCode) => {
+			clearTimeout(timeout)
+			const output = safeText(stdout)
+			const errorOutput = safeText(stderr)
+			resolve({
+				ok: exitCode === 0,
+				tool,
+				stdout: output,
+				...(errorOutput ? { stderr: errorOutput } : {}),
+				exitCode,
+				...(exitCode === 0 ? {} : { error: `Oracle Database tool exited with ${exitCode}` }),
+			})
+		})
+	})
+}
+
+function toolboxTool(
+	name: string,
+	description: string,
+	inputSchema: JsonRecord,
+	toolboxName = name.replace(/^oracle_/, ""),
+	options: { validate?: (input: JsonRecord) => ToolboxResult | undefined } = {},
+) {
+	return createTool({
+		name,
+		description,
+		inputSchema,
+		timeoutMs: 65000,
+		retryable: false,
+		async execute(input: unknown) {
+			const cleaned = cleanInput(input)
+			const validation = options.validate?.(cleaned)
+			if (validation) {
+				return validation
+			}
+			return invokeToolbox(toolboxName, cleaned)
+		},
+	})
+}
+
+function schema(properties: JsonRecord, required: string[] = []): JsonRecord {
+	return {
+		type: "object",
+		properties,
+		required,
+		additionalProperties: false,
+	}
+}
+
+const plugin: AgentPlugin = {
+	name: PLUGIN_NAME,
+	manifest: {
+		capabilities: ["tools", "skills", "rules"],
+	},
+	setup(api) {
+		api.registerRule({
+			id: "oracledb:safety",
+			source: PLUGIN_NAME,
+			content: safetyRule,
+		})
+
+		api.registerTool(
+			toolboxTool(
+				"oracle_execute_sql",
+				"Execute a read-only Oracle SQL SELECT or WITH query. This tool rejects SQL with obvious mutation, DDL, transaction, PL/SQL, grant, or maintenance keywords.",
+				schema(
+					{
+						sql: {
+							type: "string",
+							description: "Read-only SELECT or WITH SQL statement to execute.",
+						},
+					},
+					["sql"],
+				),
+				"execute_sql",
+				{
+					validate(input) {
+						const sql = typeof input.sql === "string" ? input.sql : ""
+						if (!isReadOnlySql(sql)) {
+							return {
+								ok: false,
+								tool: "execute_sql",
+								stdout: "",
+								error: "Rejected non-read-only SQL. Use oracle_execute_mutation_sql only after explicit user approval.",
+							}
+						}
+						return undefined
+					},
+				},
+			),
+		)
+		api.registerTool(
+			toolboxTool(
+				"oracle_execute_mutation_sql",
+				"Execute Oracle SQL with possible side effects after explicit user approval. Use for DML, DDL, PL/SQL, grants, maintenance, or any SQL that can mutate data or metadata.",
+				schema(
+					{
+						sql: {
+							type: "string",
+							description: "SQL statement to execute.",
+						},
+						confirmation: {
+							type: "string",
+							description: `Must exactly equal: ${MUTATION_CONFIRMATION}`,
+						},
+					},
+					["sql", "confirmation"],
+				),
+				"execute_sql",
+				{
+					validate(input) {
+						if (input.confirmation !== MUTATION_CONFIRMATION) {
+							return {
+								ok: false,
+								tool: "execute_sql",
+								stdout: "",
+								error: `Missing confirmation. The confirmation field must exactly equal: ${MUTATION_CONFIRMATION}`,
+							}
+						}
+						return undefined
+					},
+				},
+			),
+		)
+		api.registerTool(
+			toolboxTool(
+				"oracle_get_query_plan",
+				"Generate an Oracle EXPLAIN PLAN for one SQL statement without executing the statement.",
+				schema(
+					{
+						query: {
+							type: "string",
+							description: "SQL statement to explain. Do not include EXPLAIN PLAN.",
+						},
+					},
+					["query"],
+				),
+				"get_query_plan",
+			),
+		)
+		api.registerTool(
+			toolboxTool(
+				"oracle_list_active_sessions",
+				"List currently active Oracle database sessions with SID, OS user, program, and SQL text when privileges allow it.",
+				schema({}),
+				"list_active_sessions",
+			),
+		)
+		api.registerTool(
+			toolboxTool(
+				"oracle_list_invalid_objects",
+				"List invalid Oracle database objects that may need recompilation.",
+				schema({}),
+				"list_invalid_objects",
+			),
+		)
+		api.registerTool(
+			toolboxTool(
+				"oracle_list_tables",
+				"List tables in the connected Oracle schema, optionally filtered by comma-separated table names.",
+				schema({
+						names: {
+							type: "string",
+							description: "Optional comma-separated table names to filter.",
+						},
+					}),
+				"list_tables",
+			),
+		)
+		api.registerTool(
+			toolboxTool(
+				"oracle_list_tablespace_usage",
+				"List Oracle tablespace total size, free space, and used percentage for storage diagnostics.",
+				schema({}),
+				"list_tablespace_usage",
+			),
+		)
+		api.registerTool(
+			toolboxTool(
+				"oracle_list_top_sql_by_resource",
+				"List top Oracle SQL statements by resource use when database privileges allow library-cache diagnostics.",
+				schema({
+						metric: {
+							type: "string",
+							enum: ["CPU", "IO", "ELAPSED"],
+							description: "Optional resource metric such as CPU, IO, or ELAPSED.",
+						},
+						limit: {
+							type: "integer",
+							minimum: 1,
+							maximum: 50,
+							description: "Optional maximum number of statements.",
+						},
+					}),
+				"list_top_sql_by_resource",
+			),
+		)
+	},
+}
+
+export default plugin

--- a/plugins/oracledb/package.json
+++ b/plugins/oracledb/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "oracledb",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Cline plugin for Oracle Database query, schema, and diagnostics workflows.",
+  "dependencies": {
+    "@toolbox-sdk/server": "1.1.0"
+  },
+  "cline": {
+    "plugins": [
+      {
+        "paths": [
+          "./index.ts"
+        ],
+        "capabilities": [
+          "tools",
+          "skills",
+          "rules"
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/oracledb/skills/oracledb/SKILL.md
+++ b/plugins/oracledb/skills/oracledb/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: oracledb
+description: Use Oracle Database tools to run bounded SQL, inspect schema objects, explain query plans, monitor sessions, review invalid objects, and check tablespace or SQL resource diagnostics. Use when the user asks to connect to, query, troubleshoot, or inspect an Oracle Database.
+---
+
+# Oracle Database
+
+Use this skill when the task involves an Oracle Database instance and the user wants database context, query results, schema inspection, query-plan analysis, session monitoring, object health, or storage diagnostics.
+
+## Connection
+
+The tools use the Oracle Database Toolbox prebuilt connector through the plugin's pinned `@toolbox-sdk/server` dependency. They read configuration from environment variables in the Cline process:
+
+- `ORACLE_CONNECTION_STRING`: Oracle connection string such as `host:port/service_name` or a TNS alias.
+- `ORACLE_USERNAME`: Oracle database username.
+- `ORACLE_PASSWORD`: Oracle database password.
+- `ORACLE_WALLET`: optional path to an Oracle Wallet directory.
+- `ORACLE_USE_OCI`: optional `true` to use the OCI thick client driver.
+
+Do not ask the user to paste passwords or wallet contents into chat. If a tool reports missing environment variables, tell the user exactly which variables are missing and ask them to set those in their shell or secret manager before restarting Cline.
+
+## Tools
+
+- `oracle_execute_sql`: executes read-only `SELECT` or `WITH` SQL. It mechanically rejects obvious mutation, DDL, PL/SQL, grant, transaction, and maintenance keywords.
+- `oracle_execute_mutation_sql`: executes SQL with possible side effects only after explicit user approval and an exact confirmation field. Use for DML, DDL, PL/SQL, grants, maintenance commands, or any statement that can mutate data or metadata.
+- `oracle_get_query_plan`: runs EXPLAIN PLAN for a statement without executing it.
+- `oracle_list_tables`: lists tables in the connected schema and accepts an optional comma-separated `names` filter.
+- `oracle_list_active_sessions`: lists active sessions when privileges allow access to dynamic performance views.
+- `oracle_list_invalid_objects`: lists invalid objects that may require recompilation.
+- `oracle_list_tablespace_usage`: reports tablespace capacity and usage.
+- `oracle_list_top_sql_by_resource`: reports high-resource SQL from the library cache when privileges allow diagnostics.
+
+## Workflow
+
+1. Start with read-only discovery: list tables, inspect a few rows, or explain a query plan.
+2. Keep exploratory SQL bounded with `FETCH FIRST`, filters, or aggregate summaries.
+3. For performance work, compare the query plan with table sizes, active sessions, and top SQL diagnostics.
+4. If a tool returns a permission error, identify the missing view or privilege. Recommend least-privilege grants rather than broad DBA access.
+5. Before any write or maintenance action, explain the target database, affected object names, and expected effect, then wait for explicit approval. Use `oracle_execute_mutation_sql` only after that approval.
+
+## Requirements
+
+Basic connectivity requires `CREATE SESSION`. Monitoring and diagnostics may require privileges on `V$` and `DBA_` views. Wallet or OCI thick-client use requires the local Oracle client and wallet files to be available to the Cline process.


### PR DESCRIPTION
## Oracle Database Plugin

Adds an Oracle Database plugin for querying and troubleshooting Oracle instances from Cline. The plugin is meant for database exploration, schema inspection, query-plan analysis, session monitoring, object health checks, and tablespace diagnostics.

This is a tools, skills, and rules package. It installs a pinned `@toolbox-sdk/server` dependency and uses the Oracle Database prebuilt connector through the package-local `toolbox` binary. Installation does not connect to a database or execute SQL.

## Cline Primitives

- Tools: registers Oracle tools for read-only SQL, explicitly confirmed mutation SQL, query plans, table listing, active sessions, invalid objects, tablespace usage, and top SQL by resource.
- Skills: adds Oracle Database workflow guidance for connection setup, bounded exploration, diagnostics, privilege errors, and safe write handling.
- Rules: adds database safety guidance for private query output, credentials, bounded reads, least-privilege diagnostics, and explicit approval before side-effecting SQL.

## Requirements

Users need access to an Oracle Database and environment variables available to the Cline process: `ORACLE_CONNECTION_STRING`, `ORACLE_USERNAME`, and `ORACLE_PASSWORD`. Optional wallet and thick-client flows use `ORACLE_WALLET` and `ORACLE_USE_OCI`.

Basic queries require `CREATE SESSION`. Session, storage, object-health, and SQL-resource diagnostics may require read access to Oracle dynamic performance and data dictionary views.

## Trust Boundaries

Oracle query results, schemas, execution plans, session data, and storage diagnostics can contain private operational data. The read-only SQL tool mechanically rejects obvious mutation keywords. Side-effecting SQL goes through a separate mutation tool that requires an exact confirmation field after user approval.
