### PR TITLE
feat: add ruby lsp plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Each plugin lives in `plugins/<slug>`. The directory name is the install keyword
 | `linear` | Linear SDK scripting skill for issue, project, team, cycle, and comment workflows. |
 | `mac-notify` | macOS notifications when a Cline run completes. |
 | `nanobanana` | Image generation through OpenRouter and Gemini image models. |
+| `ruby-lsp` | Bounded Ruby and ERB syntax diagnostics through local Ruby tooling. |
 | `speak` | Speaks completed Cline replies with ElevenLabs text to speech. |
 | `typescript-lsp` | TypeScript language service `goto_definition` support. |
 | `weather-metrics` | Demo weather tool plus runtime metrics hooks. |

--- a/plugins/ruby-lsp/README.md
+++ b/plugins/ruby-lsp/README.md
@@ -1,0 +1,45 @@
+# ruby-lsp
+
+Adds bounded Ruby syntax diagnostics for Cline.
+
+## What It Does
+
+Registers `ruby_diagnostics(file)`. The tool checks Ruby workspace files with the user's installed Ruby tooling:
+
+- `.rb`, `.rake`, `.gemspec`, and `.ru` files run through `ruby -c`.
+- Common Ruby basenames like `Rakefile`, `Gemfile`, `Guardfile`, and `Capfile` also run through `ruby -c`.
+- `.erb` files run through `erb -x` and then `ruby -c`.
+
+This is a Cline-native diagnostic tool rather than a persistent language-server session.
+
+## Install
+
+```bash
+cline plugin install ruby-lsp
+```
+
+For local development from this repository:
+
+```bash
+cline plugin install ./plugins/ruby-lsp --cwd .
+```
+
+## Example Usage
+
+After installation, ask Cline:
+
+```text
+Check this Ruby file for syntax diagnostics before I commit it.
+```
+
+Cline can call `ruby_diagnostics` when it needs a bounded Ruby parse check instead of relying only on text search.
+
+## Requirements
+
+- Ruby 3.0 or later available as `ruby`.
+- For `.erb` files, the `erb` executable available on `PATH`.
+- The file being checked must be inside the active workspace.
+
+## Security Notes
+
+The tool does not install gems, start a language server, or intentionally execute Ruby application code. It runs the `ruby` and `erb` executables available on the plugin host's `PATH`, passes arguments without shell interpolation, caps captured output, and only accepts files inside the active workspace.

--- a/plugins/ruby-lsp/index.ts
+++ b/plugins/ruby-lsp/index.ts
@@ -1,0 +1,211 @@
+import { spawn } from "node:child_process"
+import { access, realpath } from "node:fs/promises"
+import { basename, extname, isAbsolute, relative, resolve } from "node:path"
+import { type AgentPlugin, createTool } from "@cline/core"
+
+type RubyDiagnosticsInput = {
+	file: string
+}
+
+type CommandResult = {
+	command: string
+	args: string[]
+	exitCode: number | null
+	stdout: string
+	stderr: string
+}
+
+const SUPPORTED_EXTENSIONS = new Set([".rb", ".rake", ".gemspec", ".ru", ".erb"])
+const SUPPORTED_BASENAMES = new Set(["Rakefile", "Gemfile", "Guardfile", "Capfile"])
+const MAX_OUTPUT_LENGTH = 12000
+const TIMEOUT_MS = 20000
+const KILL_AFTER_TIMEOUT_MS = 1000
+
+function appendBounded(current: string, chunk: string): string {
+	if (current.length >= MAX_OUTPUT_LENGTH) {
+		return current
+	}
+	const next = current + chunk
+	if (next.length <= MAX_OUTPUT_LENGTH) {
+		return next
+	}
+	return `${next.slice(0, MAX_OUTPUT_LENGTH)}\n[truncated]`
+}
+
+function runCommand(
+	command: string,
+	args: string[],
+	options: { cwd: string; stdin?: string },
+): Promise<CommandResult> {
+	return new Promise((resolveCommand) => {
+		const child = spawn(command, args, {
+			cwd: options.cwd,
+			stdio: ["pipe", "pipe", "pipe"],
+		})
+
+		let stdout = ""
+		let stderr = ""
+		let settled = false
+		let killTimer: ReturnType<typeof setTimeout> | undefined
+
+		function finish(exitCode: number | null, fallbackError?: string) {
+			if (settled) return
+			settled = true
+			clearTimeout(timer)
+			if (killTimer) clearTimeout(killTimer)
+			resolveCommand({
+				command,
+				args,
+				exitCode,
+				stdout,
+				stderr: fallbackError ?? stderr,
+			})
+		}
+
+		const timer = setTimeout(() => {
+			stderr = appendBounded(stderr, `\nTimed out after ${TIMEOUT_MS}ms.`)
+			child.kill("SIGTERM")
+			killTimer = setTimeout(() => {
+				if (!settled) {
+					child.kill("SIGKILL")
+				}
+			}, KILL_AFTER_TIMEOUT_MS)
+		}, TIMEOUT_MS)
+
+		child.stdout.on("data", (chunk) => {
+			stdout = appendBounded(stdout, String(chunk))
+		})
+		child.stderr.on("data", (chunk) => {
+			stderr = appendBounded(stderr, String(chunk))
+		})
+		child.on("error", (error) => {
+			finish(null, error.message)
+		})
+		child.on("close", (exitCode) => {
+			finish(exitCode)
+		})
+
+		child.stdin.end(options.stdin ?? "")
+	})
+}
+
+function isInsideWorkspace(workspaceRoot: string, filePath: string): boolean {
+	const rel = relative(workspaceRoot, filePath)
+	return rel === "" || (!rel.startsWith("..") && !isAbsolute(rel))
+}
+
+async function resolveWorkspaceFile(workspaceRoot: string, file: string) {
+	const candidate = resolve(workspaceRoot, file)
+	await access(candidate)
+	const resolvedRoot = await realpath(workspaceRoot)
+	const resolvedFile = await realpath(candidate)
+	if (!isInsideWorkspace(resolvedRoot, resolvedFile)) {
+		throw new Error("File must be inside the active workspace.")
+	}
+	return { resolvedRoot, resolvedFile }
+}
+
+const plugin: AgentPlugin = {
+	name: "ruby-lsp",
+	manifest: {
+		capabilities: ["tools"],
+	},
+
+	setup(api, ctx) {
+		const workspaceRoot = ctx.workspaceInfo?.rootPath ?? process.cwd()
+
+		api.registerTool(
+			createTool({
+				name: "ruby_diagnostics",
+				description:
+					"Run bounded Ruby syntax diagnostics for a workspace Ruby file. " +
+					"Supports .rb, .rake, .gemspec, .ru, and .erb files using the user's installed Ruby tooling.",
+				inputSchema: {
+					type: "object",
+					properties: {
+						file: {
+							type: "string",
+							description:
+								"Ruby file to check. Relative paths resolve from the active workspace.",
+						},
+					},
+					required: ["file"],
+					additionalProperties: false,
+				},
+				timeoutMs: TIMEOUT_MS + 5000,
+				retryable: false,
+				async execute(input: unknown) {
+					const { file } = (input ?? {}) as RubyDiagnosticsInput
+					if (typeof file !== "string" || file.trim() === "") {
+						return { ok: false, error: "`file` must be a non-empty string." }
+					}
+
+					let resolvedRoot: string
+					let resolvedFile: string
+					try {
+						const resolved = await resolveWorkspaceFile(workspaceRoot, file)
+						resolvedRoot = resolved.resolvedRoot
+						resolvedFile = resolved.resolvedFile
+					} catch (error) {
+						return {
+							ok: false,
+							error: error instanceof Error ? error.message : String(error),
+						}
+					}
+
+					const extension = extname(resolvedFile)
+					const name = basename(resolvedFile)
+					const isSupported =
+						SUPPORTED_EXTENSIONS.has(extension) || SUPPORTED_BASENAMES.has(name)
+					if (!isSupported) {
+						return {
+							ok: false,
+							file: resolvedFile,
+							error: `Unsupported Ruby file "${name}". Supported extensions: ${Array.from(
+								SUPPORTED_EXTENSIONS,
+							).join(", ")}. Supported basenames: ${Array.from(
+								SUPPORTED_BASENAMES,
+							).join(", ")}.`,
+						}
+					}
+
+					if (extension === ".erb") {
+						const erb = await runCommand("erb", ["-x", "-T", "-", resolvedFile], {
+							cwd: resolvedRoot,
+						})
+						if (erb.exitCode !== 0) {
+							return {
+								ok: false,
+								file: resolvedFile,
+								check: "erb -x",
+								result: erb,
+							}
+						}
+						const ruby = await runCommand("ruby", ["-c"], {
+							cwd: resolvedRoot,
+							stdin: erb.stdout,
+						})
+						return {
+							ok: ruby.exitCode === 0,
+							file: resolvedFile,
+							check: "erb -x | ruby -c",
+							result: ruby,
+						}
+					}
+
+					const ruby = await runCommand("ruby", ["-c", resolvedFile], {
+						cwd: resolvedRoot,
+					})
+					return {
+						ok: ruby.exitCode === 0,
+						file: resolvedFile,
+						check: "ruby -c",
+						result: ruby,
+					}
+				},
+			}),
+		)
+	},
+}
+
+export default plugin


### PR DESCRIPTION
## Ruby LSP

Adds a Cline-native Ruby diagnostics plugin for checking Ruby and ERB syntax from an active workspace. This adapts Ruby language-server-style value into a bounded tool shape that Cline can use today without starting or managing a persistent LSP process.

## Cline Primitives

This plugin registers `ruby_diagnostics(file)`, a tool that checks workspace Ruby files with the user-installed Ruby toolchain. Standard Ruby files (`.rb`, `.rake`, `.gemspec`, `.ru`) and common Ruby basenames (`Rakefile`, `Gemfile`, `Guardfile`, `Capfile`) run through `ruby -c`. ERB templates run through `erb -x` and then `ruby -c`.

The tool resolves relative paths from the active workspace, rejects files outside that workspace, caps captured output, and times out long-running checks. It returns structured diagnostics rather than throwing tool errors.

## Requirements

Users need Ruby 3.0 or later available as `ruby`. ERB checks also require the `erb` executable on `PATH`.

No gems are installed by the plugin, and no language server is started. The plugin uses the local Ruby/ERB executables already available on the plugin host.

## Safety Boundaries

The plugin passes command arguments without shell interpolation and only accepts files inside the active workspace. It does not intentionally execute application code, but Ruby syntax checking still invokes the user-installed Ruby executable against project files, so it should be treated as local tooling rather than a remote service.
