### PR TITLE
feat: add rootly plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Each plugin lives in `plugins/<slug>`. The directory name is the install keyword
 | `linear` | Linear SDK scripting skill for issue, project, team, cycle, and comment workflows. |
 | `mac-notify` | macOS notifications when a Cline run completes. |
 | `nanobanana` | Image generation through OpenRouter and Gemini image models. |
+| `rootly` | Rootly MCP plus incident response, on-call, deploy-risk, retrospective, and reliability workflow skills. |
 | `speak` | Speaks completed Cline replies with ElevenLabs text to speech. |
 | `typescript-lsp` | TypeScript language service `goto_definition` support. |
 | `weather-metrics` | Demo weather tool plus runtime metrics hooks. |

--- a/plugins/rootly/NOTICE.rootly-skills
+++ b/plugins/rootly/NOTICE.rootly-skills
@@ -1,0 +1,5 @@
+The bundled Rootly workflow skills were adapted from Rootly AI Labs'
+Apache-2.0 licensed Rootly plugin materials.
+
+Original copyright: Copyright 2024 Rootly AI Labs.
+Original project: https://github.com/Rootly-AI-Labs/rootly-claude-plugin

--- a/plugins/rootly/README.md
+++ b/plugins/rootly/README.md
@@ -1,0 +1,42 @@
+# rootly
+
+Rootly incident-management workflows for Cline.
+
+## What It Adds
+
+This plugin registers the Rootly remote MCP server and bundles Rootly-focused skills for incident response, on-call handoffs, deployment risk checks, retrospectives, reliability trends, alerts, action items, and stakeholder updates.
+
+The MCP server exposes Rootly incident, alert, service, team, on-call, action-item, status-page, and retrospective operations through Cline's MCP integration. The bundled skills give Cline safer workflows around those tools, including bounded incident lookup, explicit confirmation before writes, and stakeholder-ready summaries.
+
+## Install
+
+```bash
+cline plugin install rootly
+```
+
+For local development from this repository:
+
+```bash
+cline plugin install ./plugins/rootly --cwd .
+```
+
+## Requirements
+
+- A Rootly account with access to the data you want Cline to inspect or update.
+- Network access to `https://mcp.rootly.com/mcp`.
+- MCP OAuth support in the Cline host. Connect the Rootly MCP server when Cline prompts for authorization.
+
+## Included Skills
+
+- `rootly-status` for active incident and service-health summaries.
+- `rootly-alert` for read-only alert triage.
+- `rootly-brief`, `rootly-announce`, and `rootly-handoff` for stakeholder communication and response handoffs.
+- `rootly-respond`, `rootly-deploy-check`, `rootly-retro`, and `rootly-trend` for deeper incident, deploy-risk, retrospective, and reliability analysis.
+- `rootly-oncall`, `rootly-my`, `rootly-cover`, and `rootly-swap` for on-call dashboards and shift coverage workflows.
+- `rootly-action`, `rootly-lookup`, `rootly-ask`, and `rootly-setup` for action items, discovery, natural-language questions, and first-run verification.
+
+## Safety Notes
+
+The plugin does not run shell hooks, validate API tokens, call Rootly REST APIs directly, or register deployments automatically. Rootly access goes through the MCP server so Cline can use its normal MCP OAuth flow.
+
+The safety rule asks for explicit confirmation before Rootly writes, public or internal status updates, shift overrides, deployment records, and stakeholder-facing communication. It also treats incident data, alerts, schedules, retrospectives, and customer-impact details as sensitive operational data.

--- a/plugins/rootly/index.ts
+++ b/plugins/rootly/index.ts
@@ -1,0 +1,35 @@
+import type { AgentPlugin } from "@cline/core"
+
+const rootlySafetyRule = `Rootly workflow safety:
+- Use Rootly MCP tools for Rootly data. Do not call Rootly APIs with curl, wget, raw HTTP, or shell commands as a fallback.
+- Treat incident records, alerts, timelines, private status updates, responder names, schedules, postmortems, and customer-impact details as sensitive operational data.
+- Do not write Rootly API tokens, OAuth tokens, incident exports, alert payloads, private timelines, customer details, or responder schedules into source-controlled files.
+- Ask for explicit confirmation before creating or updating incidents, incident events, action items, status-page updates, overrides, shift swaps, deployments, retrospectives, or any other write in Rootly.
+- Ask before sending stakeholder-facing content, posting public updates, notifying responders, changing schedules, escalating incidents, or taking other responder-impacting actions.
+- Keep Rootly lookups bounded. Avoid walking unbounded pagination, and stop to ask for a narrower incident, service, team, or time window when the result set is broad.
+- If Rootly MCP tools are unavailable or unauthenticated, stop and explain that the user needs to connect the Rootly MCP server rather than attempting credential-based fallbacks.`
+
+const plugin: AgentPlugin = {
+	name: "rootly",
+	manifest: {
+		capabilities: ["mcp", "rules", "skills"],
+	},
+
+	setup(api) {
+		api.registerMcpServer({
+			name: "rootly",
+			transport: {
+				type: "streamableHttp",
+				url: "https://mcp.rootly.com/mcp",
+			},
+		})
+
+		api.registerRule({
+			id: "rootly-safety",
+			source: "plugin",
+			content: rootlySafetyRule,
+		})
+	},
+}
+
+export default plugin

--- a/plugins/rootly/package.json
+++ b/plugins/rootly/package.json
@@ -1,0 +1,32 @@
+{
+	"name": "rootly",
+	"version": "0.0.0",
+	"private": true,
+	"type": "module",
+	"description": "Rootly incident-management MCP and workflow skills for Cline.",
+	"exports": {
+		".": "./index.ts"
+	},
+	"cline": {
+		"plugins": [
+			{
+				"paths": [
+					"./index.ts"
+				],
+				"capabilities": [
+					"mcp",
+					"rules",
+					"skills"
+				]
+			}
+		]
+	},
+	"peerDependencies": {
+		"@cline/core": "*"
+	},
+	"peerDependenciesMeta": {
+		"@cline/core": {
+			"optional": true
+		}
+	}
+}

--- a/plugins/rootly/skills/rootly-action/SKILL.md
+++ b/plugins/rootly/skills/rootly-action/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: rootly-action
+description: Manage incident action items from the terminal. Subcommands - list (default - your open action items) or add <incident> "<summary>" (create one on an incident). Use to capture follow-ups during or after an incident without opening the Rootly UI.
+---
+
+
+# Action Items
+
+You are helping the user view or update incident action items in Rootly.
+
+## Subcommand routing
+
+Parse `$ARGUMENTS`:
+
+- Empty or starts with `list` -> List mode (default).
+- Starts with `add <incident-ref> ` -> Add mode. The remainder is the description.
+- Anything else -> show `rootly-action list` and `rootly-action add <incident> "<summary>"` usage and stop.
+
+---
+
+## List mode
+
+Goal: show the user their open action items, sorted by incident severity then age.
+
+1. Call `mcp__rootly__getCurrentUser` to get the user's UUID.
+2. Call `mcp__rootly__listAllIncidentActionItems` and filter results client-side by `assigned_to_user_id` matching the current user, plus status not in `done`/`closed`/`cancelled`.
+3. For each item, the response usually includes an `incident_id` or `incident` reference. Cluster results by incident.
+4. Render:
+
+```
+## Your Open Action Items ([N] total across [M] incidents)
+
+### [INC-XXXX] [Incident title] ([severity])
+- [ ] [Action item description] - due [date or "no due date"], priority [priority]
+- [ ] [Action item description] - due [date], priority [priority]
+
+### [INC-YYYY] [Incident title] ([severity])
+- [ ] [Action item description] - due [date], priority [priority]
+```
+
+If there are zero open items, say so plainly: "No open action items assigned to you."
+
+---
+
+## Add mode
+
+Goal: create a new action item on an incident. Write action: requires explicit confirmation.
+
+1. Parse the incident reference from `$ARGUMENTS` (UUID, `INC-XXXX`, or bare number).
+2. Resolve the incident by calling `mcp__rootly__getIncident` with the reference exactly as the user provided it. The MCP server now accepts UUIDs plus sequential forms like `4460`, `#4460`, and `INC-4460`.
+3. Parse the action item summary: everything after the incident reference, stripped of surrounding quotes.
+4. Show a preview to the user:
+
+```
+About to create action item:
+- Incident: [INC-XXXX] [title]
+- Summary: [summary]
+- Assigned to: [you / unassigned per default]
+- Priority: medium (default - adjust in Rootly UI if needed)
+
+Confirm to create? (yes / no)
+```
+
+5. Wait for the user's reply. Do not call `mcp__rootly__createIncidentActionItem` until they say yes.
+6. On confirmation, call `mcp__rootly__createIncidentActionItem` with:
+
+```json
+{
+  "incident_id": "[resolved incident UUID]",
+  "data": {
+    "type": "incident_action_items",
+    "attributes": {
+      "summary": "[summary]",
+      "priority": "medium",
+      "status": "open"
+    }
+  }
+}
+```
+
+Echo the resulting action item ID and any URL.
+7. On rejection, acknowledge and stop without making the call.
+
+---
+
+## Guidelines
+
+- Never mutate Rootly state without explicit confirmation. The "yes" must come from the user, not be assumed.
+- Show what will change before the call, not after.
+- If a write fails mid-flight, surface the exact error so the user can decide whether to retry.
+- If `mcp__rootly__listAllIncidentActionItems` is rate-limited or paginates, take just the first page (50 items). The user can re-run if they need more.
+- Do not imply that action items can be marked done through this skill until the MCP exposes an update action item tool.

--- a/plugins/rootly/skills/rootly-alert/SKILL.md
+++ b/plugins/rootly/skills/rootly-alert/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: rootly-alert
+description: Triage a Rootly alert by short ID. Pulls the alert record, its event timeline, related alerts in the same group, and any incident the alert is attached to. Use when a page comes in and you want context before opening Rootly.
+---
+
+
+# Alert Triage
+
+You are helping the user triage a Rootly alert. Alerts are the upstream signal that may or may not become incidents. The goal is to give the user enough context in one place that they can decide: ignore, acknowledge, escalate, or open an incident.
+
+## Workflow
+
+### 1. Resolve the alert
+
+`$ARGUMENTS` should contain a short alert ID (e.g. `A-1234` or `1234`).
+
+- If `$ARGUMENTS` is empty: report "No alert ID provided. Pass a short ID like `A-1234` or `1234`." and stop.
+- Otherwise call `mcp__rootly__get_alert_by_short_id` with the value as given.
+- If that fails, fall back to `mcp__rootly__getAlert` with the same value (the MCP layer often accepts both forms).
+- If both fail, surface the error and stop.
+
+### 2. Gather context
+
+Once you have the alert UUID:
+
+1. Call `mcp__rootly__listAlertEvents` (or filter by alert) to get the event timeline.
+2. If the alert response includes an `alert_group_id` or `group` reference, call `mcp__rootly__getAlertGroup` for sibling alerts.
+3. If the alert is attached to an incident, the response usually carries an `incident_id`. Call `mcp__rootly__getIncident` for incident context.
+4. Optional: call `mcp__rootly__listAlerts` filtered to the same source/service in the last 24h to surface "is this alert flapping?"
+
+Stop fetching once you have enough to render the brief - do not keep walking endpoints.
+
+### 3. Present the alert brief
+
+```
+## Alert Brief: [alert title]
+
+Short ID: [short-id] | Source: [source] | Urgency: [urgency]
+Started: [time] ([duration] ago) | State: [state]
+Service: [service or "unmapped"]
+
+### Summary
+[Alert summary or first event message]
+
+### Event Timeline
+- [time] [event-type]: [message]
+- [time] [event-type]: [message]
+[at most 8 events, oldest first]
+
+### Group Context
+[If part of a group:]
+This alert is one of [N] in group [group-name]. Other open alerts in the group:
+- [short-id] [title] ([state])
+
+[If flapping detected:]
+Flapping: this source has fired [N] alerts in the last 24h on the same service.
+
+### Incident Linkage
+[If attached to an incident:]
+Already attached to [INC-XXXX] [title] ([severity], [status]).
+
+[If not attached:]
+Not attached to an incident.
+
+### Suggested Next Step
+[Pick one based on the data:]
+- "Acknowledge - looks like a known transient pattern"
+- "Open an incident - first occurrence, customer-facing surface"
+- "Escalate - already linked to a critical incident with no responder yet"
+- "Ignore - historical noise from this source on this service"
+```
+
+### 4. Read-only
+
+This skill never mutates Rootly state. If the user wants to acknowledge, escalate, or convert the alert into an incident, point them to the Rootly UI or to the `rootly-respond` skill for the linked incident.
+
+### 5. Error handling
+
+- Alert not found: report the short ID and suggest checking the format (e.g. `A-1234`).
+- MCP tool errors: report the specific error and continue with whatever data you have.
+- No event timeline available: note it and skip that section rather than failing entirely.

--- a/plugins/rootly/skills/rootly-announce/SKILL.md
+++ b/plugins/rootly/skills/rootly-announce/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: rootly-announce
+description: Draft a stakeholder-facing status update for an active incident, then post it after explicit confirmation. Useful for incident commanders pushing public-status-page or internal updates without opening the Rootly UI. Write action: never posts without confirming.
+---
+
+
+# Incident Announcement
+
+You are helping the user (often the incident commander) post a stakeholder-facing update on an incident. Write action: explicit confirmation required.
+
+## Workflow
+
+### 1. Resolve the incident
+
+`$ARGUMENTS` should contain an incident reference (UUID, `INC-XXXX`, or sequential number).
+
+- If empty: call `mcp__rootly__listIncidents` with `filter_status="started"`, `page_size=10`, and `sort="-started_at"` and ask the user which incident to announce.
+- Otherwise call `mcp__rootly__getIncident` with the incident reference exactly as provided. The MCP server accepts UUIDs plus sequential forms like `4460`, `#4460`, and `INC-4460`.
+
+Once resolved, use the returned incident record for the full context.
+
+### 2. Identify the publication target
+
+Inspect the incident record for:
+- An attached status page (often `status_page_id` or similar field)
+- Public-facing flag (`is_public` / `private`)
+
+If the incident has a status page attached:
+- Call `mcp__rootly__getStatusPage` for the page details (name, URL).
+- Call `mcp__rootly__listStatusPageTemplates` to surface preset update templates.
+
+If no status page is attached, fall back to posting an incident event that surfaces in Rootly's internal stream - call `mcp__rootly__createIncidentEvent` instead. Make the distinction clear to the user.
+
+### 3. Draft the update
+
+Compose a 2--4 sentence update with this structure:
+
+```
+[Status verb: "Investigating" / "Identified" / "Monitoring" / "Resolved"] - [one-sentence summary of customer impact].
+[Optional: what we know about the cause, briefly.]
+[Optional: what we're doing about it.]
+[Next update: in [duration] / when status changes.]
+```
+
+Keep it stakeholder-grade: no Rootly internal IDs, no engineer names, no jargon.
+
+### 4. Show the draft
+
+```
+Incident: [INC-XXXX] [title] - [severity], [status]
+Posting to: [Status page name + URL] | [Internal incident stream if no status page]
+Visibility: [Public / Internal]
+
+Draft update:
+
+> [the drafted message]
+
+Confirm to post this update? (yes / edit / no)
+```
+
+### 5. Handle the user's reply
+
+- `yes` -> call the appropriate tool:
+  - Status page update path: use the status-page-specific MCP tool only if one is exposed. If no such tool is available, stop and explain that you cannot confirm a public status-page post from Cline.
+  - Internal-only path: if the user confirms an internal incident-stream update, call `mcp__rootly__createIncidentEvent` with this shape:
+
+```json
+{
+  "incident_id": "[resolved incident UUID]",
+  "data": {
+    "type": "incident_events",
+    "attributes": {
+      "event": "[drafted message]",
+      "visibility": "internal"
+    }
+  }
+}
+```
+- `edit` -> ask the user for revisions. Re-show the draft. Re-confirm.
+- `no` or anything else -> acknowledge, do not post.
+
+### 6. After posting
+
+```
+ Update posted.
+- [Status page URL if applicable]
+- [Event ID]
+
+Reminder: this skill posts a single update. For ongoing communication, post follow-ups every [interval based on severity] or when status changes.
+```
+
+### 7. Guidelines
+
+- Never post without explicit `yes`. Stakeholder updates are visible and hard to retract.
+- Severity-aware tone:
+  - SEV0/SEV1 -> calm, factual, frequent updates expected.
+  - SEV2 -> succinct, focused on impact.
+  - SEV3+ -> minimal, often only at status changes.
+- Resolved updates: if the incident status is `resolved` or `closed`, default the verb to "Resolved" and include a one-line root-cause summary if available.
+- Edit loops: don't infinitely revise. After two edit rounds, ask the user to type the exact text they want.
+- If the user has no permission to post on the status page (API returns 403), surface the error clearly. Don't try to escalate.

--- a/plugins/rootly/skills/rootly-ask/SKILL.md
+++ b/plugins/rootly/skills/rootly-ask/SKILL.md
@@ -1,0 +1,43 @@
+---
+name: rootly-ask
+description: Ask natural language questions about incidents, on-call, services, and reliability data. Translates your question into Rootly API calls and returns structured answers.
+---
+
+
+# Natural Language Query
+
+You are answering a natural language question about the user's incident, on-call, or reliability data using Rootly's MCP tools.
+
+## Workflow
+
+### 1. Understand the Question
+
+Parse the user's question from `$ARGUMENTS`. Identify what data they need.
+
+### 2. Discover Available Tools
+
+Call `mcp__rootly__list_endpoints` to see the full list of available Rootly MCP tools and their capabilities. This helps you select the right tools for the query.
+
+### 3. Execute Queries
+
+Select the most appropriate tools for the question. You may need multiple calls to fully answer the question. Common patterns:
+
+- "How many incidents last week?" -> `mcp__rootly__search_incidents` with date filters
+- "Who's on call?" -> `mcp__rootly__get_oncall_handoff_summary`
+- "What happened with [service]?" -> `mcp__rootly__search_incidents` filtered by service
+- "Show me critical incidents" -> `mcp__rootly__search_incidents` filtered by severity
+- "Any patterns in auth service failures?" -> `mcp__rootly__search_incidents` + `mcp__rootly__find_related_incidents`
+
+### 4. Present Answer
+
+Provide a clear, structured answer with supporting data. Include:
+- Direct answer to the question
+- Supporting data in tables or lists where helpful
+- Source attribution (which tools/queries produced the data)
+
+### 5. Limitations
+
+Be explicit about what you can't answer. If the question requires data that isn't available through the Rootly MCP tools, say so clearly rather than guessing or hallucinating. For example:
+
+- "I can't answer questions about infrastructure metrics - Rootly tracks incidents, not system metrics."
+- "This question requires data from [other system]. I can only query Rootly incident and on-call data."

--- a/plugins/rootly/skills/rootly-brief/SKILL.md
+++ b/plugins/rootly/skills/rootly-brief/SKILL.md
@@ -1,0 +1,62 @@
+---
+name: rootly-brief
+description: Generate a concise stakeholder brief for an incident. Creates executive summary with key details, impact, timeline, and current status.
+---
+
+
+# Incident Stakeholder Brief
+
+You are creating a concise stakeholder brief for an incident. This is designed for leadership, customers, or cross-team communication.
+
+## Workflow
+
+### 1. Get Incident Details
+
+If `$ARGUMENTS` contains an incident ID:
+- Call `mcp__rootly__getIncident` with the provided ID
+- Call `mcp__rootly__listIncidentAlerts` to get associated alerts
+
+If no incident ID provided, prompt the user to specify one.
+
+### 2. Generate Brief
+
+Create a structured brief with these sections:
+
+```markdown
+# Incident Brief: [incident-title]
+
+Incident ID: [short-id]  
+Severity: [severity]  
+Status: [status]  
+Started: [started-at]  
+Duration: [calculated duration]
+
+## Impact Summary
+[Brief description of customer/business impact]
+
+## Current Status
+[What's happening now - investigation, mitigation, resolution]
+
+## Services Affected
+- [list of affected services]
+
+## Timeline (Key Events)
+- [time]: [event description]
+- [time]: [event description]
+
+## Next Steps
+[What's being done to resolve or prevent recurrence]
+
+---
+*Brief generated at [current-time] | Status may have changed since generation*
+```
+
+### 3. Formatting Guidelines
+
+- Keep the brief under 200 words total
+- Use clear, non-technical language suitable for stakeholders
+- Focus on business impact rather than technical details
+- Include estimated resolution time if available
+- If incident is resolved, include resolution summary
+
+If the incident is not found or there's an error, provide a helpful message about checking the incident ID.

--- a/plugins/rootly/skills/rootly-cover/SKILL.md
+++ b/plugins/rootly/skills/rootly-cover/SKILL.md
@@ -1,0 +1,90 @@
+---
+name: rootly-cover
+description: Offer to cover someone else's on-call shift. Lists upcoming shifts on a team or schedule and creates an override placing you on the chosen one after explicit confirmation. Write action: never executes without confirming.
+---
+
+
+# Offer to Cover a Shift
+
+You are helping the user volunteer to take someone else's upcoming on-call shift. This is the inverse of the `rootly-swap` skill. Write action: explicit confirmation required.
+
+## Workflow
+
+### 1. Identify the user
+
+Call `mcp__rootly__getCurrentUser` to capture the current user's `user_id` and team membership.
+
+### 2. Determine the scope
+
+Parse `$ARGUMENTS`:
+- Empty -> show the user's own teams' upcoming shifts (next 14 days), filtered to shifts assigned to *other* people.
+- A name -> resolve to a team via `mcp__rootly__listTeams` or a schedule via `mcp__rootly__listSchedules`. If multiple matches, list them and ask.
+
+### 3. Pull candidate shifts
+
+Call `mcp__rootly__list_shifts` for the chosen schedule(s) over the next 14 days.
+
+Filter:
+- Exclude shifts already assigned to the current user.
+- Exclude shifts that have already started or are in the past.
+
+### 4. Present the list
+
+```
+## Upcoming shifts you could cover
+
+| # | Schedule | When | Currently | Length |
+|---|---|---|---|---|
+| 1 | [name] | [start] -> [end] | [user name] | [duration] |
+| 2 | [name] | [start] -> [end] | [user name] | [duration] |
+[max 10]
+
+Reply with the shift number you'd like to cover, or `none` to cancel.
+```
+
+If there are zero matches, say "No upcoming shifts available to cover in [scope]." and stop.
+
+### 5. On user selection
+
+When the user picks a number:
+
+1. Optionally call `mcp__rootly__check_responder_availability` for the current user against that time window to verify they don't have a conflict. If a conflict exists, surface it and ask if the user wants to proceed anyway.
+2. Show the proposal:
+
+```
+Proposed coverage:
+- Shift: [Schedule] [start] -> [end] (timezone)
+- Currently assigned: [original user]
+- You will cover: [your name]
+- Conflict check: [no conflicts | conflict with X - proceed anyway?]
+
+Confirm to create the override? (yes / no)
+```
+
+3. Wait for explicit `yes`. Anything else -> cancel.
+
+### 6. On confirmation
+
+Call `mcp__rootly__createOverrideShift` with:
+- `schedule_id` of the target shift's schedule
+- `data.type = "shifts"`
+- `data.attributes.starts_at` and `data.attributes.ends_at` matching the shift window
+- `data.attributes.user_id` = current user's integer Rootly user ID
+
+Echo the result:
+
+```
+ Override created. You're now on call for [Schedule] [start] -> [end].
+- Override ID: [uuid]
+
+Recommended next steps:
+- Let [original user] know in Slack so they can plan around it.
+- Verify in the `rootly-my` skill that the shift now appears under your upcoming on-call.
+```
+
+### 7. Guidelines
+
+- Never mutate without confirmation. Same rule as the `rootly-swap` skill.
+- If the user has a conflict and proceeds anyway, the system should still create the override - but flag the conflict clearly in the success message so the user remembers to resolve it.
+- Show timezones explicitly. Always.
+- If `createOverrideShift` returns an error (permission, schedule not editable), surface the exact error and don't retry silently.

--- a/plugins/rootly/skills/rootly-deploy-check/SKILL.md
+++ b/plugins/rootly/skills/rootly-deploy-check/SKILL.md
@@ -1,0 +1,91 @@
+---
+name: rootly-deploy-check
+description: Evaluate deployment risk by analyzing code changes against incident history, active incidents, and on-call readiness.
+---
+
+
+# Pre-Deploy Safety Check
+
+
+You are evaluating whether it is safe to deploy the current code changes. Follow this workflow carefully.
+
+## Current changes
+Inspect the current git diff summary (`git diff --stat HEAD`) when the user wants deploy risk analysis.
+
+## Current branch
+Inspect the current branch (`git branch --show-current`) when relevant.
+
+## Recent commits
+Inspect recent commits (`git log --oneline -5`) when relevant.
+
+## Workflow
+
+### 1. Assess Changes
+
+Review the git diff output above. If the diff is empty (no changes), report "No changes to evaluate - working tree is clean" and stop.
+
+Identify which files and components are affected by the changes.
+
+### 2. Resolve Affected Services
+
+Determine which Rootly service(s) these changes map to, using this resolution chain (in priority order):
+
+1. Check `.cline/rootly-config.json` in the project root - if it exists, use the `services` field
+2. Match repo name: Use the git repo name (from `basename $(git rev-parse --show-toplevel)`) to search for matching Rootly services via `mcp__rootly__search_incidents`
+3. Ask the user: If neither method works, ask which service(s) this repo maps to
+
+### 3. Search Incident History
+
+Call `mcp__rootly__search_incidents` for the identified services, looking at the last 90 days. Note any patterns in frequency, severity, or root causes.
+
+### 4. Find Related Incidents
+
+Call `mcp__rootly__find_related_incidents` with a summary of the current changes (based on the diff). This uses TF-IDF similarity matching to find historically similar incidents.
+
+If results have confidence scores below 0.3, flag them as low confidence and note that manual review may be needed.
+
+### 5. Check Active Incidents
+
+Call `mcp__rootly__search_incidents` filtered to active (`started`) status for the affected services. Pay special attention to P1/P2 (critical/high severity) incidents.
+
+### 6. Check On-Call Readiness
+
+Call `mcp__rootly__get_oncall_handoff_summary` to verify:
+- Who is currently on-call
+- When the next handoff is
+- Whether there are any on-call gaps
+
+### 7. Synthesize Deployment Brief
+
+Present a structured deployment brief:
+
+```
+## Deployment Safety Brief
+
+Risk Level: [LOW / MEDIUM / HIGH / CRITICAL]
+Branch: [branch name]
+Changed files: [count]
+
+### Active Incidents
+[List any active incidents on affected services, or "None"]
+
+### On-Call Status
+- Current: [name] (since [time])
+- Next handoff: [time]
+- Status: [Available / Gap detected / High fatigue]
+
+### Similar Past Incidents
+[Top 3 similar incidents with what happened and how they were resolved]
+
+### Risk Factors
+[Bullet list of specific risks identified]
+
+### Recommendation
+[GO / CAUTION / NO-GO]: [1-2 sentence reasoning]
+```
+
+Risk level criteria:
+- LOW: No active incidents, no similar past incidents, on-call is healthy
+- MEDIUM: Minor past incidents found, or on-call handoff is imminent
+- HIGH: Active incidents on related services, or recurring pattern of similar incidents
+- CRITICAL: Active P1/P2 incident on the affected service, or significant on-call gaps

--- a/plugins/rootly/skills/rootly-handoff/SKILL.md
+++ b/plugins/rootly/skills/rootly-handoff/SKILL.md
@@ -1,0 +1,103 @@
+---
+name: rootly-handoff
+description: Prepare an incident or on-call handoff document. Creates structured summary for shift changes or incident commander transitions.
+---
+
+
+# Incident & On-Call Handoff
+
+You are preparing a handoff document for either incident response or on-call shift transitions.
+
+## Workflow
+
+### 1. Determine Handoff Type
+
+If `$ARGUMENTS` contains an incident ID:
+- Incident Handoff: Create handoff for specific incident
+- Call `mcp__rootly__getIncident` with the provided ID
+- Call `mcp__rootly__listIncidentAlerts` for associated alerts
+
+If no incident ID provided:
+- On-Call Handoff: Create general shift handoff
+- Call `mcp__rootly__get_oncall_handoff_summary` or relevant on-call endpoints
+- Call `mcp__rootly__search_incidents` filtered to recent active incidents
+
+### 2. Generate Incident Handoff
+
+For incident-specific handoffs:
+
+```markdown
+# Incident Handoff: [incident-title]
+
+Handoff Time: [current-time]  
+Incident ID: [short-id]  
+Severity: [severity]  
+Current Status: [status]  
+Started: [started-at] ([duration] ago)
+
+## Current Situation
+[Brief summary of what's happening now]
+
+## What's Been Done
+- [action 1]
+- [action 2]
+- [action 3]
+
+## Immediate Next Steps
+1. [priority action]
+2. [next action]
+3. [monitoring action]
+
+## Key Contacts
+- Incident Commander: [if assigned]
+- On-Call: [current on-call person]
+- Escalation Path: [relevant escalation details]
+
+## Important Notes
+[Any critical context, gotchas, or special considerations]
+
+## Monitoring
+- [key dashboards/alerts to watch]
+- [specific metrics to monitor]
+```
+
+### 3. Generate On-Call Handoff
+
+For general on-call handoffs:
+
+```markdown
+# On-Call Handoff
+
+Handoff Time: [current-time]  
+Previous On-Call: [if determinable]  
+Incoming On-Call: [current/next on-call]
+
+## Active Incidents
+[List current active incidents with brief status]
+
+## Recent Activity (Last 24h)
+- [incident summaries]
+- [any resolved issues]
+
+## Ongoing Concerns
+- [items requiring monitoring]
+- [scheduled maintenance]
+- [known issues]
+
+## Escalation Paths
+[Current escalation contacts and procedures]
+
+## Key Dashboards
+[Important monitoring dashboards to check]
+
+## Upcoming Events
+[Deployments, maintenance, or other scheduled activities]
+```
+
+### 4. Formatting Notes
+
+- Keep handoffs concise but comprehensive
+- Include actionable next steps
+- Highlight any time-sensitive items
+- Provide context for complex situations
+- Include relevant links/IDs for quick access

--- a/plugins/rootly/skills/rootly-lookup/SKILL.md
+++ b/plugins/rootly/skills/rootly-lookup/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: rootly-lookup
+description: Look up a service, team, or catalog entity in Rootly. Returns owner, on-call, recent reliability, dependencies, and any active incidents. Use when something breaks and the first question is who owns this.
+---
+
+
+# Service / Team Lookup
+
+You are answering "what is this thing and who owns it?" for a service, team, or catalog entity. The user may pass a partial or full name; do your best to resolve it.
+
+## Workflow
+
+### 1. Resolve the target
+
+`$ARGUMENTS` is the search term. It might be:
+- A service name (e.g. `payments-api`)
+- A team name (e.g. `Platform`)
+- A repository name
+- A catalog entity slug
+
+Strategy:
+1. Try `mcp__rootly__listServices` with the term as a filter where supported. If the MCP tool offers a name/query filter, use it; otherwise fetch the first 50 and match client-side (case-insensitive substring).
+2. If no service match, try `mcp__rootly__listTeams` similarly.
+3. If still no match, try `mcp__rootly__listCatalogEntities` (across all catalogs).
+
+Determine the kind of the resolved entity (`service`, `team`, or `catalog-entity`) - branch the rendering on that.
+
+If multiple matches, list the top 5 and ask the user to disambiguate. Do not guess.
+
+If no matches, say so and suggest the user check spelling or try a broader term.
+
+### 2. Gather details - service path
+
+If the resolved entity is a service:
+
+1. Call `mcp__rootly__getService` for the full record. Capture: name, description, owning team, environment, slug, URL.
+2. Call `mcp__rootly__getServiceUptimeChart` for the last 30 days (if the MCP supports a period parameter; otherwise default).
+3. Call `mcp__rootly__listIncidents` with `filter_service_ids=<id>` and `filter_status=started` to surface active incidents on this service.
+4. If the service references an owning team, call `mcp__rootly__getTeam` for the team's name and `mcp__rootly__get_oncall_schedule_summary` (or `mcp__rootly__get_oncall_handoff_summary`) for current on-call.
+5. Optional: `mcp__rootly__listIncidents` filter by service in the last 90 days, page 1 only, to spot frequency.
+
+### 3. Gather details - team path
+
+If the resolved entity is a team:
+
+1. Call `mcp__rootly__getTeam` for the record. Capture name, description, slug, members count if available.
+2. Call `mcp__rootly__listServices` filtered by team to enumerate owned services.
+3. Call `mcp__rootly__get_oncall_schedule_summary` for current on-call across the team.
+4. Call `mcp__rootly__listIncidents` filtered by team and `status=started` for active incidents.
+
+### 4. Gather details - catalog entity path
+
+If the resolved entity is a catalog entity:
+
+1. Call `mcp__rootly__getCatalogEntity` for the full record.
+2. Note the catalog it belongs to (`mcp__rootly__getCatalog` if you need the catalog's name).
+3. Surface any service/team references in the entity's properties.
+
+### 5. Render
+
+Service rendering:
+
+```
+## Service: [name]
+*[slug] - [environment]*
+
+### Ownership
+- Team: [team name]
+- On-call right now: [user name] (until [shift end])
+- Backup: [backup name if available]
+
+### Recent Reliability (30 days)
+- Uptime: [percentage]
+- Incidents: [count] ([critical: N, high: N, medium: N])
+- MTTR: [duration]
+
+### Active Incidents
+[If any:]
+-  [INC-XXXX] [title] - started [duration] ago
+[If none:]
+No active incidents.
+
+### Description
+[service description]
+```
+
+Team rendering:
+
+```
+## Team: [name]
+*[slug] - [N members]*
+
+### Owned Services ([N])
+- [service-name] ([environment])
+- [service-name] ([environment])
+[max 10, then "+N more"]
+
+### Currently On-Call
+- [Schedule]: [user name] (until [time])
+
+### Active Incidents ([N])
+-  [INC-XXXX] [title]
+[If none: "No active incidents."]
+```
+
+Catalog entity rendering:
+
+```
+## [Catalog] Entity: [name]
+*[slug]*
+
+### Properties
+- [key]: [value]
+- [key]: [value]
+
+### Linked References
+[Any service/team links found]
+```
+
+### 6. Read-only
+
+This skill never mutates Rootly state.
+
+### 7. Error handling
+
+- If a downstream call fails (e.g. uptime chart API errors), render the rest of the data and add a one-line note: "*[Section]: not available - [error]*".
+- Don't fail the whole response because one optional chart didn't load.
+- If `getCurrentUser` is needed for context (and most cases don't require it), skip it.

--- a/plugins/rootly/skills/rootly-my/SKILL.md
+++ b/plugins/rootly/skills/rootly-my/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: rootly-my
+description: Personal Rootly dashboard. Shows your open action items, your active incidents (where you're a responder), and your upcoming on-call shifts. Use to start the day or to context-switch back into incident work.
+---
+
+
+# Your Rootly Dashboard
+
+You are building a personal status board for the current Rootly user. Read-only, focused, and quick to scan.
+
+## Workflow
+
+### 1. Identify the user
+
+Call `mcp__rootly__getCurrentUser`. Capture:
+- `user_id` (UUID) - for filtering downstream calls
+- `name` and `email` - for the header
+- Team membership if present in the response
+
+If `getCurrentUser` fails, stop with a clear auth error message.
+
+### 2. Pull the three data slices in parallel
+
+You may issue these tool calls in parallel where the model supports it. Keep each call narrow - we want a fast dashboard, not a full audit.
+
+a. Open action items
+- Call `mcp__rootly__listAllIncidentActionItems` (first page, page_size = 50).
+- Filter to items where `assigned_to_user_id` (or equivalent field) matches the user, with status not in `done`/`closed`/`cancelled`.
+
+b. Active incidents you're on
+- Call `mcp__rootly__listIncidents` with `filter_status=started` and `filter_user_id=<user_id>` if supported, or with the user's team via `filter_team_ids` if individual filtering isn't available.
+- Page size 25 is plenty.
+
+c. Upcoming shifts
+- Call `mcp__rootly__list_shifts` for the current user, scoped to the next 7 days.
+- If individual user filtering isn't available, call the broader shift listing and filter client-side.
+
+### 3. Render the dashboard
+
+```
+## [User name]'s Rootly Dashboard
+*[email] - [primary team if known]*
+
+### Active Incidents ([N])
+[For each: severity badge, INC-XXXX, title, your role, started X ago]
+-  [INC-XXXX] [title] - your role: [responder/IC/observer], started [duration] ago
+-  [INC-YYYY] [title] - your role: [responder], started [duration] ago
+
+[If zero: "No active incidents you're responding to."]
+
+### Open Action Items ([N])
+[Cluster by incident, max 10 items]
+
+#### [INC-XXXX] [title]
+- [ ] [description] - due [date or "no due date"]
+- [ ] [description]
+
+[If zero: "No open action items assigned to you."]
+
+### Upcoming On-Call ([N] shifts in the next 7 days)
+- [Schedule name]: [start] -> [end] ([role/level if available])
+- [Schedule name]: [start] -> [end]
+
+[If currently on call:]
+Currently on call: [Schedule name] until [end time].
+
+[If zero: "No on-call shifts in the next 7 days."]
+
+---
+
+### Quick links
+- the `rootly-status` skill - service health overview
+- the `rootly-oncall` skill - full team on-call schedule
+- the `rootly-action` skill add <incident> "<desc>" - capture a follow-up
+- the `rootly-swap` skill - request a shift swap
+```
+
+### 4. Tone & formatting
+
+- Compact. This is meant to be glanceable, not a full report.
+- Use severity emoji or symbols if they render in the user's terminal:  (critical),  (high),  (medium),  (low). If unsure, use plain text labels.
+- Cap each section at the most-relevant 10 items. If there are more, append a single line: "(+N more - run the `rootly-status` skill or check Rootly UI)".
+
+### 5. Error handling
+
+- If any one slice fails (e.g. shifts API returns 500), render the other two and add a short note: "*Could not load on-call shifts: [error]*".
+- Never leave a section blank with no explanation.

--- a/plugins/rootly/skills/rootly-oncall/SKILL.md
+++ b/plugins/rootly/skills/rootly-oncall/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: rootly-oncall
+description: Show current on-call status, shift metrics, and health indicators for your team. Use to check who's on-call, handoff context, or on-call workload.
+---
+
+
+# On-Call Dashboard
+
+You are showing the user a compact on-call dashboard. Gather data and present it concisely.
+
+## Workflow
+
+### 1. Gather Data
+
+Make these calls (in parallel if possible):
+
+1. `mcp__rootly__get_oncall_handoff_summary` - Current and next on-call, shift context
+2. `mcp__rootly__get_oncall_shift_metrics` - Workload data (hours, incident count)
+3. `mcp__rootly__check_oncall_health_risk` - Fatigue and health risk indicators
+
+If `$ARGUMENTS` contains a team name, pass it to scope the queries.
+
+### 2. Present Dashboard
+
+```
+## On-Call Dashboard
+
+### Current On-Call
+- Who: [name]
+- Since: [start time] ([hours] hours into shift)
+- Incidents this shift: [count]
+
+### Next On-Call
+- Who: [name]
+- Handoff: [time] ([hours] from now)
+
+### Shift Health
+- Hours worked: [current hours] / [shift length]
+- Fatigue risk: [LOW / MEDIUM / HIGH]
+- Workload: [incidents handled] incidents, [pages received] pages
+
+### Recent Incidents This Shift
+[List of incidents handled during current shift, if any]
+| Severity | Title | Duration | Status |
+|----------|-------|----------|--------|
+| ... | ... | ... | ... |
+```
+
+Keep the output compact. If any data source returns an error or empty result, omit that section rather than showing empty tables.

--- a/plugins/rootly/skills/rootly-respond/SKILL.md
+++ b/plugins/rootly/skills/rootly-respond/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: rootly-respond
+description: Investigate and respond to a production incident. Pulls context, finds similar past incidents, suggests solutions, and enables coordination.
+---
+
+
+# Incident Response
+
+
+You are helping the user investigate and respond to a production incident.
+
+## Workflow
+
+### 1. Identify the Incident
+
+If `$ARGUMENTS` contains an incident reference:
+1. Call `mcp__rootly__getIncident` with the provided reference exactly as given. The Rootly MCP accepts UUIDs plus sequential forms like `4460`, `#4460`, and `INC-4460`.
+2. If direct resolution fails, ask the user for the incident UUID or a more precise incident reference. Do not walk paginated incident lists to guess.
+3. Use the resolved incident ID for all subsequent MCP calls.
+
+If no incident ID provided:
+1. Call `mcp__rootly__search_incidents` filtered to active status (`started`)
+2. If no active incidents, report "No active incidents found" and stop
+3. If multiple active incidents, list them sorted by severity (critical first, then high, then medium, then low) and ask the user to select one
+4. For long lists, show critical/high severity first with a note about additional lower-severity incidents
+
+### 2. Gather Full Context
+
+Once you have the incident ID:
+
+1. Call `mcp__rootly__getIncident` to get the full incident record
+2. Call `mcp__rootly__get_alert_by_short_id` or search alerts for associated alert details and timeline
+3. Call `mcp__rootly__find_related_incidents` to find historically similar incidents
+4. Call `mcp__rootly__suggest_solutions` to get resolution recommendations
+5. Call `mcp__rootly__get_oncall_handoff_summary` for current team status
+
+### 3. Present Response Brief
+
+```
+## Incident Response Brief
+
+### Summary
+[Incident title] (ID: [id])
+- Status: [status] | Severity: [severity]
+- Started: [time] ([duration] ago)
+- Affected services: [list]
+
+### Timeline
+[Key events from alert and incident data, chronological]
+
+### Related Historical Incidents
+[Top matches from find_related_incidents]
+- [Incident title] ([date]) - Confidence: [score] - Resolution: [what fixed it]
+[If all scores < 0.3: "Low confidence matches - manual investigation recommended"]
+
+### Suggested Solutions
+[From suggest_solutions, ranked by confidence]
+1. [Solution] (confidence: [score], source: [incident/runbook])
+
+### Current Responders & On-Call
+- Assigned: [responders]
+- On-call: [name] (since [time])
+- Next handoff: [time]
+
+### Available Actions
+The following actions require your explicit approval:
+- Update severity
+- Add responder
+- Post status update
+- Escalate to next on-call
+```
+
+### 4. Write Operations
+
+This skill is advisory. Do not execute write operations from this workflow.
+
+Write operations include:
+- `updateIncident` (changing severity, status, or any incident field)
+- Adding or removing responders
+- Posting status updates
+- Escalating incidents
+- Any other mutation of Rootly data
+
+When the user wants to act on a recommendation, route them to the dedicated workflow where possible:
+- Use `rootly-action` for follow-up action items.
+- Use `rootly-announce` for stakeholder or incident-stream updates.
+- Use `rootly-swap` or `rootly-cover` for on-call shift changes.
+- For severity changes, responder changes, or escalation, show the exact proposed change and ask the user to perform it in Rootly unless a dedicated skill is added later.
+
+### 5. Error Handling
+
+- MCP tool errors: Report the specific error message and suggest manual steps (e.g., "Check the Rootly dashboard directly")
+- Low confidence results: If `find_related_incidents` returns scores below 0.3, explicitly flag: "These matches are low confidence - consider manual investigation"
+- Missing data: If any tool call returns empty results, note it and continue with available data rather than failing entirely

--- a/plugins/rootly/skills/rootly-retro/SKILL.md
+++ b/plugins/rootly/skills/rootly-retro/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: rootly-retro
+description: Generate a structured post-incident retrospective from incident data.
+---
+
+
+# Retrospective Generator
+
+
+You are generating a structured post-incident retrospective. The output should be copy-pasteable markdown.
+
+## Workflow
+
+### 1. Get Incident Data
+
+The incident ID should be provided in `$ARGUMENTS`. If not provided, ask the user for it.
+
+1. Call `mcp__rootly__getIncident` for the full incident record
+2. Check the incident status:
+   - If status is `started` (still active), warn the user: "This incident is still active. Retrospectives are typically done after resolution. Continue anyway?" Wait for confirmation before proceeding.
+
+### 2. Gather Context
+
+1. Call `mcp__rootly__get_alert_by_short_id` or alert search tools for the alert timeline
+2. Call `mcp__rootly__find_related_incidents` to check for recurring patterns
+
+### 3. Generate Retrospective
+
+Output as clean, copy-pasteable markdown:
+
+```markdown
+# Retrospective: [Incident Title]
+
+Incident ID: [id]
+Date: [date]
+Duration: [start] to [end] ([total duration])
+Severity: [severity]
+
+## Summary
+[1-2 sentence summary of what happened]
+
+## Impact
+- Duration: [time from detection to resolution]
+- Affected services: [list]
+- Severity: [level]
+- User impact: [description if available]
+
+## Timeline
+| Time | Event |
+|------|-------|
+| [time] | [event] |
+| ... | ... |
+
+## Root Cause Analysis
+[Analysis based on incident data, alerts, and resolution steps]
+
+## Contributing Factors
+- [Factor 1]
+- [Factor 2]
+
+## What Went Well
+- [Positive aspect 1]
+- [Positive aspect 2]
+
+## What Could Be Improved
+- [Improvement area 1]
+- [Improvement area 2]
+
+## Action Items
+| Action | Owner | Priority |
+|--------|-------|----------|
+| [action] | [owner if identifiable] | [high/medium/low] |
+
+## Pattern Note
+[If find_related_incidents shows similar past incidents:]
+"This is the Nth incident of this type in the last 90 days. Consider systemic fixes."
+[If no similar incidents: omit this section]
+```
+
+Base the analysis on actual incident data. Do not fabricate details. If information is unavailable, note it as "Not available in incident data" rather than guessing.

--- a/plugins/rootly/skills/rootly-setup/SKILL.md
+++ b/plugins/rootly/skills/rootly-setup/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: rootly-setup
+description: Set up the Rootly plugin. Verifies the MCP server connection and guides through lightweight project service mapping.
+---
+
+
+# Rootly Plugin Setup
+
+You are running the first-time setup for the Rootly Cline plugin. Follow these steps in order:
+
+## Step 1: Verify MCP Connection
+
+First, test the MCP server connection by calling `mcp__rootly__get_server_version`.
+
+- Succeeds: The MCP server is reachable. Continue to Step 2.
+- Fails with 401 / OAuth prompt: Cline should automatically start the OAuth2 flow - a browser window will open for you to log in to Rootly and grant access. Once authorized, retry `mcp__rootly__get_server_version`.
+- Fails with other error: MCP server connection issue. Check network connectivity to `https://mcp.rootly.com`.
+
+## Step 2: Verify Authentication
+
+Call `mcp__rootly__getCurrentUser` to confirm your identity.
+
+- Succeeds: Authentication is working. Report the authenticated user and team, then continue to Step 3.
+- Fails: Authentication issue. Provide troubleshooting:
+
+> Authentication Troubleshooting
+>
+> This plugin uses OAuth2 by default - Cline handles the login flow automatically when it connects to the MCP server. No API token is needed for MCP commands.
+>
+> If OAuth2 is not working:
+> 1. Ensure your Rootly organization has OAuth2 enabled
+> 2. Try disconnecting and reconnecting the MCP server: the MCP settings view > find Rootly > disconnect > reconnect
+> 3. Check that your browser can reach `https://rootly.com/oauth/authorize`
+>
+> This Cline plugin does not use Rootly API tokens, shell hooks, or direct REST fallbacks. Fix the MCP connection before continuing.
+
+Then stop here - no further steps possible without working authentication.
+
+## Step 3: Service Mapping Configuration
+
+Check if `.cline/rootly-config.json` exists in the current project directory.
+
+If the file does NOT exist, offer to create it:
+
+1. Ask the user which Rootly service(s) correspond to this repository
+2. Ask which team owns this service (optional)
+3. Create `.cline/rootly-config.json` with the format:
+   ```json
+   {
+     "services": ["service-name-1", "service-name-2"],
+     "team": "team-name"
+   }
+   ```
+
+If the file exists, read and display its current configuration.
+
+## Step 4: Show Quick-Start Guide
+
+Once setup is complete, display:
+
+> Rootly plugin is ready!
+>
+> Authentication: OAuth2 (logged in as {user name})
+>
+> | Command | Description |
+> |---------|-------------|
+> | the `rootly-deploy-check` skill | Check deployment safety before pushing |
+> | the `rootly-respond` skill [incident-id] | Investigate and respond to an incident |
+> | the `rootly-oncall` skill | View on-call dashboard |
+> | the `rootly-retro` skill [incident-id] | Generate post-incident retrospective |
+> | the `rootly-status` skill | Service health overview |
+> | the `rootly-ask` skill [question] | Ask questions about your incident data |
+> | the `rootly-brief` skill [incident-id] | Generate stakeholder brief for executives |
+> | the `rootly-handoff` skill [incident-id] | Prepare incident or on-call handoff docs |
+>
+> Automation note: this Cline plugin does not install shell hooks or register deployment events automatically. Use the Rootly skills explicitly when you want incident, on-call, deployment-risk, or retrospective help.

--- a/plugins/rootly/skills/rootly-status/SKILL.md
+++ b/plugins/rootly/skills/rootly-status/SKILL.md
@@ -1,0 +1,42 @@
+---
+name: rootly-status
+description: Show a compact service health overview including active incidents by severity. Use for a quick health check of your services.
+---
+
+
+# Service Health Overview
+
+You are showing the user a compact view of current service health based on active incidents.
+
+## Workflow
+
+### 1. Fetch Active Incidents
+
+Call `mcp__rootly__search_incidents` filtered to active status (`started`).
+
+If `$ARGUMENTS` contains a service name, filter to that service.
+
+### 2. Present Health Dashboard
+
+Group incidents by service and severity. Present as a compact table:
+
+```
+## Service Health
+
+| Service | Critical | High | Medium | Low | Oldest Active |
+|---------|----------|------|--------|-----|---------------|
+| [name]  | [count]  | [count] | [count] | [count] | [duration] |
+| ...     | ...      | ...  | ...    | ... | ...           |
+
+Total active incidents: [count]
+```
+
+If no active incidents are found, report:
+
+```
+## Service Health
+
+All clear - no active incidents.
+```
+
+Keep the output concise. This is a quick health check, not a detailed report.

--- a/plugins/rootly/skills/rootly-swap/SKILL.md
+++ b/plugins/rootly/skills/rootly-swap/SKILL.md
@@ -1,0 +1,100 @@
+---
+name: rootly-swap
+description: Request someone to cover one of your upcoming on-call shifts. Lists your shifts, helps identify a candidate based on availability, and creates an override after explicit confirmation. Write action: never executes without confirming.
+---
+
+
+# Shift Swap Request
+
+You are helping the user offload one of their on-call shifts to someone else. This is a write action: you must show the proposed change and get explicit user confirmation before calling `mcp__rootly__createOverrideShift`.
+
+## Workflow
+
+### 1. Identify the user
+
+Call `mcp__rootly__getCurrentUser`. Capture `user_id`.
+
+### 2. List the user's shifts
+
+Call `mcp__rootly__list_shifts` scoped to:
+- The current user
+- Next 14 days
+
+If the MCP doesn't expose user-level filtering, call the broader shift listing and filter client-side by `user_id`.
+
+### 3. Pick the target shift
+
+- If `$ARGUMENTS` is empty: show the next 5 shifts and ask "Which shift do you want covered?"
+- If `$ARGUMENTS` is `next`: pick the soonest upcoming shift.
+- If `$ARGUMENTS` is a date or shift identifier: try to match.
+
+If no match, list options and ask.
+
+### 4. Find candidate coverers
+
+For the shift's schedule and time window:
+1. Call `mcp__rootly__create_override_recommendation` if it accepts the shift parameters - this is the cleanest path; it returns suggested coverers.
+2. Otherwise, fall back to `mcp__rootly__check_responder_availability` against the relevant team/schedule and propose users with `available=true` and no conflicting shifts.
+3. Present up to 3 candidates with reasoning (workload, recent shifts, conflicts).
+
+If no candidates are available, surface that and stop.
+
+### 5. Show the proposal
+
+```
+Proposed shift swap:
+- Shift: [Schedule name] [start] -> [end] ([duration])
+- Currently assigned: you ([your name])
+- Proposed coverer: [candidate name]
+- Why: [reason - e.g. "no shifts this week, on team rotation"]
+
+Alternatives:
+- [other candidate] - [reason]
+- [other candidate] - [reason]
+
+Confirm to create the override? (yes / no / pick another)
+```
+
+### 6. Wait for confirmation
+
+- `yes` -> call `mcp__rootly__createOverrideShift` with this shape:
+
+```json
+{
+  "schedule_id": "[schedule_id]",
+  "data": {
+    "type": "shifts",
+    "attributes": {
+      "starts_at": "[shift start ISO8601]",
+      "ends_at": "[shift end ISO8601]",
+      "user_id": [coverer user id]
+    }
+  }
+}
+```
+
+Echo the resulting override ID and a confirmation line.
+- `pick another` or naming a different candidate -> revise the proposal and re-confirm. Do not execute on the first reply if the user is changing the candidate.
+- `no` or any other answer -> acknowledge and stop. Do not call the create tool.
+
+### 7. After the override is created
+
+Output:
+
+```
+ Override created.
+- ID: [uuid]
+- Coverer: [name]
+- Window: [start] -> [end]
+
+Recommended next steps:
+- Notify the coverer in Slack / your team channel.
+- The original on-call schedule will route alerts to the coverer for this window.
+```
+
+### 8. Guidelines
+
+- Never call `createOverrideShift` without confirmation. The "yes" must come from the user, not be inferred.
+- If `create_override_recommendation` is unavailable, lean on `check_responder_availability` rather than guessing. Don't propose a coverer you can't verify is available.
+- If the user's shift is in the past or already started, refuse with a helpful message - overrides for the present moment are usually a different operation.
+- Show timezone explicitly in the proposal. Ambiguous times cause mistakes.

--- a/plugins/rootly/skills/rootly-trend/SKILL.md
+++ b/plugins/rootly/skills/rootly-trend/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: rootly-trend
+description: Reliability trend summary for a service, team, or the whole org. Reports incident volume, severity mix, and MTTR direction over a window (default 30 days). Use for standups, 1-on-1s, or quarterly reviews.
+---
+
+
+# Reliability Trend
+
+You are summarizing whether things are getting better or worse, scoped to a service, team, or the whole org.
+
+## Workflow
+
+### 1. Determine scope
+
+Parse `$ARGUMENTS`:
+- Empty or `all` -> org-wide.
+- A name -> resolve to a service or team using the same approach as the `rootly-lookup` skill:
+  1. Try `mcp__rootly__listServices` first.
+  2. Fall back to `mcp__rootly__listTeams`.
+  3. If multiple matches, list the top 5 and ask the user to disambiguate.
+
+### 2. Pull the chart data
+
+Service scope:
+- Call `mcp__rootly__getServiceIncidentsChart` for the last 30 days.
+- Call `mcp__rootly__getServiceUptimeChart` for the same window if available.
+- Call `mcp__rootly__listIncidents` filtered to the service over the last 30 days (page_size=100) for severity and resolution timing.
+
+Team scope:
+- Call `mcp__rootly__getTeamIncidentsChart` for the last 30 days.
+- Call `mcp__rootly__listIncidents` filtered to the team over the last 30 days for severity and MTTR.
+
+Org scope:
+- Call `mcp__rootly__listIncidents` over the last 30 days (page_size=100, sort=-created_at). If the volume exceeds one page, note the truncation and proceed with a partial picture rather than walking pages.
+
+### 3. Pull the comparison window
+
+Repeat the same call for the previous 30-day window (days 31--60). This gives a baseline for trend direction.
+
+### 4. Compute the metrics
+
+For each window, compute:
+- Total incidents
+- Severity mix (count per severity, with critical+high highlighted)
+- MTTR - for resolved incidents only, average `resolved_at - started_at`. Skip incidents with missing timestamps rather than imputing.
+- Repeat incidents - count of incidents whose service or root cause appears more than once in the window. (Best-effort: if `cause` data is absent, skip this metric and note it.)
+
+Compare current vs previous to derive trend direction:
+- Improving: incident count down >=10% AND MTTR not significantly worse.
+- Degrading: incident count up >=10% OR MTTR up >=25%.
+- Stable: anything else.
+
+### 5. Render
+
+```
+## Reliability Trend: [scope name]
+*30-day window vs prior 30 days*
+
+### Headline
+[Improving  / Stable  / Degrading ] - [one-sentence summary]
+
+### Metrics
+| Metric | This period | Prior period | Delta |
+|---|---|---|---|
+| Total incidents | [N] | [N] | [+/-N (%)] |
+| Critical/High | [N] | [N] | [+/-N] |
+| MTTR | [duration] | [duration] | [+/-duration] |
+| Repeat incidents | [N] | [N] | [+/-N] |
+
+### Severity Mix (this period)
+-  Critical: [N]
+-  High: [N]
+-  Medium: [N]
+-  Low: [N]
+
+### Top Incidents (most recent / highest severity)
+- [INC-XXXX] [title] ([severity], [duration])
+- [INC-YYYY] [title] ([severity], [duration])
+[max 5]
+
+### What I'd flag
+[Concise observations:]
+- [e.g. "Critical count doubled - both incidents on payments-api in the same week"]
+- [e.g. "MTTR worsening despite stable volume - investigate response process"]
+- [e.g. "No incidents this period on this service - expected or coverage gap?"]
+```
+
+### 6. Read-only
+
+This skill never mutates Rootly state.
+
+### 7. Error handling
+
+- If a chart endpoint isn't available for the scope (some MCP versions only support service-level, not team-level), compute metrics manually from `listIncidents` and proceed.
+- If the prior window has no data, skip the comparison row and label the headline "Insufficient history".
+- If incident count is below 5 in either window, add a caveat: "*Sample size is small - trend may not be meaningful.*"


### PR DESCRIPTION
## Rootly

Adds a Rootly plugin for incident-management work inside Cline. The plugin is aimed at teams that use Rootly for incidents, alerts, on-call scheduling, deployment readiness, retrospectives, action items, and stakeholder communication.

## Cline Primitives

This plugin uses three Cline primitives:

- MCP: registers the Rootly remote MCP server at `https://mcp.rootly.com/mcp`, so Cline can use the normal MCP OAuth flow instead of storing static Rootly API tokens in plugin code or settings.
- Skills: bundles 17 Rootly-prefixed workflow skills for service health, alert triage, incident briefs, incident response, deployment risk checks, retrospectives, reliability trends, on-call dashboards, handoffs, shift coverage, action items, lookup, setup, and natural-language Rootly questions.
- Rules: adds a Rootly safety rule that keeps Rootly access on MCP tools, treats incident/on-call data as sensitive, requires explicit confirmation before writes, and prevents shell or raw HTTP credential fallbacks.

The skills are intentionally prefixed as `rootly-*` instead of generic names like `status`, `ask`, or `action`, which keeps the user-facing skill list clear and avoids collisions with other plugins.

## Requirements

Users need a Rootly account with access to the incident, alert, service, team, and on-call data they want Cline to inspect or update. They also need network access to the Rootly MCP endpoint and a Cline host with MCP OAuth support.

There are no install-time Rootly API calls, no local MCP server package, and no required Rootly API token. The Rootly MCP connection is authorized through Cline's MCP flow when the user connects the server.

## Safety Boundaries

The plugin does not install shell hooks, validate API tokens, register deployment events automatically, or call Rootly REST APIs directly. Rootly operations go through the MCP server.

Write-capable workflows require the model to show the proposed Rootly change and wait for explicit confirmation before calling a mutation tool. The broader incident-response skill is advisory only and routes writes to dedicated workflows or the Rootly UI instead of improvising severity, responder, escalation, or status changes.

Public status-page updates are handled conservatively: if a dedicated status-page MCP tool is not exposed, the skill stops and explains that it cannot confirm a public status-page post from Cline rather than silently creating an internal incident event and implying public syndication.
