### PR TITLE
feat: add pydantic ai plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Each plugin lives in `plugins/<slug>`. The directory name is the install keyword
 | `linear` | Linear SDK scripting skill for issue, project, team, cycle, and comment workflows. |
 | `mac-notify` | macOS notifications when a Cline run completes. |
 | `nanobanana` | Image generation through OpenRouter and Gemini image models. |
+| `pydantic-ai` | Pydantic AI agent-building skill with references for tools, structured output, hooks, streaming, and tests. |
 | `speak` | Speaks completed Cline replies with ElevenLabs text to speech. |
 | `typescript-lsp` | TypeScript language service `goto_definition` support. |
 | `weather-metrics` | Demo weather tool plus runtime metrics hooks. |

--- a/plugins/pydantic-ai/LICENSE.pydantic-ai
+++ b/plugins/pydantic-ai/LICENSE.pydantic-ai
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) Pydantic Services Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/plugins/pydantic-ai/README.md
+++ b/plugins/pydantic-ai/README.md
@@ -1,0 +1,41 @@
+# pydantic-ai
+
+Pydantic AI agent-building guidance for Cline.
+
+## What It Does
+
+Installs the `building-pydantic-ai-agents` skill with reference material for building Python agents using Pydantic AI. The skill covers agents, tools, structured output, capabilities, lifecycle hooks, streaming, testing, debugging, and multi-agent patterns.
+
+## Install
+
+```bash
+cline plugin install pydantic-ai
+```
+
+For local development from this repository:
+
+```bash
+cline plugin install ./plugins/pydantic-ai --cwd .
+```
+
+## Example Usage
+
+After installation, ask Cline:
+
+```text
+Build a Pydantic AI agent with a weather tool and deterministic tests.
+```
+
+## Requirements
+
+- Python 3.10 or newer for projects that run Pydantic AI code.
+- The user's project chooses and installs its own `pydantic-ai` dependency.
+- Model provider credentials are only needed when the user asks Cline to run or test live agent calls.
+
+## Security Notes
+
+This plugin ships documentation and skills only. It does not install Python packages, register MCP servers, start services, read credentials, or call model providers at install time. Some bundled references describe optional Pydantic AI MCP, provider-native web, code execution, and A2A patterns; those are guidance for user-requested implementation work, not plugin behavior.
+
+## License Notes
+
+The bundled `building-pydantic-ai-agents` skill is MIT licensed by Pydantic. See `LICENSE.pydantic-ai`.

--- a/plugins/pydantic-ai/index.ts
+++ b/plugins/pydantic-ai/index.ts
@@ -1,0 +1,10 @@
+import type { AgentPlugin } from "@cline/sdk"
+
+const plugin: AgentPlugin = {
+	name: "pydantic-ai",
+	manifest: {
+		capabilities: ["skills"],
+	},
+}
+
+export default plugin

--- a/plugins/pydantic-ai/package.json
+++ b/plugins/pydantic-ai/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "pydantic-ai",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Cline plugin with bundled Pydantic AI agent-building guidance.",
+  "cline": {
+    "plugins": [
+      {
+        "paths": [
+          "./index.ts"
+        ],
+        "capabilities": [
+          "skills"
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/pydantic-ai/skills/building-pydantic-ai-agents/SKILL.md
+++ b/plugins/pydantic-ai/skills/building-pydantic-ai-agents/SKILL.md
@@ -1,0 +1,263 @@
+---
+name: building-pydantic-ai-agents
+description: Build AI agents with Pydantic AI - tools, capabilities (including on-demand loading), structured output, streaming, testing, and multi-agent patterns. Use when the user mentions Pydantic AI, imports pydantic_ai, or asks to build an AI agent, add tools/capabilities, defer capability loading, stream output, define agents from YAML, or test agent behavior.
+license: MIT
+compatibility: Requires Python 3.10+
+metadata:
+  version: "1.1.0"
+  author: pydantic
+---
+
+# Building AI Agents with Pydantic AI
+
+Pydantic AI is a Python agent framework for building production-grade Generative AI applications.
+This skill provides patterns, architecture guidance, and tested code examples for building applications with Pydantic AI.
+
+## When to Use This Skill
+
+Invoke this skill when:
+- User asks to build an AI agent, create an LLM-powered app, or mentions Pydantic AI
+- User wants to add tools, capabilities (thinking, web search), or structured output to an agent
+- User asks to define agents from YAML/JSON specs or use template strings
+- User wants to stream agent events, delegate between agents, or test agent behavior
+- Code imports `pydantic_ai` or references Pydantic AI classes (`Agent`, `RunContext`, `Tool`)
+- User asks about hooks, lifecycle interception, or agent observability with Logfire
+- The agent design includes optional instructions, specialist workflows, long-tail tools, or any context the model does not need on most turns
+
+Do not use this skill for:
+- The Pydantic validation library alone (`pydantic`/`BaseModel` without agents)
+- Other AI frameworks (LangChain, LlamaIndex, CrewAI, AutoGen)
+- General Python development unrelated to AI agents
+
+## Quick-Start Patterns
+
+### Create a Basic Agent
+
+```python
+from pydantic_ai import Agent
+
+agent = Agent(
+    'anthropic:claude-sonnet-4-6',
+    instructions='Be concise, reply with one sentence.',
+)
+
+result = agent.run_sync('Where does "hello world" come from?')
+print(result.output)
+"""
+The first known use of "hello, world" was in a 1974 textbook about the C programming language.
+"""
+```
+
+### Add Tools to an Agent
+
+```python
+import random
+
+from pydantic_ai import Agent, RunContext
+
+agent = Agent(
+    'google:gemini-3-flash-preview',
+    deps_type=str,
+    instructions=(
+        "You're a dice game, you should roll the die and see if the number "
+        "you get back matches the user's guess. If so, tell them they're a winner. "
+        "Use the player's name in the response."
+    ),
+)
+
+
+@agent.tool_plain
+def roll_dice() -> str:
+    """Roll a six-sided die and return the result."""
+    return str(random.randint(1, 6))
+
+
+@agent.tool
+def get_player_name(ctx: RunContext[str]) -> str:
+    """Get the player's name."""
+    return ctx.deps
+
+
+dice_result = agent.run_sync('My guess is 4', deps='Anne')
+print(dice_result.output)
+#> Congratulations Anne, you guessed correctly! You're a winner!
+```
+
+### Structured Output with Pydantic Models
+
+```python
+from pydantic import BaseModel
+
+from pydantic_ai import Agent
+
+
+class CityLocation(BaseModel):
+    city: str
+    country: str
+
+
+agent = Agent('google:gemini-3-flash-preview', output_type=CityLocation)
+result = agent.run_sync('Where were the olympics held in 2012?')
+print(result.output)
+#> city='London' country='United Kingdom'
+print(result.usage)
+#> RunUsage(input_tokens=57, output_tokens=8, requests=1)
+```
+
+### Dependency Injection
+
+```python
+from datetime import date
+
+from pydantic_ai import Agent, RunContext
+
+agent = Agent(
+    'openai:gpt-5.2',
+    deps_type=str,
+    instructions="Use the customer's name while replying to them.",
+)
+
+
+@agent.instructions
+def add_the_users_name(ctx: RunContext[str]) -> str:
+    return f"The user's name is {ctx.deps}."
+
+
+@agent.instructions
+def add_the_date() -> str:
+    return f'The date is {date.today()}.'
+
+
+result = agent.run_sync('What is the date?', deps='Frank')
+print(result.output)
+#> Hello Frank, the date today is 2032-01-02.
+```
+
+### Testing with TestModel
+
+```python
+from pydantic_ai import Agent
+from pydantic_ai.models.test import TestModel
+
+my_agent = Agent('openai:gpt-5.2', instructions='...')
+
+
+async def test_my_agent():
+    """Unit test for my_agent, to be run by pytest."""
+    m = TestModel()
+    with my_agent.override(model=m):
+        result = await my_agent.run('Testing my agent...')
+        assert result.output == 'success (no tool calls)'
+    assert m.last_model_request_parameters.function_tools == []
+```
+
+### Use Capabilities
+
+Capabilities are reusable, composable units of agent behavior - bundling tools, hooks, instructions, and model settings.
+
+```python
+from pydantic_ai import Agent
+from pydantic_ai.capabilities import Thinking, WebSearch
+
+agent = Agent(
+    'anthropic:claude-opus-4-6',
+    instructions='You are a research assistant. Be thorough and cite sources.',
+    capabilities=[
+        Thinking(effort='high'),
+        WebSearch(),
+    ],
+)
+```
+
+### Add Lifecycle Hooks
+
+Use `Hooks` to intercept model requests, tool calls, and runs with decorators - no subclassing needed.
+
+```python
+from pydantic_ai import Agent, RunContext
+from pydantic_ai.capabilities.hooks import Hooks
+from pydantic_ai.models import ModelRequestContext
+
+hooks = Hooks()
+
+
+@hooks.on.before_model_request
+async def log_request(ctx: RunContext[None], request_context: ModelRequestContext) -> ModelRequestContext:
+    print(f'Sending {len(request_context.messages)} messages')
+    return request_context
+
+
+agent = Agent('openai:gpt-5.2', capabilities=[hooks])
+```
+
+### Define Agent from YAML Spec
+
+Use `Agent.from_file` to load agents from YAML or JSON - no Python agent construction code needed.
+
+```python
+from pydantic_ai import Agent
+
+# agent.yaml:
+# model: anthropic:claude-opus-4-6
+# instructions: You are a helpful research assistant.
+# capabilities:
+#   - WebSearch
+#   - Thinking:
+#       effort: high
+
+agent = Agent.from_file('agent.yaml')
+```
+
+## Task Routing Table
+
+Load only the most relevant reference first. Read additional references only if the task spans multiple areas.
+
+| I want to... | Reference |
+|---|---|
+| Create/configure agents, choose output types, use deps, define specs, or pick run methods | [Agents Core](./references/AGENTS-CORE.md) |
+| Bundle reusable behavior or intercept lifecycle events | [Capabilities and Hooks](./references/CAPABILITIES-AND-HOOKS.md) |
+| Decide what should load eagerly vs on demand, apply progressive disclosure, defer capability loading, or explain `load_capability` | [Capabilities on Demand](./references/ON-DEMAND-CAPABILITIES.md) |
+| Add function tools, toolsets, MCP servers, or explicit search tools | [Tools Core](./references/TOOLS-CORE.md) |
+| Use provider-native web search, web fetch, or code execution | [Native Tools](./references/NATIVE-TOOLS.md) |
+| Use advanced tool features such as approval, retries, `ToolReturn`, validators, timeouts, or tool search | [Tools Advanced](./references/TOOLS-ADVANCED.md) |
+| Work with multimodal input, message history, or context trimming | [Input and History](./references/INPUT-AND-HISTORY.md) |
+| Test or debug agent behavior | [Testing and Debugging](./references/TESTING-AND-DEBUGGING.md) |
+| Coordinate multiple agents or build graph workflows | [Orchestration and Integrations](./references/ORCHESTRATION-AND-INTEGRATIONS.md#coordinate-multiple-agents) |
+| Call the model directly, expose A2A, use durable execution, embeddings, evals, or third-party integrations | [Orchestration and Integrations](./references/ORCHESTRATION-AND-INTEGRATIONS.md) |
+| Compare abstractions, output modes, decorators, or model-string patterns | [Architecture and Decision Guide](./references/ARCHITECTURE.md) |
+| Follow an older link into `COMMON-TASKS.md` | [Task Reference Map](./references/COMMON-TASKS.md) |
+
+## Architecture and Decisions
+
+Load [Architecture and Decision Guide](./references/ARCHITECTURE.md) only when the user is choosing between abstractions or wants comparison tables and decision trees:
+
+| Topic | What it covers |
+|---|---|
+| Decision Trees | Tool registration, output modes, multi-agent patterns, capabilities, testing approaches, extensibility |
+| Comparison Tables | Output modes, model provider prefixes, tool decorators, built-in capabilities, agent methods |
+| Architecture Overview | Execution flow, generic types, construction patterns, lifecycle hooks, model string format |
+
+Quick reference - model string format: `"provider:model-name"` (e.g., `"openai:gpt-5.2"`, `"anthropic:claude-sonnet-4-6"`, `"google:gemini-3-pro-preview"`)
+
+Quick reference - key agent methods: `run()`, `run_sync()`, `run_stream()`, `run_stream_sync()`, `run_stream_events()`, `iter()`
+
+## Key Practices
+
+- Python 3.10+ compatibility required
+- Progressive disclosure by default: For every capability, explicitly consider whether `defer_loading=True` would benefit the agent before choosing eager loading. Do not eagerly load specialist instructions, rarely used tool schemas, or domain context unless the model needs them on most turns. Prefer capabilities on demand for named instruction+tool bundles, and tool search for large flat tool catalogs.
+- Optional networked/runtime features: References include Pydantic AI MCP, native web tools, code execution, A2A, and package installation examples. Use those only when the user explicitly asks for that behavior. Do not install packages, start services, call live model providers, or enable networked tools merely because the plugin is installed.
+- Observability: Pydantic AI has first-class integration with Logfire for tracing agent runs, tool calls, and model requests. Add it with `logfire.instrument_pydantic_ai()`. For deeper HTTP-level visibility, `logfire.instrument_httpx(capture_all=True)` captures the exact payloads sent to model providers.
+- Testing: Use `TestModel` for deterministic tests, `FunctionModel` for custom logic
+
+## Common Gotchas
+
+These are mistakes agents commonly make with Pydantic AI. Getting these wrong produces silent failures or confusing errors.
+
+- `@agent.tool` requires `RunContext` as first param; `@agent.tool_plain` must not have it. Mixing these up causes runtime errors. Use `tool_plain` when you don't need deps, usage, or messages.
+- Model strings need the provider prefix: `'openai:gpt-5.2'` not `'gpt-5.2'`. Without the prefix, Pydantic AI can't resolve the provider.
+- `TestModel` requires `agent.override()`: Don't set `agent.model` directly. Always use the context manager: `with agent.override(model=TestModel()):`.
+- `str` in output_type allows plain text to end the run: If your union includes `str` (or no `output_type` is set), the model can return plain text instead of structured output. Omit `str` from the union to force tool-based output.
+- Hook decorator names on `.on` don't repeat `on_`: Use `hooks.on.run_error` and `hooks.on.model_request_error` - not `hooks.on.on_run_error`.
+- `history_processors` is deprecated; use `capabilities=[ProcessHistory(p), ...]`, or hook `before_model_request` directly via `capabilities=[Hooks(before_model_request=fn)]`. `ProcessHistory` is a thin wrapper around that hook - the hook itself is the underlying primitive. The kwarg still works in 1.x but emits a `PydanticAIDeprecationWarning` and will be removed in v2.
+
+Use [Task Reference Map](./references/COMMON-TASKS.md) only for compatibility with older links or when you need a pointer from an old section name to the new file.

--- a/plugins/pydantic-ai/skills/building-pydantic-ai-agents/references/AGENTS-CORE.md
+++ b/plugins/pydantic-ai/skills/building-pydantic-ai-agents/references/AGENTS-CORE.md
@@ -1,0 +1,158 @@
+# Agents Core
+
+Read this file when the user needs the core `Agent` workflow: creating agents, choosing output types, using dependencies, defining specs, selecting models, or choosing how to run/stream an agent.
+
+## Create a Basic Agent
+
+```python
+from pydantic_ai import Agent
+
+agent = Agent(
+    'anthropic:claude-sonnet-4-6',
+    instructions='Be concise, reply with one sentence.',
+)
+
+result = agent.run_sync('Where does "hello world" come from?')
+print(result.output)
+```
+
+## Structured Output with Pydantic Models
+
+Use `output_type=MyModel` when the model should return validated structured data.
+
+```python
+from pydantic import BaseModel
+
+from pydantic_ai import Agent
+
+
+class CityLocation(BaseModel):
+    city: str
+    country: str
+
+
+agent = Agent('google:gemini-3-flash-preview', output_type=CityLocation)
+result = agent.run_sync('Where were the olympics held in 2012?')
+print(result.output)
+```
+
+If the user is choosing between output modes:
+
+- `output_type=str` for plain text
+- `output_type=MyModel` for structured output
+- `TextOutput` for custom text parsing
+- `NativeOutput` or `ToolOutput` when they need explicit output-mode control
+
+## Dependency Injection
+
+Use `deps_type=...` plus `RunContext[...]` when tools or instructions need app state.
+
+```python
+from pydantic_ai import Agent, RunContext
+
+agent = Agent('openai:gpt-5.2', deps_type=str)
+
+
+@agent.instructions
+def add_user_name(ctx: RunContext[str]) -> str:
+    return f"The user's name is {ctx.deps}."
+```
+
+Use `@agent.tool` when the tool needs `RunContext`. Use `@agent.tool_plain` when it does not.
+
+## Define Agents Declaratively with Specs
+
+Use YAML or JSON specs when configuration should live outside Python code.
+
+```yaml
+model: anthropic:claude-opus-4-6
+instructions: "You are helping {{user_name}} with research."
+capabilities:
+  - WebSearch
+  - Thinking:
+      effort: high
+```
+
+```python
+from dataclasses import dataclass
+
+from pydantic_ai import Agent
+
+
+@dataclass
+class UserContext:
+    user_name: str
+
+
+agent = Agent.from_file('agent.yaml', deps_type=UserContext)
+result = agent.run_sync('Find recent papers on AI safety', deps=UserContext(user_name='Alice'))
+```
+
+Template strings are part of the spec flow, so route template-string questions here too.
+
+## Choose or Configure Models
+
+Model strings use the `"provider:model-name"` format.
+
+Examples:
+
+- `openai:gpt-5.2`
+- `anthropic:claude-sonnet-4-6`
+- `google:gemini-3-pro-preview`
+
+Use a model instance instead of a string when the user needs provider-specific constructor arguments.
+
+## Run Methods and Streaming
+
+Pick a run method based on the interaction pattern:
+
+- `run()` for async runs that complete normally
+- `run_sync()` for synchronous scripts and notebooks
+- `run_stream()` for streaming final output
+- `run_stream_sync()` for sync streaming
+- `run_stream_events()` when the caller needs the typed event stream directly
+- `iter()` when the caller needs step-by-step control over the agent loop
+
+Use `event_stream_handler=` with `run()` or `run_stream()` when the user wants progress updates without manually consuming the event stream:
+
+```python
+from collections.abc import AsyncIterable
+
+from pydantic_ai import Agent, AgentStreamEvent, FunctionToolCallEvent, RunContext
+
+agent = Agent('openai:gpt-5.2')
+
+
+async def stream_handler(ctx: RunContext[None], events: AsyncIterable[AgentStreamEvent]):
+    async for event in events:
+        if isinstance(event, FunctionToolCallEvent):
+            print(f'Calling {event.part.tool_name}...')
+
+
+async def main():
+    await agent.run('Do the task', event_stream_handler=stream_handler)
+```
+
+## Handle Provider Failures
+
+Use `FallbackModel` when the user wants automatic provider or model failover.
+
+```python
+from pydantic_ai import Agent
+from pydantic_ai.models.anthropic import AnthropicModel
+from pydantic_ai.models.fallback import FallbackModel
+from pydantic_ai.models.openai import OpenAIChatModel
+
+fallback = FallbackModel(
+    OpenAIChatModel('gpt-5.2'),
+    AnthropicModel('claude-sonnet-4-6'),
+)
+
+agent = Agent(fallback)
+```
+
+Good defaults:
+
+- primary expensive/strong model, cheaper fallback for resilience
+- same prompt/output contract across both models
+- per-model settings only when the user actually needs them

--- a/plugins/pydantic-ai/skills/building-pydantic-ai-agents/references/ARCHITECTURE.md
+++ b/plugins/pydantic-ai/skills/building-pydantic-ai-agents/references/ARCHITECTURE.md
@@ -1,0 +1,252 @@
+# Architecture and Decision Guide
+
+Detailed decision trees, comparison tables, and architecture overview for Pydantic AI.
+
+## Contents
+
+- [Task-Family References](#task-family-references)
+- [Decision Trees](#decision-trees)
+  - [Choosing a Tool Registration Method](#choosing-a-tool-registration-method)
+  - [Choosing an Output Mode](#choosing-an-output-mode)
+  - [Choosing a Multi-Agent Pattern](#choosing-a-multi-agent-pattern)
+  - [Choosing How to Extend Agent Behavior](#choosing-how-to-extend-agent-behavior)
+  - [Choosing What to Load Eagerly](#choosing-what-to-load-eagerly)
+  - [Choosing a Capability](#choosing-a-capability)
+  - [Choosing a Testing Approach](#choosing-a-testing-approach)
+- [Comparison Tables](#comparison-tables)
+  - [Output Mode Comparison](#output-mode-comparison)
+  - [Model Provider Prefixes](#model-provider-prefixes)
+  - [Tool Decorator Comparison](#tool-decorator-comparison)
+  - [Built-in Capabilities](#built-in-capabilities)
+  - [When to Use Each Agent Method](#when-to-use-each-agent-method)
+- [Architecture Overview](#architecture-overview)
+
+## Task-Family References
+
+Use this file for comparisons and abstraction choices.
+
+If the user already knows what they want to do, load the narrower task guide instead:
+
+- [AGENTS-CORE.md](./AGENTS-CORE.md)
+- [CAPABILITIES-AND-HOOKS.md](./CAPABILITIES-AND-HOOKS.md)
+- [ON-DEMAND-CAPABILITIES.md](./ON-DEMAND-CAPABILITIES.md)
+- [TOOLS-CORE.md](./TOOLS-CORE.md)
+- [NATIVE-TOOLS.md](./NATIVE-TOOLS.md)
+- [TOOLS-ADVANCED.md](./TOOLS-ADVANCED.md)
+- [INPUT-AND-HISTORY.md](./INPUT-AND-HISTORY.md)
+- [TESTING-AND-DEBUGGING.md](./TESTING-AND-DEBUGGING.md)
+- [ORCHESTRATION-AND-INTEGRATIONS.md](./ORCHESTRATION-AND-INTEGRATIONS.md)
+
+## Decision Trees
+
+### Choosing a Tool Registration Method
+
+```
+Need RunContext (deps, usage, messages)?
+|-- Yes -> Use @agent.tool
+`-- No -> Pure function, no context needed?
+    |-- Yes -> Use @agent.tool_plain
+    `-- Tools defined outside agent file?
+        |-- Yes -> Use tools=[Tool(...)] in constructor
+        `-- Dynamic tools based on context?
+            |-- Yes -> Use ToolPrepareFunc
+            `-- Multiple related tools as a group?
+                `-- Yes -> Use FunctionToolset
+```
+
+### Choosing an Output Mode
+
+```
+Need structured data with Pydantic validation?
+|-- Yes -> Does provider support native JSON mode?
+|   |-- Yes, and you want it -> Use NativeOutput(MyModel)
+|   `-- No, or prefer consistency -> Use ToolOutput(MyModel) [default]
+`-- No -> Need custom parsing logic?
+    |-- Yes -> Use TextOutput(parser_fn)
+    `-- No -> Just plain text?
+        `-- Yes -> Use output_type=str [default]
+
+Dynamic schema at runtime?
+`-- Yes -> Use StructuredDict(json_schema)
+```
+
+### Choosing a Multi-Agent Pattern
+
+```
+Child agent returns result to parent?
+|-- Yes -> Use agent delegation via tools
+`-- No -> Permanent hand-off to specialist?
+    |-- Yes -> Use output functions
+    `-- Application code between agents?
+        |-- Yes -> Use programmatic hand-off
+        `-- Complex state machine?
+            `-- Yes -> Use Graph-based control
+```
+
+### Choosing How to Extend Agent Behavior
+
+```
+Need reusable behavior across agents (tools + hooks + instructions)?
+|-- Yes -> Build a custom capability, then consider whether `defer_loading=True` should be the default
+`-- No -> Just intercepting lifecycle events?
+    |-- Yes -> Complex interception needing tools/instructions too?
+    |   |-- Yes -> Subclass AbstractCapability
+    |   `-- No -> Use Hooks capability with decorators
+    `-- No -> Defining agents from config files?
+        |-- Yes -> Use Agent.from_file() with YAML/JSON specs
+        `-- No -> Just adding tools?
+            |-- Yes -> Use @agent.tool or Toolset
+            `-- Pass args directly to Agent constructor
+```
+
+### Choosing What to Load Eagerly
+
+```
+Is this part of a capability?
+|-- Yes -> First consider `defer_loading=True`; would eager loading improve most turns or be required for hooks/settings?
+|   |-- Yes -> Keep it eager in an always-on capability
+|   `-- No -> Use capabilities on demand with `defer_loading=True`
+`-- No -> Will this information/tool schema improve most model turns?
+    |-- Yes -> Keep it eager in the base agent or hot-path toolset
+    `-- No -> Is it a named workflow with instructions plus tools?
+        |-- Yes -> Use capabilities on demand with `defer_loading=True`
+        `-- No -> Is it one of many individually discoverable tools?
+            |-- Yes -> Use tool-level `defer_loading=True` and ToolSearch
+            `-- No -> Can the caller fetch it outside the agent and pass only the relevant slice?
+                |-- Yes -> Keep it out of the agent; inject the slice through deps, prompt, or retrieval
+                `-- No -> Reconsider whether the agent actually needs this context
+```
+
+Be opinionated here. Any capability should at least be evaluated for deferral; eager loading is a choice to justify, not the unexamined default. Pydantic AI agents should not carry large optional policy text, rarely used schemas, or specialist runbooks in the eager prompt just because they are available. Prefer progressive disclosure unless the information is genuinely universal.
+
+### Choosing a Capability
+
+```
+Need model thinking/reasoning?
+|-- Yes -> Use Thinking(effort='high')
+`-- Need web search?
+    |-- Yes -> Use WebSearch() (auto-fallback to local)
+    `-- Need URL fetching?
+        |-- Yes -> Use WebFetch()
+        `-- Need MCP servers?
+            |-- Yes -> Use MCP()
+            `-- Need lifecycle hooks only?
+                |-- Yes -> Use Hooks()
+                `-- Need to filter/modify tool defs per step?
+                    `-- Yes -> Use PrepareTools()
+```
+
+### Choosing a Testing Approach
+
+```
+Need deterministic, fast tests?
+|-- Yes -> Use TestModel with agent.override()
+`-- Need specific tool call behavior?
+    |-- Yes -> Use FunctionModel
+    `-- Testing against real API (integration)?
+        `-- Yes -> Use pytest-recording with VCR cassettes
+```
+
+## Comparison Tables
+
+### Output Mode Comparison
+
+| Scenario | Mode |
+|----------|------|
+| Need structured data and want maximum provider compatibility | `ToolOutput` (default) - works with all providers, supports streaming |
+| Want the provider to natively enforce JSON schema compliance | `NativeOutput` - OpenAI, Anthropic, Google only; limited streaming |
+| Provider doesn't support tools or JSON mode | `PromptedOutput` - works everywhere as a fallback |
+| LLM returns non-JSON structured text (markdown, YAML, domain-specific) | `TextOutput` - custom parsing function |
+
+### Model Provider Prefixes
+
+| Provider | Prefix | Example |
+|----------|--------|---------|
+| OpenAI | `openai:` | `openai:gpt-5.2` |
+| Anthropic | `anthropic:` | `anthropic:claude-sonnet-4-6` |
+| Google (Gemini API) | `google:` | `google:gemini-3-pro-preview` |
+| Google Cloud | `google-cloud:` | `google-cloud:gemini-3-pro-preview` |
+| Groq | `groq:` | `groq:llama-3.3-70b-versatile` |
+| Mistral | `mistral:` | `mistral:mistral-large-latest` |
+| Cohere | `cohere:` | `cohere:command-r-plus-08-2024` |
+| AWS Bedrock | `bedrock:` | `bedrock:anthropic.claude-sonnet-4-6` |
+| Azure | `azure:` | `azure:gpt-5.2` |
+| OpenRouter | `openrouter:` | `openrouter:anthropic/claude-sonnet-4-6` |
+| xAI | `xai:` | `xai:grok-4.3` |
+| DeepSeek | `deepseek:` | `deepseek:deepseek-chat` |
+| Fireworks | `fireworks:` | `fireworks:accounts/fireworks/models/llama-v3p3-70b-instruct` |
+| Together | `together:` | `together:meta-llama/Meta-Llama-3.1-70B-Instruct-Turbo` |
+| Ollama (local) | `ollama:` | `ollama:llama3.2` |
+| GitHub Models | `github:` | `github:openai/gpt-5.2` |
+| Hugging Face | `huggingface:` | `huggingface:meta-llama/Llama-3.3-70B-Instruct` |
+| Cerebras | `cerebras:` | `cerebras:llama-4-scout-17b-16e-instruct` |
+| Heroku | `heroku:` | `heroku:claude-sonnet-4-6` |
+
+Additional prefixes: `litellm:`, `nebius:`, `ovhcloud:`, `alibaba:`, `sambanova:`, `vercel:`, `outlines:`, `moonshotai:`. For truly custom providers, subclass `Model` or use `OpenAIChatModel` with a custom `base_url`.
+
+### Tool Decorator Comparison
+
+| Scenario | Decorator |
+|----------|-----------|
+| Tool needs access to deps, usage stats, messages, or retry info | `@agent.tool` - `RunContext` as required first param |
+| Pure function, no agent context needed | `@agent.tool_plain` |
+| Tools defined in a separate module or shared across agents | `Tool(fn)` - pass to agent constructor via `tools=[...]` |
+
+### Built-in Capabilities
+
+| Capability | What it provides | Usable in YAML Specs |
+|---|---|:---:|
+| `Thinking` | Model thinking/reasoning at configurable effort | Yes |
+| `Hooks` | Decorator-based lifecycle hook registration | No |
+| `WebSearch` | Web search - native when supported, local fallback | Yes |
+| `WebFetch` | URL fetching - native when supported, custom fallback | Yes |
+| `ImageGeneration` | Image generation - native when supported, custom fallback | Yes |
+| `MCP` | MCP server - native when supported, direct connection | Yes |
+| `PrepareTools` | Filters or modifies tool definitions per step | No |
+| `PrefixTools` | Wraps a capability and prefixes its tool names | Yes |
+| `NativeTool` | Registers a provider-native tool with the agent | Yes |
+| `Toolset` | Wraps an `AbstractToolset` | No |
+| `ProcessHistory` | Wraps a history processor function - a thin wrapper over the `before_model_request` hook | No |
+
+### When to Use Each Agent Method
+
+| Scenario | Method |
+|----------|--------|
+| Building a chatbot or assistant that shows tool calls, progress, and output in real-time | `agent.run(event_stream_handler=...)` - streams all events while running to completion |
+| Running an autonomous agent, batch job, or background task | `agent.run()` |
+| Writing a CLI tool, script, or Jupyter notebook (no async) | `agent.run_sync()` |
+| Streaming final text word-by-word to a UI | `agent.run_stream()` |
+| Synchronous streaming for CLI tools or scripts (no async) | `agent.run_stream_sync()` |
+| Receiving an async iterable of typed events (tool calls, results, final output) | `agent.run_stream_events()` |
+| Inspecting or modifying state between agent steps, human-in-the-loop approval | `agent.iter()` |
+
+See [Run Methods and Streaming](./AGENTS-CORE.md#run-methods-and-streaming) for `event_stream_handler` details.
+
+## Architecture Overview
+
+Agent execution flow:
+`Agent.run()` -> `UserPromptNode` -> `ModelRequestNode` -> `CallToolsNode` -> (loop or end)
+
+Key generic types:
+
+- `Agent[AgentDepsT, OutputDataT]` - dependency type + output type
+- `RunContext[AgentDepsT]` - available in tools and system prompts
+- `AbstractCapability[AgentDepsT]` - base class for reusable behavior bundles
+
+Agent construction:
+
+- Python: `Agent(model, instructions=..., tools=..., capabilities=...)`
+- Declarative: `Agent.from_file('agent.yaml')` or `Agent.from_spec({...})`
+
+Capabilities are the primary extension point - they bundle tools, lifecycle hooks, instructions, and model settings into reusable units. Built-in capabilities include `Thinking`, `WebSearch`, `WebFetch`, `Hooks`, `MCP`, and more.
+
+Lifecycle hooks (via `Hooks` or `AbstractCapability`) intercept every stage: `before_run` -> `before_model_request` -> `before_tool_execute` -> `after_tool_execute` -> `after_model_request` -> `after_run`
+
+Model string format: `"provider:model-name"` (e.g., `"openai:gpt-5.2"`, `"anthropic:claude-sonnet-4-6"`, `"google:gemini-3-pro-preview"`)
+
+Output modes:
+
+- `ToolOutput` - structured data via tool calls (default for Pydantic models)
+- `NativeOutput` - provider-specific structured output
+- `PromptedOutput` - prompt-based structured extraction
+- `TextOutput` - plain text responses

--- a/plugins/pydantic-ai/skills/building-pydantic-ai-agents/references/CAPABILITIES-AND-HOOKS.md
+++ b/plugins/pydantic-ai/skills/building-pydantic-ai-agents/references/CAPABILITIES-AND-HOOKS.md
@@ -1,0 +1,116 @@
+# Capabilities and Hooks
+
+Read this file when the user wants reusable agent behavior, provider-adaptive tools, or lifecycle interception.
+
+## Add Capabilities to an Agent
+
+Capabilities bundle reusable behavior and compose automatically.
+
+```python
+from pydantic_ai import Agent
+from pydantic_ai.capabilities import Thinking, WebSearch
+
+agent = Agent(
+    'anthropic:claude-opus-4-6',
+    capabilities=[
+        Thinking(effort='high'),
+        WebSearch(),
+    ],
+)
+```
+
+Provider-adaptive capabilities to reach for first:
+
+- `Thinking`
+- `WebSearch`
+- `WebFetch`
+- `ImageGeneration`
+- `MCP`
+
+Use capabilities when the user wants behavior that should survive model/provider changes.
+
+## Enable Thinking Across Providers
+
+Use the unified `Thinking` capability or the `thinking` model setting.
+
+```python
+from pydantic_ai import Agent
+from pydantic_ai.capabilities import Thinking
+
+agent = Agent('anthropic:claude-opus-4-6', capabilities=[Thinking(effort='high')])
+agent = Agent('anthropic:claude-opus-4-6', model_settings={'thinking': 'high'})
+```
+
+Supported effort values:
+
+- `True`
+- `False`
+- `'minimal'`
+- `'low'`
+- `'medium'`
+- `'high'`
+- `'xhigh'`
+
+## Intercept Agent Lifecycle with Hooks
+
+Use `Hooks` for decorator-based lifecycle interception.
+
+```python
+from pydantic_ai import Agent, RunContext, ToolDefinition
+from pydantic_ai.capabilities import ValidatedToolArgs
+from pydantic_ai.capabilities.hooks import Hooks
+from pydantic_ai.messages import ToolCallPart
+from pydantic_ai.models import ModelRequestContext
+
+hooks = Hooks()
+
+
+@hooks.on.before_model_request
+async def log_request(ctx: RunContext[None], request_context: ModelRequestContext) -> ModelRequestContext:
+    print(f'Sending {len(request_context.messages)} messages')
+    return request_context
+
+
+@hooks.on.before_tool_execute(tools=['send_email'])
+async def audit_tool(
+    ctx: RunContext[None],
+    *,
+    call: ToolCallPart,
+    tool_def: ToolDefinition,
+    args: ValidatedToolArgs,
+) -> ValidatedToolArgs:
+    print(f'Executing {call.tool_name}')
+    return args
+
+
+agent = Agent('openai:gpt-5.2', capabilities=[hooks])
+```
+
+Important hook families:
+
+- run-level hooks
+- node-level hooks
+- model-request hooks
+- tool-validation hooks
+- tool-execution hooks
+- event-stream hooks
+
+Use hooks when the user wants observability, auditing, or light interception without adding a new abstraction.
+
+## Build a Custom Capability
+
+Subclass `AbstractCapability` when the user wants reusable behavior that combines tools, hooks, instructions, or model settings into one package.
+
+Reach for a custom capability when:
+
+- the same bundle should be reused across multiple agents
+- `Hooks` alone is not enough
+- the behavior should be installable or declarative
+
+Keep custom capabilities focused. If the user only needs one tool or one hook, do not introduce a capability.
+
+For every capability, consider whether `defer_loading=True` would improve the system by keeping instructions and tool schemas out of the eager context. Keep it eager only when the model benefits from that capability on most turns, when its hooks/settings must always apply, or when deferral would make capability selection unreliable.
+
+## Defer Capability Loading
+
+For capabilities on demand, load [Capabilities on Demand](./ON-DEMAND-CAPABILITIES.md). Use it when the user mentions deferred capabilities, capability progressive disclosure, `defer_loading=True` on a capability, or `load_capability`; also use it proactively when an agent design includes optional instructions, specialist workflows, long-tail tools, or context the model does not need on most turns.

--- a/plugins/pydantic-ai/skills/building-pydantic-ai-agents/references/COMMON-TASKS.md
+++ b/plugins/pydantic-ai/skills/building-pydantic-ai-agents/references/COMMON-TASKS.md
@@ -1,0 +1,113 @@
+# Task Reference Map
+
+This file exists as a compatibility index for older links into `COMMON-TASKS.md`.
+
+Prefer the narrower task-family guides below so the agent loads only the material it needs:
+
+- [AGENTS-CORE.md](./AGENTS-CORE.md) - agent creation, output, deps, specs, models, run methods
+- [CAPABILITIES-AND-HOOKS.md](./CAPABILITIES-AND-HOOKS.md) - `Thinking`, `WebSearch`, `Hooks`, custom capabilities
+- [ON-DEMAND-CAPABILITIES.md](./ON-DEMAND-CAPABILITIES.md) - progressive disclosure, deferred capabilities, capabilities on demand, `load_capability`
+- [TOOLS-CORE.md](./TOOLS-CORE.md) - `@agent.tool`, `Tool`, toolsets, MCP, common search tools
+- [NATIVE-TOOLS.md](./NATIVE-TOOLS.md) - provider-native tools like `WebSearchTool` and `CodeExecutionTool`
+- [TOOLS-ADVANCED.md](./TOOLS-ADVANCED.md) - approval, retries, `ToolReturn`, timeouts, validators, tool-level deferred loading
+- [INPUT-AND-HISTORY.md](./INPUT-AND-HISTORY.md) - multimodal input, message history, history processors
+- [TESTING-AND-DEBUGGING.md](./TESTING-AND-DEBUGGING.md) - `TestModel`, `FunctionModel`, `capture_run_messages`, Logfire
+- [ORCHESTRATION-AND-INTEGRATIONS.md](./ORCHESTRATION-AND-INTEGRATIONS.md) - multi-agent patterns, graphs, A2A, direct API, durable execution, embeddings, evals, third-party tools
+
+## Add Capabilities to an Agent
+
+Read [Add Capabilities](./CAPABILITIES-AND-HOOKS.md#add-capabilities-to-an-agent).
+
+## Apply Progressive Disclosure
+
+Read [Capabilities on Demand](./ON-DEMAND-CAPABILITIES.md).
+
+## Intercept Agent Lifecycle with Hooks
+
+Read [Intercept Agent Lifecycle with Hooks](./CAPABILITIES-AND-HOOKS.md#intercept-agent-lifecycle-with-hooks).
+
+## Define Agents Declaratively with Specs
+
+Read [Define Agents Declaratively with Specs](./AGENTS-CORE.md#define-agents-declaratively-with-specs).
+
+## Enable Thinking Across Providers
+
+Read [Enable Thinking Across Providers](./CAPABILITIES-AND-HOOKS.md#enable-thinking-across-providers).
+
+## Use MCP Servers
+
+Read [Use MCP Servers](./TOOLS-CORE.md#use-mcp-servers).
+
+## Search with DuckDuckGo, Tavily, or Exa
+
+Read [Search with DuckDuckGo, Tavily, or Exa](./TOOLS-CORE.md#search-with-duckduckgo-tavily-or-exa).
+
+## Require Tool Approval (Human in the Loop)
+
+Read [Require Tool Approval](./TOOLS-ADVANCED.md#require-tool-approval-human-in-the-loop).
+
+## Send Images, Audio, Video, or Documents to the Model
+
+Read [Send Images, Audio, Video, or Documents to the Model](./INPUT-AND-HISTORY.md#send-images-audio-video-or-documents-to-the-model).
+
+## Manage Context Size
+
+Read [Manage Context Size](./INPUT-AND-HISTORY.md#manage-context-size).
+
+## Work with Message History
+
+Read [Work with Message History](./INPUT-AND-HISTORY.md#work-with-message-history).
+
+## Show Real-Time Progress
+
+Read [Run Methods and Streaming](./AGENTS-CORE.md#run-methods-and-streaming).
+
+## Handle Provider Failures
+
+Read [Handle Provider Failures](./AGENTS-CORE.md#handle-provider-failures).
+
+## Make an Agent Resilient with Retries
+
+Read [Make an Agent Resilient with Retries](./TOOLS-ADVANCED.md#make-an-agent-resilient-with-retries).
+
+## Debug a Failed Agent Run
+
+Read [Debug a Failed Agent Run](./TESTING-AND-DEBUGGING.md#debug-a-failed-agent-run).
+
+## Test Agent Behavior
+
+Read [Test Agent Behavior](./TESTING-AND-DEBUGGING.md#test-agent-behavior).
+
+## Coordinate Multiple Agents
+
+Read [Coordinate Multiple Agents](./ORCHESTRATION-AND-INTEGRATIONS.md#coordinate-multiple-agents).
+
+## Build Multi-Step Workflows with Graphs
+
+Read [Build Multi-Step Workflows with Graphs](./ORCHESTRATION-AND-INTEGRATIONS.md#build-multi-step-workflows-with-graphs).
+
+## Debug and Validate Agent Behavior
+
+Read [Debug and Validate Agent Behavior](./TESTING-AND-DEBUGGING.md#debug-and-validate-agent-behavior).
+
+## Advanced and Less Common Features
+
+Read only the relevant section in [ORCHESTRATION-AND-INTEGRATIONS.md](./ORCHESTRATION-AND-INTEGRATIONS.md):
+
+- [Direct API](./ORCHESTRATION-AND-INTEGRATIONS.md#call-the-model-without-using-an-agent)
+- [A2A](./ORCHESTRATION-AND-INTEGRATIONS.md#expose-agents-as-http-servers-a2a)
+- [Durable Execution](./ORCHESTRATION-AND-INTEGRATIONS.md#use-durable-execution)
+- [Embeddings](./ORCHESTRATION-AND-INTEGRATIONS.md#use-embeddings-for-rag)
+- [Third-Party Tools](./ORCHESTRATION-AND-INTEGRATIONS.md#use-langchain-or-acidev-tools)
+- [Custom Extensibility](./ORCHESTRATION-AND-INTEGRATIONS.md#build-custom-toolsets-models-or-agents)
+- [Evals](./ORCHESTRATION-AND-INTEGRATIONS.md#systematically-verify-agent-behavior-with-evals)
+
+## Working with the Installed Pydantic AI Package
+
+Prefer the checked-out repository or these bundled references first.
+
+Inspect local package source only as a last resort when:
+
+- the user asks about a symbol that is not covered in this skill
+- the local environment already includes `pydantic_ai` and you need exact module layout
+- you have no narrower offline reference available

--- a/plugins/pydantic-ai/skills/building-pydantic-ai-agents/references/INPUT-AND-HISTORY.md
+++ b/plugins/pydantic-ai/skills/building-pydantic-ai-agents/references/INPUT-AND-HISTORY.md
@@ -1,0 +1,94 @@
+# Input and History
+
+Read this file when the user wants multimodal input, message history, or context trimming.
+
+## Send Images, Audio, Video, or Documents to the Model
+
+Pass multimodal content as a list mixing text with `ImageUrl`, `AudioUrl`, `VideoUrl`, `DocumentUrl`, or `BinaryContent`.
+
+```python
+from pydantic_ai import Agent, ImageUrl
+
+agent = Agent(model='openai:gpt-5.2')
+result = agent.run_sync(
+    [
+        'What company is this logo from?',
+        ImageUrl(url='https://example.com/logo.png'),
+    ]
+)
+print(result.output)
+```
+
+Use `BinaryContent(...)` when the asset is already in memory instead of at a URL.
+
+Not every model supports every input type. Keep provider expectations in mind when the user chooses a specific model.
+
+## Work with Message History
+
+Use `message_history=` to continue a conversation across runs.
+
+```python
+from pydantic_ai import Agent
+
+agent = Agent('openai:gpt-5.2', instructions='Be a helpful assistant.')
+
+result1 = agent.run_sync('Tell me a joke.')
+result2 = agent.run_sync('Explain?', message_history=result1.new_messages())
+print(result2.output)
+```
+
+Important distinctions:
+
+- `new_messages()` returns only the current run
+- `all_messages()` returns the full history accumulated so far
+- when `message_history` is non-empty, Pydantic AI assumes the history already carries the system prompt
+
+## Manage Context Size
+
+Use `capabilities=[ProcessHistory(...)]` to trim or rewrite message history before each model request. `ProcessHistory` is a thin wrapper around the `before_model_request` lifecycle hook - for richer control (access to `RunContext`/`ModelRequestContext`, ability to short-circuit the model call), hook the event directly via `capabilities=[Hooks(before_model_request=fn)]`.
+
+The legacy `Agent(history_processors=[fn])` kwarg is deprecated and remapped onto `ProcessHistory` capabilities; it will be removed in v2.
+
+```python
+from pydantic_ai import Agent, ModelMessage
+from pydantic_ai.capabilities import ProcessHistory
+
+
+async def keep_recent(messages: list[ModelMessage]) -> list[ModelMessage]:
+    return messages[-10:] if len(messages) > 10 else messages
+
+
+agent = Agent('openai:gpt-5.2', capabilities=[ProcessHistory(keep_recent)])
+```
+
+Good uses:
+
+- trimming long conversations
+- removing PII before provider calls
+- summarizing old messages
+- applying app-specific history policies
+
+## Inject Messages Mid-Run
+
+Use `RunContext.enqueue(...)` (from a tool or capability hook) or `AgentRun.enqueue(...)` (from external code driving `agent.iter()`) to add content to the conversation while a run is in progress - e.g. a tool adding follow-up context, or an external event "steering" the agent.
+
+`enqueue` is variadic; each positional arg is one item: a piece of `UserContent` (a `str` or multi-modal content like an `ImageUrl`), a `ModelRequestPart` (e.g. a `SystemPromptPart`), or a complete `ModelRequest`/`ModelResponse`. Adjacent user content is gathered into one `UserPromptPart`. Pass an existing list by spreading it (`enqueue(*items)`).
+
+```python
+from pydantic_ai import Agent, RunContext
+
+agent = Agent('anthropic:claude-opus-4-7')
+
+
+@agent.tool
+def trigger_alert(ctx: RunContext[None]) -> str:
+    ctx.enqueue('Alert: production is degraded, prioritize triage.')
+    return 'alert raised'
+```
+
+A `priority` controls delivery:
+
+- `'asap'` (default): delivered at the earliest opportunity - added to the next model request, or, if the agent would otherwise terminate, used to redirect the run into one more request. This is "steering" an in-flight agent.
+- `'when_idle'`: delivered only when the agent would otherwise terminate, after any `'asap'` messages - a follow-up task that shouldn't interrupt in-flight work.
+
+`'when_idle'` redirects need `agent.run()` or explicit `AgentRun.next()` driving; they aren't drained inside a bare `async for node in agent_run:` loop. See [message history docs](https://ai.pydantic.dev/message-history/#injecting-messages-mid-run) for details.

--- a/plugins/pydantic-ai/skills/building-pydantic-ai-agents/references/NATIVE-TOOLS.md
+++ b/plugins/pydantic-ai/skills/building-pydantic-ai-agents/references/NATIVE-TOOLS.md
@@ -1,0 +1,77 @@
+# Native Tools
+
+Read this file when the user wants provider-native tools such as web search, web fetch, code execution, memory, or file search.
+
+Prefer provider-adaptive capabilities like `WebSearch()`, `WebFetch()`, `MCP()`, or `ImageGeneration()` when the user wants a provider-agnostic solution. Use native tools directly when they explicitly want provider-native behavior or provider-specific configuration.
+
+## Give My Agent Web Search or Code Execution
+
+Native tools are wrapped in [`NativeTool`][pydantic_ai.capabilities.NativeTool] and passed via `capabilities=[...]`.
+
+```python
+from pydantic_ai import Agent
+from pydantic_ai.capabilities import NativeTool
+from pydantic_ai.native_tools import WebSearchTool
+
+agent = Agent('openai-responses:gpt-5.2', capabilities=[NativeTool(WebSearchTool())])
+result = agent.run_sync('Give me a sentence with the biggest news in AI this week.')
+print(result.output)
+```
+
+For OpenAI web search, use the Responses API model prefix (`openai-responses:`), not `openai:`.
+
+## Native Tool Defaults
+
+Reach for these when the provider supports them:
+
+- `WebSearchTool`
+- `WebFetchTool`
+- `CodeExecutionTool`
+- `ImageGenerationTool`
+- `MemoryTool`
+- `MCPServerTool`
+- `FileSearchTool`
+
+## Dynamic Native Tool Configuration
+
+Prepare native tools from `RunContext` when configuration depends on the current user or request. Wrap the prepare function in `NativeTool(...)`.
+
+```python
+from pydantic_ai import Agent, RunContext
+from pydantic_ai.capabilities import NativeTool
+from pydantic_ai.native_tools import WebSearchTool
+
+
+async def prepared_web_search(ctx: RunContext[dict]) -> WebSearchTool | None:
+    if not ctx.deps.get('location'):
+        return None
+    return WebSearchTool(user_location={'city': ctx.deps['location']})
+
+
+agent = Agent(
+    'openai-responses:gpt-5.2',
+    capabilities=[NativeTool(prepared_web_search)],
+    deps_type=dict,
+)
+```
+
+## When to Use Native Tools vs Provider-Adaptive Capabilities
+
+Use provider-adaptive capabilities - `WebSearch()`, `WebFetch()`, `MCP()`, `ImageGeneration()` - when:
+
+- the code should work across providers
+- you want local fallback when native support is missing
+- the user has not committed to a provider yet
+
+```python
+from pydantic_ai import Agent
+from pydantic_ai.capabilities import WebSearch
+
+agent = Agent('anthropic:claude-sonnet-4-6', capabilities=[WebSearch()])
+```
+
+Use native tools (`NativeTool(WebSearchTool(...))`) when:
+
+- the user explicitly wants provider-native behavior
+- provider-specific configuration matters (e.g. `WebSearchTool(user_location=...)`)
+- the user already picked a provider that supports the tool

--- a/plugins/pydantic-ai/skills/building-pydantic-ai-agents/references/ON-DEMAND-CAPABILITIES.md
+++ b/plugins/pydantic-ai/skills/building-pydantic-ai-agents/references/ON-DEMAND-CAPABILITIES.md
@@ -1,0 +1,127 @@
+# Capabilities on Demand
+
+Read this file when designing progressive disclosure of any kind, when an agent has information it does not need on most turns, or when the user asks about deferred capabilities, capabilities on demand, `defer_loading=True` on capabilities, or the `load_capability` tool.
+
+## Mental Model
+
+Capabilities on demand are bundle-level progressive disclosure for Pydantic AI. The model initially sees a compact catalog of deferred capability `id` values, plus `description` values when provided, and the framework-managed `load_capability` tool. When the model calls `load_capability(id)`, Pydantic AI returns that capability's instructions; its function tools, native tools, and model settings are reflected on the next model request, and its hooks can fire for later hook points in the run.
+
+Be opinionated: review every capability for whether `defer_loading=True` would benefit the system before accepting eager loading. If the model does not need a piece of information, a specialist instruction set, or a tool schema on most turns, do not put it in the eager prompt by default.
+
+Use this for specialist behavior where instructions and tools should travel together:
+
+- support workflows such as refunds, returns, account management, or fraud review
+- domain-specific tool bundles where most requests need only one bundle
+- agents that would otherwise load many capability instructions and tool schemas on every turn
+
+Use tool search instead when the agent has a large flat tool catalog and the model should discover individual tools. Tool search uses `search_tools`; capabilities on demand use `load_capability`.
+
+## Opinionated Design Rules
+
+- Treat `defer_loading=True` as a design question for every capability, not a niche option users must ask for.
+- Keep the base agent prompt small: identity, task boundaries, global safety, and the routing instruction needed to decide what to load.
+- Put specialist runbooks behind capabilities on demand when they are useful only for a subset of requests.
+- Put broad tool catalogs behind tool search when the tools are individually discoverable and do not need shared instructions.
+- Keep hot-path tools and universal instructions eager when they are used most turns.
+- Prefer a few coherent capability bundles over dozens of tiny capabilities that force the model to plan its own dependency graph.
+- Do not hide information the model needs to decide which capability to load; that belongs in the capability description or always-on routing instructions.
+
+## Minimal Pattern
+
+Every deferred capability needs a stable explicit `id` and `defer_loading=True`. A concise `description` is optional; add one when the `id` alone is not enough for routing.
+
+```python
+from pydantic_ai import Agent
+from pydantic_ai.capabilities import Capability
+
+refunds = Capability(
+    id='refunds',
+    description='Refund policy tools and instructions.',
+    instructions='Use the refund policy before answering refund questions.',
+    defer_loading=True,
+)
+
+
+@refunds.tool_plain
+def lookup_refund_policy(order_id: str) -> str:
+    """Look up whether an order is eligible for a refund."""
+    return f'{order_id} is eligible for a refund for 30 days after purchase.'
+
+
+agent = Agent(
+    'anthropic:claude-sonnet-4-6',
+    instructions='Answer as a support assistant.',
+    capabilities=[refunds],
+)
+```
+
+`Capability` is a convenience helper for simple bundles of instructions, descriptions, function tools, and toolsets. It accepts callable descriptions, dynamic instruction functions, and dynamic toolset functions. Use a custom `AbstractCapability` for model settings, hooks, native tools, wrapper toolsets, reusable public behavior, or custom per-run logic. Wrapper toolsets are applied during per-run toolset assembly; if wrapper behavior should wait for a deferred capability to load, gate that behavior inside the wrapper.
+
+## Runtime Semantics
+
+Initial request:
+
+- deferred capability instructions are not included
+- deferred capability function tools are present in the framework toolset but marked with `defer_loading=True`; they go through client-executed local search, so the provider's hosted search never sees them, and they are not callable until the capability loads
+- non-deferred capabilities are treated as already loaded
+- the framework adds `load_capability` if any deferred capability exists
+
+When `load_capability` succeeds:
+
+- the call is typed as a capability-load message part
+- the return may include resolved capability instructions and owned toolset instructions
+- the capability id is added to `ctx.available_capability_ids`
+- tools owned by the loaded capability become visible on later steps
+- `load_capability` remains visible so the tool set stays stable
+
+Message history matters. Loaded capability state is reconstructed from matching `LoadCapabilityCallPart` and `LoadCapabilityReturnPart` pairs in message history. If a history processor removes those parts, the model may need to load the capability again.
+
+## Dynamic Descriptions and Instructions
+
+Use `get_description()` when the catalog text depends on run context. Return a callable (with or without `RunContext`) that produces the description string. Use dynamic instructions when load-time instructions need deps or current run state.
+
+```python
+from dataclasses import dataclass
+
+from pydantic_ai import RunContext
+from pydantic_ai.capabilities import AbstractCapability
+
+
+@dataclass
+class SupportDeps:
+    plan: str
+    account_id: str
+
+
+@dataclass
+class AccountCapability(AbstractCapability[SupportDeps]):
+    def get_description(self):
+        def describe(ctx: RunContext[SupportDeps]) -> str:
+            return f'Account-management tools for {ctx.deps.plan} plan customers.'
+
+        return describe
+
+    def get_instructions(self):
+        def load_instructions(ctx: RunContext[SupportDeps]) -> str:
+            return f'Use account ID {ctx.deps.account_id} for account-management tools.'
+
+        return load_instructions
+
+
+account_capability = AccountCapability(id='account-management', defer_loading=True)
+```
+
+## Composition Rules
+
+- Capability `id` values must be unique in a run.
+- Deferred capability ids must be explicit and stable; auto-generated ids are rejected because history replay cannot rely on them.
+- `load_capability` is reserved when any deferred capability exists.
+- Deferred capability instructions and model settings activate only after the capability is loaded.
+- Both function and native tools defer with the capability. Deferring a native tool delays its definition entering the request, which breaks the prompt-cache prefix on load - only worth it for tools that materially bloat the prompt.
+- Capability-level `defer_loading=True` gates the bundle as a unit. Once the model loads the capability, all tools owned by that deferred capability become visible together. Use tool-level `defer_loading=True` outside a deferred capability when individual tools should stay behind `search_tools`.
+
+## Choosing Between Deferral Mechanisms
+
+Capabilities on demand (`load_capability`) and tool search (`search_tools`) are covered above. The third mechanism is deferred tool calls: use these when the issue is execution timing, approval, or external execution. Deferred tool calls decide whether a *visible* tool call can run now; they do not control whether the model can see a capability.
+
+When in doubt: "Would a high-quality answer to most user prompts get worse if this information were absent until requested?" If no, recommend progressive disclosure.

--- a/plugins/pydantic-ai/skills/building-pydantic-ai-agents/references/ORCHESTRATION-AND-INTEGRATIONS.md
+++ b/plugins/pydantic-ai/skills/building-pydantic-ai-agents/references/ORCHESTRATION-AND-INTEGRATIONS.md
@@ -1,0 +1,142 @@
+# Orchestration and Integrations
+
+Read this file when the user wants multi-agent coordination, graphs, direct model calls, A2A, durable execution, embeddings, evals, or third-party integrations.
+
+## Coordinate Multiple Agents
+
+Use agent delegation when one agent should call another and return the result.
+
+```python
+from pydantic_ai import Agent, RunContext
+
+parent = Agent('openai:gpt-5.2')
+researcher = Agent('openai:gpt-5.2', output_type=str)
+
+
+@parent.tool
+async def research(ctx: RunContext[None], topic: str) -> str:
+    result = await researcher.run(f'Research: {topic}', usage=ctx.usage)
+    return result.output
+```
+
+Good split:
+
+- delegation via tools when the parent keeps control
+- output functions or programmatic hand-off when control should move elsewhere
+
+## Build Multi-Step Workflows with Graphs
+
+Use `pydantic_graph` when the workflow is a state machine rather than a single agent loop.
+
+```python
+from dataclasses import dataclass
+
+from pydantic_graph import BaseNode, End, Graph, GraphRunContext
+
+
+@dataclass
+class FirstNode(BaseNode[None, None, int]):
+    value: int
+
+    async def run(self, ctx: GraphRunContext) -> 'SecondNode | End[int]':
+        if self.value >= 5:
+            return End(self.value)
+        return SecondNode(self.value + 1)
+
+
+@dataclass
+class SecondNode(BaseNode):
+    value: int
+
+    async def run(self, ctx: GraphRunContext) -> FirstNode:
+        return FirstNode(self.value)
+
+
+graph = Graph(nodes=[FirstNode, SecondNode])
+result = graph.run_sync(FirstNode(0))
+```
+
+## Call the Model Without Using an Agent
+
+Use the direct API when the user wants a single model request without agent orchestration.
+
+```python
+from pydantic_ai import ModelRequest
+from pydantic_ai.direct import model_request_sync
+
+response = model_request_sync(
+    'openai:gpt-5.2',
+    [ModelRequest.user_text_prompt('Summarize this in one sentence.')],
+)
+```
+
+Reach for this when there is no need for tools, retries, or agent loop state.
+
+## Expose Agents as HTTP Servers (A2A)
+
+Use `fasta2a.pydantic_ai.agent_to_a2a` when the agent should be exposed as an ASGI app that speaks the A2A protocol. Install with `pip install 'fasta2a[pydantic-ai]>=0.6.1'`.
+
+```python
+from fasta2a.pydantic_ai import agent_to_a2a
+
+from pydantic_ai import Agent
+
+agent = Agent('openai:gpt-5.2')
+app = agent_to_a2a(agent)
+```
+
+`Agent.to_a2a()` still works in 1.x but emits a deprecation warning and is removed in 2.0.
+
+## Use Durable Execution
+
+Use the durable execution integrations when the run must survive crashes, retries, or long-lived workflows.
+
+Temporal entry points:
+
+- `TemporalAgent`
+- `PydanticAIWorkflow`
+- `PydanticAIPlugin`
+
+There are parallel integrations for DBOS and Prefect.
+
+## Use Embeddings for RAG
+
+Use `Embedder(...)` for query/document embeddings when the user is building retrieval or semantic search.
+
+```python
+from pydantic_ai import Embedder
+
+embedder = Embedder('openai:text-embedding-3-small')
+```
+
+## Use LangChain or ACI.dev Tools
+
+Third-party integrations to reach for:
+
+- `tool_from_langchain`
+- `LangChainToolset`
+- `tool_from_aci` (deprecated, removed in 2.0)
+- `ACIToolset` (deprecated, removed in 2.0)
+
+Use these when the user explicitly wants those ecosystems instead of native Pydantic AI tools. The ACI.dev wrappers are deprecated in 1.x and removed in 2.0; wrap ACI tools yourself with `Tool.from_schema` against `aci.ACI().functions.get_definition(...)`.
+
+## Systematically Verify Agent Behavior with Evals
+
+Use `pydantic_evals` when the user wants repeatable evaluation datasets and evaluators rather than ad hoc tests.
+
+Common entry points:
+
+- `Case`
+- `Dataset`
+- evaluator classes from `pydantic_evals.evaluators`
+
+## Build Custom Toolsets, Models, or Agents
+
+Extensibility entry points:
+
+- `AbstractToolset` / `WrapperToolset`
+- `Model` / `WrapperModel`
+- `AbstractAgent` / `WrapperAgent`
+- `AbstractCapability`
+
+Reach for these only when the built-in primitives are genuinely insufficient.

--- a/plugins/pydantic-ai/skills/building-pydantic-ai-agents/references/TESTING-AND-DEBUGGING.md
+++ b/plugins/pydantic-ai/skills/building-pydantic-ai-agents/references/TESTING-AND-DEBUGGING.md
@@ -1,0 +1,75 @@
+# Testing and Debugging
+
+Read this file when the user wants deterministic tests, custom test models, request inspection, or runtime debugging.
+
+## Test Agent Behavior
+
+Use `TestModel` for fast deterministic tests and `FunctionModel` for custom response logic.
+
+```python
+from pydantic_ai import Agent
+from pydantic_ai.models.test import TestModel
+
+agent = Agent('openai:gpt-5.2')
+
+with agent.override(model=TestModel()):
+    result = agent.run_sync('test prompt')
+    assert result.output == 'success (no tool calls)'
+```
+
+```python
+from pydantic_ai import Agent, ModelResponse, TextPart
+from pydantic_ai.models.function import FunctionModel
+
+agent = Agent('openai:gpt-5.2')
+
+
+def custom_model(messages, info):
+    return ModelResponse(parts=[TextPart(content='mocked response')])
+
+
+with agent.override(model=FunctionModel(custom_model)):
+    result = agent.run_sync('test prompt')
+```
+
+Default split:
+
+- `TestModel` when you want automatic valid outputs
+- `FunctionModel` when you need exact behavior for assertions, failures, or retries
+
+## Debug a Failed Agent Run
+
+Use `capture_run_messages()` when the user needs the exact request/response history that led to a failure.
+
+```python
+from pydantic_ai import Agent, UnexpectedModelBehavior, capture_run_messages
+
+agent = Agent('openai:gpt-5.2')
+
+with capture_run_messages() as messages:
+    try:
+        agent.run_sync('Please get me the volume of a box with size 6.')
+    except UnexpectedModelBehavior:
+        print(messages)
+```
+
+Use this for in-process debugging. It is a better fit than broad logging when the user wants to inspect one failing run.
+
+## Debug and Validate Agent Behavior
+
+Use Logfire when the user wants observability across agent runs, tools, and model requests.
+
+```python
+import logfire
+
+logfire.configure()
+logfire.instrument_pydantic_ai()
+logfire.instrument_httpx(capture_all=True)
+```
+
+Good uses:
+
+- tracing tool calls
+- validating what was sent to the provider
+- understanding structured-output failures
+- production observability

--- a/plugins/pydantic-ai/skills/building-pydantic-ai-agents/references/TOOLS-ADVANCED.md
+++ b/plugins/pydantic-ai/skills/building-pydantic-ai-agents/references/TOOLS-ADVANCED.md
@@ -1,0 +1,135 @@
+# Tools Advanced
+
+Read this file when the user wants advanced tool behavior: approval, retries, validation, timeouts, rich tool returns, or tool search/deferred loading.
+
+## Require Tool Approval (Human in the Loop)
+
+Use deferred tools when the run should pause for approval.
+
+```python
+from pydantic_ai import (
+    Agent,
+    DeferredToolRequests,
+    DeferredToolResults,
+    ToolDenied,
+)
+
+agent = Agent('openai:gpt-5.2', output_type=[str, DeferredToolRequests])
+
+
+@agent.tool_plain(requires_approval=True)
+def delete_file(path: str) -> str:
+    return f'File {path!r} deleted'
+
+
+result = agent.run_sync('Delete __init__.py')
+messages = result.all_messages()
+
+assert isinstance(result.output, DeferredToolRequests)
+results = DeferredToolResults()
+for call in result.output.approvals:
+    results.approvals[call.tool_call_id] = ToolDenied('Deleting files is not allowed')
+
+result = agent.run_sync('Continue', message_history=messages, deferred_tool_results=results)
+print(result.output)
+```
+
+Two key rules:
+
+- `DeferredToolRequests` must be in the output type
+- for conditional approval, raise `ApprovalRequired(...)` instead of marking the whole tool `requires_approval=True`
+
+## Make an Agent Resilient with Retries
+
+Raise `ModelRetry` from inside the tool when the model should correct and try again.
+
+```python
+from pydantic_ai import Agent, ModelRetry, RunContext
+
+agent = Agent('openai:gpt-5.2', deps_type=dict[str, int])
+
+
+@agent.tool(retries=2)
+def get_user_by_name(ctx: RunContext[dict[str, int]], name: str) -> int:
+    user_id = ctx.deps.get(name)
+    if user_id is None:
+        raise ModelRetry(f'No user found with name {name!r}')
+    return user_id
+```
+
+Use retries for recoverable model mistakes, not application crashes.
+
+## Validate or Require Approval Before Tool Execution
+
+Use `args_validator=` when arguments are structurally valid but still need business-rule validation before execution or approval.
+
+```python
+from pydantic_ai import Agent, DeferredToolRequests, ModelRetry, RunContext
+
+agent = Agent('openai:gpt-5.2', deps_type=int, output_type=[str, DeferredToolRequests])
+
+
+def validate_sum_limit(ctx: RunContext[int], x: int, y: int) -> None:
+    if x + y > ctx.deps:
+        raise ModelRetry(f'Sum of x and y must not exceed {ctx.deps}')
+
+
+@agent.tool(requires_approval=True, args_validator=validate_sum_limit)
+def add_numbers(ctx: RunContext[int], x: int, y: int) -> int:
+    return x + y
+```
+
+## Use Advanced Tool Features
+
+Reach for these features when the user needs more than a simple function tool:
+
+- `ToolReturn` for rich return values plus separate content/metadata
+- `prepare=` for dynamic tool definitions
+- `timeout=` for tool execution limits
+- `sequential=True` when tool calls must not run concurrently
+
+Example with `ToolReturn`:
+
+```python
+from pydantic_ai import Agent, BinaryContent, ToolReturn
+
+agent = Agent('openai:gpt-5.2')
+
+
+@agent.tool_plain
+def click_and_capture(x: int, y: int) -> ToolReturn:
+    return ToolReturn(
+        return_value=f'Successfully clicked at ({x}, {y})',
+        content=['After:', BinaryContent(data=b'png-data', media_type='image/png')],
+        metadata={'coordinates': {'x': x, 'y': y}},
+    )
+```
+
+## Handle Network Errors and Rate Limiting Automatically
+
+For tool-call retries, use `ModelRetry` and tool `retries=...`.
+
+For HTTP request retries at the transport layer, use the library's retry configuration separately. Do not assume `ModelRetry` alone solves provider transport failures.
+
+## Tool Search and Tool-Level Deferred Loading
+
+Use tool-level deferred loading when the agent has many tools and the model should discover individual tools on demand via `search_tools`.
+
+```python
+from pydantic_ai import Agent
+
+agent = Agent('openai:gpt-5.2')
+
+
+@agent.tool_plain(defer_loading=True)
+def lookup_internal_policy(policy_name: str) -> str:
+    return f'policy details for {policy_name}'
+```
+
+Good fit:
+
+- large MCP servers
+- big tool catalogs
+- situations where loading all tool schemas would bloat context
+
+For bundle-level progressive disclosure of instructions plus tools, read [Capabilities on Demand](./ON-DEMAND-CAPABILITIES.md) instead.

--- a/plugins/pydantic-ai/skills/building-pydantic-ai-agents/references/TOOLS-CORE.md
+++ b/plugins/pydantic-ai/skills/building-pydantic-ai-agents/references/TOOLS-CORE.md
@@ -1,0 +1,102 @@
+# Tools Core
+
+Read this file when the user wants to add function tools, organize toolsets, connect MCP servers, or use explicit common search tools.
+
+## Add Tools to an Agent
+
+Use `@agent.tool_plain` for pure functions and `@agent.tool` for tools that need `RunContext`.
+
+```python
+import random
+
+from pydantic_ai import Agent, RunContext
+
+agent = Agent('google:gemini-3-flash-preview', deps_type=str)
+
+
+@agent.tool_plain
+def roll_dice() -> str:
+    return str(random.randint(1, 6))
+
+
+@agent.tool
+def get_player_name(ctx: RunContext[str]) -> str:
+    return ctx.deps
+```
+
+Use `Tool(fn)` when tools are defined outside the agent file or shared between agents.
+
+## Choosing a Tool Registration Method
+
+Default choices:
+
+- `@agent.tool` when the tool needs deps, usage, retry count, or message history
+- `@agent.tool_plain` when the tool is a plain function
+- `Tool(...)` in `tools=[...]` when the tool should be reusable across agents
+- `FunctionToolset` when multiple related tools should be managed as a group
+
+## Organize or Restrict Which Tools an Agent Can Use
+
+Use toolsets when the user has multiple related tools or wants cross-cutting behavior applied to a group.
+
+Examples:
+
+- `FunctionToolset` for a bundle of Python tools
+- MCP servers, which are themselves toolsets
+- wrapper toolsets for approval, deferred loading, or other cross-cutting behavior
+
+## Access Usage Stats, Message History, or Retry Count in Tools
+
+Route this to `@agent.tool` with `RunContext`.
+
+Useful `RunContext` fields include:
+
+- `ctx.deps`
+- `ctx.usage`
+- `ctx.messages`
+- `ctx.retry`
+
+## Use MCP Servers
+
+Attach an MCP server as a toolset on the agent.
+
+```python
+from pydantic_ai import Agent
+from pydantic_ai.mcp import MCPServerStdio
+
+server = MCPServerStdio('python', args=['mcp_server.py'], timeout=10)
+agent = Agent('openai:gpt-5.2', toolsets=[server])
+
+
+async def main():
+    async with agent:
+        result = await agent.run('What is the weather in Paris?')
+        print(result.output)
+```
+
+Default transport choices:
+
+- `MCPServerStdio` for local subprocess servers
+- `MCPServerStreamableHTTP` for HTTP servers
+
+`MCPServerSSE` still exists, but Streamable HTTP is the better default.
+
+## Search with DuckDuckGo, Tavily, or Exa
+
+Use common tools when the user wants explicit search tools rather than provider-adaptive capabilities.
+
+```python
+from pydantic_ai import Agent
+from pydantic_ai.common_tools.duckduckgo import duckduckgo_search_tool
+
+agent = Agent(
+    'openai:gpt-5.2',
+    tools=[duckduckgo_search_tool()],
+    instructions='Search DuckDuckGo for the given query and return the results.',
+)
+```
+
+Good default split:
+
+- use `WebSearch()` capability when the user wants model-agnostic search with native fallback
+- use `duckduckgo_search_tool()` / Tavily / Exa when the user explicitly wants those engines as tools


### PR DESCRIPTION
# Pydantic AI

Adds a Cline plugin for building Python agents with Pydantic AI. The plugin bundles the `building-pydantic-ai-agents` skill plus focused reference docs for common Pydantic AI workflows: agent construction, tools, structured output, capabilities, lifecycle hooks, streaming, testing, debugging, and multi-agent patterns.

The useful shape here is intentionally documentation-first. Users get Pydantic AI guidance inside Cline without the plugin installing Python packages, registering MCP servers, or starting any runtime services.

# Cline Primitives

- Skill: `building-pydantic-ai-agents` helps Cline recognize Pydantic AI work and route to the right reference material for the task.
- References: bundled docs cover core agents, capabilities and hooks, tools, provider-native features, input/history, testing, orchestration, and architecture decisions.

# Requirements

- Python 3.10 or newer for projects that run Pydantic AI code.
- The user's project chooses and installs its own `pydantic-ai` dependency.
- Model provider credentials are only needed if the user asks Cline to run or test live model calls.

# Trust Boundaries

This plugin has no MCP servers, hooks, commands, tools, background processes, install-time package installs, credential handling, or model-provider calls. Some bundled references explain optional Pydantic AI MCP, provider-native web, code execution, and A2A patterns; those are guidance for user-requested implementation work, not plugin behavior.

The bundled Pydantic AI skill material carries its MIT license notice in `LICENSE.pydantic-ai`.
