### PR TITLE
feat: add Save to Spotify plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Each plugin lives in `plugins/<slug>`. The directory name is the install keyword
 | `linear` | Linear SDK scripting skill for issue, project, team, cycle, and comment workflows. |
 | `mac-notify` | macOS notifications when a Cline run completes. |
 | `nanobanana` | Image generation through OpenRouter and Gemini image models. |
+| `save-to-spotify` | Audio episode production and Spotify upload workflows using the save-to-spotify CLI. |
 | `speak` | Speaks completed Cline replies with ElevenLabs text to speech. |
 | `typescript-lsp` | TypeScript language service `goto_definition` support. |
 | `weather-metrics` | Demo weather tool plus runtime metrics hooks. |

--- a/plugins/save-to-spotify/NOTICE.save-to-spotify
+++ b/plugins/save-to-spotify/NOTICE.save-to-spotify
@@ -1,0 +1,4 @@
+This plugin includes adapted skill material from Spotify's save-to-spotify plugin.
+
+Source: https://github.com/spotify/save-to-spotify
+License: Apache-2.0

--- a/plugins/save-to-spotify/README.md
+++ b/plugins/save-to-spotify/README.md
@@ -1,0 +1,37 @@
+# save-to-spotify
+
+Create polished audio episodes and save them to Spotify from Cline.
+
+## What It Does
+
+This plugin bundles the `save-to-spotify` skill and its reference material for producing audio episodes with TTS narration, cover art, show notes, rich timeline chapters, in-player images, external links, Spotify entity cards, and uploads through the `save-to-spotify` CLI.
+
+The skill can also guide raw media saves, show and episode management, timeline updates, Spotify catalog URI lookups, and audio assembly workflows.
+
+## Install
+
+```bash
+cline plugin install save-to-spotify
+```
+
+For local development from this repository:
+
+```bash
+cline plugin install ./plugins/save-to-spotify --cwd .
+```
+
+## Requirements
+
+- The `save-to-spotify` CLI for authentication, uploads, show/episode management, and timeline updates.
+- Spotify authentication through the CLI before uploads or private account operations.
+- A user-selected TTS provider and `ffmpeg`/`ffprobe` for generated audio workflows.
+- API keys or local models only when the user chooses paid or external TTS/image providers.
+- Rights to reproduce and transform the source content into an audio episode.
+
+## Security Notes
+
+The bundled skill asks for explicit user confirmation before installing the CLI, authenticating with Spotify, uploading audio, creating shows, updating timelines, generating paid TTS or images, fetching third-party sources, or publishing QR/shareable outputs. Keep Spotify tokens, source media, generated audio, and unpublished episode metadata out of logs and commits.
+
+## Attribution
+
+The bundled skill material is derived from Spotify's `save-to-spotify` plugin materials, licensed under Apache-2.0. See `NOTICE.save-to-spotify`.

--- a/plugins/save-to-spotify/index.ts
+++ b/plugins/save-to-spotify/index.ts
@@ -1,0 +1,10 @@
+import type { AgentPlugin } from "@cline/sdk"
+
+const plugin: AgentPlugin = {
+	name: "save-to-spotify",
+	manifest: {
+		capabilities: ["skills"],
+	},
+}
+
+export default plugin

--- a/plugins/save-to-spotify/package.json
+++ b/plugins/save-to-spotify/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "save-to-spotify",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Cline plugin that bundles the Save to Spotify audio production skill.",
+  "cline": {
+    "plugins": [
+      {
+        "paths": [
+          "./index.ts"
+        ],
+        "capabilities": [
+          "skills"
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/save-to-spotify/skills/save-to-spotify/SKILL.md
+++ b/plugins/save-to-spotify/skills/save-to-spotify/SKILL.md
@@ -1,0 +1,140 @@
+---
+id: save-to-spotify
+name: save-to-spotify
+description: Create polished audio content and save to Spotify. Produces episodes with TTS narration, a rich timeline (chapters plus in-player images, external links, and Spotify entity cards), and a cover image. Also use for raw media saves, show/episode management, and timeline navigation.
+enabled: true
+---
+
+# Audio Content Production Skill
+
+`save-to-spotify` saves audio files to the user's Spotify library. Anything they can play locally -- lecture recordings, voice memos, conference talks, language lessons -- they can save to Spotify and listen from any device.
+
+Shows are folders for organizing saves.
+
+You are a podcast and audio content production agent. You create polished audio episodes from a variety of sources and formats, produce them with a rich in-player timeline (chapters plus image, link, and Spotify entity companions that appear during playback in the Now Playing View), and save to Spotify.
+
+This skill defines the shared production pipeline -- core principles, the user interview checkpoint, and the execution checklist.
+
+## Reference Directory
+
+These files cover the detailed rules. Load the one you need -- don't inline them.
+
+- [references/cli-usage.md](references/cli-usage.md) -- Binary install, auth, `upload`/`shows`/`episodes`/`timeline` commands, JSON mode, error handling, troubleshooting, and common end-to-end workflows
+- [references/spotify-api.md](references/spotify-api.md) -- Using `developer.spotify.com/llms.txt`, the Spotify Web API OpenAPI spec, and the CLI's token to resolve album / track / artist / playlist / show / episode names to `spotify:...` URIs for `spotify_entity` timeline companions
+- [references/audio-providers.md](references/audio-providers.md) -- TTS engine selection, voice config, ffmpeg assembly, silence generation, timeline timestamp calculation
+- [references/cover-image.md](references/cover-image.md) -- Cover image paths (user-provided, AI-generated, CDN artwork), typography rules, font & RTL, Pillow compositing recipe
+- [references/timeline.md](references/timeline.md) -- Timeline data model, validation rules, companion images (sourced / AI-generated / mixed / skip), including DALL-E / Stable Diffusion code and batch generation
+- [references/episode-description.md](references/episode-description.md) -- HTML description format, Python builder from `timeline.json`, formatting rules
+- [references/content-quality.md](references/content-quality.md) -- Editorial guidelines: voice, transitions, person context, depth control, visual description, pacing, self-critique
+
+---
+
+## Install
+
+If `save-to-spotify` is not available on `PATH`, show the user the install options from [references/cli-usage.md](references/cli-usage.md). Do not run a remote installer yourself unless the user explicitly asks Cline to run that exact command in the current session.
+
+```shell
+curl -fsSL https://saveto.spotify.com/install.sh | bash
+```
+
+See [references/cli-usage.md](references/cli-usage.md) for manual binary downloads, source builds, authentication, command usage, and troubleshooting.
+
+---
+
+## Cline Safety Notes
+
+- Ask for explicit confirmation before running installer commands, starting Spotify OAuth, printing or using an access token, uploading audio, creating shows, updating timelines, generating paid TTS or image assets, or fetching third-party source material. Prefer showing install/auth commands for the user to run unless they explicitly ask Cline to run them.
+- Treat Spotify tokens, OAuth redirect URLs, source media, generated audio, show metadata, timeline files, and unpublished episode details as sensitive. Do not echo tokens or commit generated media, credentials, or private source files.
+- Use only user-provided content, authorized APIs, or sources the user has the right to transform into audio and upload with any images. If rights are unclear, ask before producing or uploading.
+- For paid or external TTS/image providers, identify the provider, expected cost/risk, and files to be created before running commands.
+
+---
+
+## Core Principles
+
+### Read-only. Always.
+
+When sourcing content, always respect platform terms of service and robots.txt and third-party IP rights. Use only authorized APIs and user-provided content. Never interact with source platforms beyond reading -- do not post, like, follow, or modify content.
+
+### Be the listener's eyes
+
+Podcast listeners can't see anything. You are their eyes. Every piece of visual content -- screenshots, images, charts -- must be described in the script. If it matters to the segment, say what's in it.
+
+### Deep-link everything
+
+Every segment in the show notes must link to the original source when possible. A link to a specific moment or post is 10x more valuable than a link to a homepage.
+
+### Respect Third-Party Rights
+
+The final product must be a noninfringing synthesis of source materials, and must not infringe copyright or other third-party IP rights. It must not mislead as to the source or sponsorship of any material or information.
+
+### Prefer Spotify-native references
+
+When a segment points to something that already exists on Spotify -- music, podcasts, audiobook titles, artists, albums, playlists, episodes, creators -- capture the Spotify URI and use a `spotify_entity` timeline item whenever possible. Prefer the full `spotify:...` URI form, not a bare ID or `open.spotify.com` URL. Use external `link` companions for off-Spotify destinations such as articles, stores, docs, newsletters, and event pages. A `spotify_entity` and a `link` can both appear for the same segment/chapter when both the Spotify destination and the original source are valuable; just place them at non-overlapping times.
+
+### Segment-to-source integrity
+
+The script has a strict 1:1 mapping: segment [N] corresponds to source item N. This mapping drives chapters, timeline companions, and show notes alignment. Never reorder, merge, or skip segments after assignment.
+
+### Save incrementally
+
+Write collected data to disk after each sourcing step. If a later step fails, previous work is preserved.
+
+### Pacing and silence
+
+Don't fear strategic silence. Pauses between segments give the listener time to absorb. The 300ms gaps between segments are a minimum -- use longer pauses (500ms+) between major topic shifts. Vary the pacing: slow down for important analysis or emotional moments, keep it brisk for roundups and quick hits.
+
+---
+
+## User Interview (MANDATORY)
+
+Before doing any work, you MUST have a conversation with the user to confirm preferences. Do not assume defaults. Ask, then STOP and wait for their reply. Do not proceed until they respond. Skipping the interview will feel efficient; don't. Treat this as a hard checkpoint before sourcing, scripting, or generation.
+
+At minimum, always confirm these before producing anything:
+
+1. Content scope -- What sources, topics, or material to use
+2. Language -- What language the episode should be in (do not assume from the source language)
+3. Length -- How long the episode should be
+4. TTS voice -- Which voice to use (offer options from [references/audio-providers.md](references/audio-providers.md))
+5. Cover image style -- How to generate the cover image. Present these options (see [references/cover-image.md](references/cover-image.md) for full details):
+   - User-provided -- the user supplies their own image file
+   - AI-generated (requires explicit opt-in) -- unique image themed to the episode content, text composited with Pillow
+   - CDN artwork (terminal fallback when the user accepts the Spotify-provided artwork) -- pre-designed abstract illustration from the STS CDN with Pillow typography
+6. Timeline companion images -- How to produce images that appear in the player during playback. Timeline is the default rich output: every episode gets chapters, Spotify entity companions for Spotify-native references, external link companions for off-platform sources, and image companions placed inside each chapter's window. A Spotify entity and a link can both be included in the same chapter when both are useful. When a segment has one canonical source URL and one representative image for that same source, default to a single image companion with `url` set instead of separate image-only and link-only items. For images, present these options:
+   - AI-generated -- DALL-E, Stable Diffusion, or the user's preferred image model, from a themed prompt per segment. Use only when the user explicitly chooses generated images
+   - Mixed -- sourced where the user has reuse/upload rights, AI-generated fill only when the user explicitly opts into generation. Aim for at least one image per chapter
+   - Sourced -- user-provided or authorized source images only
+   - Skip -- chapters and link companions only, no images. Lightest pipeline, still richer than the old chapters-only output
+7. Show -- After listing shows, ask whether to add this episode to an existing show or create a new one. Do not silently choose for them unless they already specified the destination.
+
+Collect the missing choices explicitly rather than inventing your own default profile.
+
+Ask these questions in your first response and STOP. Wait for the user to answer. Do not start fetching content, writing scripts, or generating audio until the user has replied.
+
+If the user's initial prompt already covers some of these (e.g., "make an 8-minute English podcast about..."), skip those questions but still present a plan and wait for confirmation.
+
+### Plan confirmation
+
+Before starting production, present a short plan:
+- Episode title, language, estimated length, number of segments, voice, show name
+
+Say: "Here's what I'll produce -- let me know if you'd like to change anything, or say 'go' to proceed."
+
+Do not start production until the user confirms.
+
+---
+
+## Execution Checklist
+
+Every episode -- regardless of content type -- must complete these steps.
+
+0. Interview -- Ask the user about preferences, including companion-image source. Present a plan and wait for confirmation.
+1. Preflight install and auth -- After the user confirms the plan, check whether `save-to-spotify` is available. If the binary is missing, show install instructions and only run an installer if the user explicitly asks Cline to run it. Run `save-to-spotify --json auth status` only after confirmation because it may touch local auth state. If unauthenticated or token refresh is broken, prompt the user to run `save-to-spotify auth login` first unless they explicitly ask Cline to run it.
+2. Script -- Write the script following this skill's universal rules (see [references/content-quality.md](references/content-quality.md))
+3. Critique -- Self-review the script, revise without reordering or removing segments
+4. Produce -- Generate audio per-segment, concatenate, convert to MP3 (see [references/audio-providers.md](references/audio-providers.md)). Build `timeline.json` with chapters, Spotify entity companions where applicable, image companions with `url` set when image + source belong together, standalone links only for imageless or extra destinations, and additional images as needed (sourced and/or AI-generated per the interview answer) -- see [references/timeline.md](references/timeline.md)
+5. Describe -- Build the timestamped HTML description from the chapter entries in `timeline.json` and source URLs (see [references/episode-description.md](references/episode-description.md))
+6. Cover image -- Generate or select cover image (square, max 1 MB). MANDATORY -- never skip this step (see [references/cover-image.md](references/cover-image.md))
+7. Save -- Save MP3 with title, description, cover image, and an explicit `--show-id` or confirmed `--new-show` via `save-to-spotify --json upload` (see [references/cli-usage.md](references/cli-usage.md))
+8. Timeline -- Push `timeline.json` with `timeline set` (uploads image files automatically)
+9. Verify -- Poll `episodes status` until `READY`

--- a/plugins/save-to-spotify/skills/save-to-spotify/references/audio-providers.md
+++ b/plugins/save-to-spotify/skills/save-to-spotify/references/audio-providers.md
@@ -1,0 +1,365 @@
+# Audio Providers & Assembly
+
+Reference for generating speech and assembling audio files for saving via `save-to-spotify`. The user picks their own TTS engine and voice -- this documents how to use each one.
+
+Tell the user:
+
+> The skill produces audio content that may be distributed via a streaming platform.
+> Every episode must be grounded in content you have the right to reproduce in this form.
+
+## Production pipeline
+
+Every episode walks the same steps. Recipes define what to write (sourcing, scripting, segment map). This reference covers generation and assembly.
+
+1. Generate TTS audio per segment (one file each for exact chapter timing)
+2. Generate silence files for transitions (300ms minimum between segments, 500ms+ between major shifts)
+3. Concatenate all segments into a single MP3
+4. Normalize volume levels
+5. Calculate chapter timestamps from cumulative segment durations
+6. Build `timeline.json` with chapters, Spotify entity companions, external link companions, and image companions (see [timeline.md](timeline.md))
+
+Accepted formats: `.mp3`, `.m4a`, `.wav`, `.ogg` (max 1 GB). Default to `.mp3`. Convert anything else with ffmpeg before upload -- see "Convert formats" below.
+
+### Voice selection guide
+
+- Kokoro (local, free): `af_alloy` (American female, recommended), `am_adam` (American male), `bf_emma` (British female), `bm_george` (British male)
+- ElevenLabs (high quality, paid): Amelia, George, Bella
+- Edge TTS (free, 300+ voices): `en-US-AriaNeural` (F), `en-US-GuyNeural` (M)
+- OpenAI TTS (high quality, paid): `nova`, `alloy`, `echo`, `onyx`
+
+### Multi-voice / bilingual segments
+
+Default to one voice per episode, but when the content is bilingual, role-played, or otherwise needs multiple voices, use a part-based segment schema and a flattened render manifest.
+
+Example source schema:
+
+```json
+{
+  "segments": [
+    {
+      "title": "Swedish intro",
+      "parts": [
+        {"lang": "sv", "voice": "sv-SE-SofieNeural", "text": "Hej och valkommen."},
+        {"lang": "en", "voice": "en-GB-LibbyNeural", "text": "Welcome back to the show."}
+      ]
+    }
+  ]
+}
+```
+
+Flatten that into a render manifest before synthesis:
+
+```json
+[
+  {"segment_index": 0, "part_index": 0, "lang": "sv", "voice": "sv-SE-SofieNeural", "text": "Hej och valkommen.", "out": "seg_00_00.mp3"},
+  {"segment_index": 0, "part_index": 1, "lang": "en", "voice": "en-GB-LibbyNeural", "text": "Welcome back to the show.", "out": "seg_00_01.mp3"}
+]
+```
+
+Concatenate manifest outputs in order, then compute chapter timestamps from the flattened audio segments.
+
+## Provider selection
+
+When a content creation recipe is triggered and no TTS provider has been established, ask the user:
+
+> What TTS (text-to-speech) tool would you like me to use?
+>
+> - macOS `say` -- built-in, no setup, limited voices
+> - Edge TTS (`edge-tts`) -- free, 300+ voices, 70+ languages
+> - OpenAI TTS -- high quality, paid
+> - ElevenLabs -- most natural, paid
+> - Google Cloud TTS -- high quality, paid
+> - Piper -- offline, fast, open-source
+> - gTTS -- free, Google Translate quality
+> - Amazon Polly -- cloud, paid
+> - Something else?
+>
+> Which voice do you prefer? (I can list available voices.)
+
+### Verification
+
+Before generating, verify the chosen provider is available:
+
+```shell
+which say          # macOS (always available)
+which edge-tts     # pip install edge-tts
+which piper        # separate install
+python3 -c "import openai"      # OpenAI
+python3 -c "import elevenlabs"  # ElevenLabs
+
+# ffmpeg is required for assembly
+which ffmpeg && which ffprobe
+```
+
+If not installed, offer to install or suggest an alternative.
+
+## TTS provider reference
+
+### macOS `say`
+
+```shell
+say --voice '?'                                          # List voices
+say -v <Voice> -o output.m4a --data-format=aac "Text"    # Generate m4a
+say -v <Voice> -o output.m4a --data-format=aac -f in.txt # From file
+```
+
+Voices: `Samantha` (en-US), `Daniel` (en-GB), `Alex` (en-US high quality). Limited languages.
+
+### Edge TTS (recommended free option)
+
+```shell
+edge-tts --list-voices                                                  # List all
+edge-tts --voice "en-US-AriaNeural" --text "Hello" --write-media o.mp3  # Generate
+edge-tts --voice "en-US-GuyNeural" -f input.txt --write-media o.mp3     # From file
+edge-tts --voice "en-US-AriaNeural" --rate="+10%" --text "Fast" --write-media o.mp3  # Faster
+edge-tts --voice "en-US-AriaNeural" --rate="-30%" --text "Slow" --write-media o.mp3  # Slower
+```
+
+Key voices: `en-US-AriaNeural` (F), `en-US-GuyNeural` (M), `en-GB-SoniaNeural` (F), `en-GB-RyanNeural` (M), `es-ES-ElviraNeural`, `fr-FR-DeniseNeural`, `de-DE-KatjaNeural`, `ja-JP-NanamiNeural`, `zh-CN-XiaoxiaoNeural`.
+
+### OpenAI TTS
+
+```python
+from openai import OpenAI
+client = OpenAI()
+resp = client.audio.speech.create(model="tts-1", voice="nova", input="Text")
+resp.stream_to_file("output.mp3")
+```
+
+Voices: `alloy`, `echo`, `fable`, `onyx`, `nova`, `shimmer`. Use `tts-1-hd` for higher quality.
+
+### ElevenLabs
+
+```python
+from elevenlabs import generate, save
+audio = generate(text="Text", voice="Rachel", model="eleven_multilingual_v2")
+save(audio, "output.mp3")
+```
+
+Most natural. Supports multiple languages.
+
+### Piper (offline)
+
+```shell
+echo "Text" | piper --model en_US-lessac-medium.onnx --output_file output.wav
+ffmpeg -i output.wav -codec:a libmp3lame -qscale:a 2 output.mp3  # convert
+```
+
+### Kokoro (local, free, no API limits)
+
+```python
+from kokoro_onnx import Kokoro
+import soundfile as sf
+import numpy as np
+import json
+
+kokoro = Kokoro('kokoro-v1.0.onnx', 'voices-v1.0.bin')
+
+segments = [
+    ("Introduction", intro_text),
+    ("Main Topic", body_text),
+    ("Sign-off", outro_text),
+]
+
+timeline_items = []
+all_samples = []
+cursor_ms = 0
+
+for title, text in segments:
+    samples, sr = kokoro.create(text, voice='af_alloy', speed=1.0)
+    timeline_items.append({"chapter": {"title": title, "start_time_ms": cursor_ms}})
+    all_samples.append(samples)
+    # 300ms silence between segments
+    silence = np.zeros(int(sr * 0.3))
+    all_samples.append(silence)
+    cursor_ms += int((len(samples) + len(silence)) / sr * 1000)
+
+combined = np.concatenate(all_samples)
+sf.write('episode.wav', combined, sr)
+
+with open('timeline.json', 'w') as f:
+    json.dump({"items": timeline_items}, f, indent=2)
+```
+
+Convert to MP3: `ffmpeg -i episode.wav -codec:a libmp3lame -b:a 192k episode.mp3`
+
+Voices: `af_alloy` (American female, recommended), `am_adam` (American male), `bf_emma` (British female), `bm_george` (British male). Fully offline, no API limits. Generates audio + chapter timestamps in one pass.
+
+### gTTS (free, basic)
+
+```shell
+gtts-cli "Text to speak" --lang en --output output.mp3
+gtts-cli -f input.txt --lang en --output output.mp3
+```
+
+### Google Cloud TTS
+
+```python
+from google.cloud import texttospeech
+client = texttospeech.TextToSpeechClient()
+input_text = texttospeech.SynthesisInput(text="Text")
+voice = texttospeech.VoiceSelectionParams(language_code="en-US", name="en-US-Neural2-F")
+config = texttospeech.AudioConfig(audio_encoding=texttospeech.AudioEncoding.MP3)
+resp = client.synthesize_speech(input=input_text, voice=voice, audio_config=config)
+with open("output.mp3", "wb") as f:
+    f.write(resp.audio_content)
+```
+
+## Text sanitization for TTS
+
+Before sending text to any TTS engine, clean it:
+
+- Strip markdown: `bold` -> `bold`, `# heading` -> `heading`
+- Remove hashtags, emojis, and non-speech artifacts
+- Expand abbreviations that sound wrong when spoken aloud
+- Replace em dashes `--` with hyphens `-` to avoid encoding issues in shell commands
+- Remove URLs from the spoken text (mention them as "link in the description" instead)
+
+## Audio assembly with ffmpeg
+
+All content recipes generate multiple segments that must be joined into a single file; the segment boundaries become chapters in the timeline.
+
+### Generate silence
+
+```shell
+# 1.5 seconds (transitions between sections)
+ffmpeg -f lavfi -i anullsrc=r=44100:cl=mono -t 1.5 -q:a 9 -acodec libmp3lame /tmp/silence_1.5s.mp3
+
+# 3 seconds (recall pauses for language drills)
+ffmpeg -f lavfi -i anullsrc=r=44100:cl=mono -t 3 -q:a 9 -acodec libmp3lame /tmp/silence_3s.mp3
+
+# 5 seconds (speaking practice pauses)
+ffmpeg -f lavfi -i anullsrc=r=44100:cl=mono -t 5 -q:a 9 -acodec libmp3lame /tmp/silence_5s.mp3
+```
+
+### Concatenate segments
+
+```shell
+# Build a file list (order matters)
+cat > /tmp/segments.txt << 'EOF'
+file 'segment_01.mp3'
+file 'silence_1.5s.mp3'
+file 'segment_02.mp3'
+file 'silence_1.5s.mp3'
+file 'segment_03.mp3'
+EOF
+
+# Concatenate -- re-encode rather than `-c copy`. Stream-copying small MP3
+# segments yields non-monotonic frame timestamps that `loudnorm` silently
+# drops audio on. The explicit `-ar 44100 -ac 1` also normalizes any stray
+# stereo/48kHz segment to the common format so concat doesn't break.
+ffmpeg -f concat -safe 0 -i /tmp/segments.txt -ar 44100 -ac 1 -c:a libmp3lame -b:a 192k /tmp/output.mp3
+```
+
+### Normalize volume
+
+Always normalize after concatenation -- different TTS segments may have different levels:
+
+```shell
+ffmpeg -i /tmp/output.mp3 -af loudnorm /tmp/output_normalized.mp3
+```
+
+### Convert formats
+
+If the TTS outputs a format other than `.mp3`, `.m4a`, `.wav`, or `.ogg`, convert before upload:
+
+```shell
+ffmpeg -i input.aiff -codec:a libmp3lame -qscale:a 2 output.mp3
+ffmpeg -i input.webm -codec:a libmp3lame -qscale:a 2 output.mp3
+```
+
+### Get segment duration (for timeline timestamps)
+
+```shell
+ffprobe -v error -show_entries format=duration -of csv=p=0 segment.mp3
+```
+
+### Timeline timestamp calculation
+
+After generating all segments, build `timeline.json` by walking the file list, summing durations for chapter start times, and placing image/link companions inside each chapter's window. The only backend rule for companions is that they do not overlap with each other -- chapter windows are independent.
+
+```python
+import json, subprocess
+from pathlib import Path
+
+def ms(path):
+    out = subprocess.check_output(
+        ['ffprobe', '-v', 'error', '-show_entries', 'format=duration',
+         '-of', 'csv=p=0', str(path)], text=True).strip()
+    return int(float(out) * 1000)
+
+# Each segment: (chapter_title, audio_file, companions)
+# companions is a list of dicts:
+#   {"image": "img_01_a.jpg", "url": "...", "title": "..."}  -- image companion
+#   {"link":  "https://..."}                                  -- external link
+#   {"spotify_entity": "spotify:track:4uLU6hMCjMI75M1A2tKUQC"}  -- Spotify card
+#
+# When a spotify_entity is used for a track/album/artist, do NOT also add an
+# image companion with that entity's artwork -- the card already renders it.
+segments = [
+    ("Introduction",   "segment_01.mp3", []),
+    ("Chapter A",      "segment_02.mp3", [
+        {"spotify_entity": "spotify:track:4uLU6hMCjMI75M1A2tKUQC"},
+        {"link":  "https://example.com/article-1"},
+    ]),
+    ("Chapter B",      "segment_03.mp3", [
+        {"image": "img_03_a.jpg", "url": "https://example.com/article-2", "title": "Source photo"},
+    ]),
+    ("Sign-off",       "segment_04.mp3", []),
+]
+silence_ms = ms('silence_1.5s.mp3')
+
+items = []
+cursor = 0
+for title, audio, companions in segments:
+    items.append({"chapter": {"title": title, "start_time_ms": cursor}})
+    dur = ms(audio)
+    # Distribute companions evenly inside the chapter window, with a 500 ms buffer.
+    if companions:
+        usable = dur - 500 * (len(companions) + 1)
+        slot = max(usable // len(companions), 1000)
+        for i, c in enumerate(companions):
+            start = cursor + 500 + i * (slot + 500)
+            duration = slot
+            if "spotify_entity" in c:
+                items.append({"spotify_entity": {"start_time_ms": start, "duration_ms": duration, "uri": c["spotify_entity"]}})
+            elif "image" in c:
+                item = {"image": {"start_time_ms": start, "duration_ms": duration, "image": c["image"]}}
+                if c.get("url"):   item["image"]["url"] = c["url"]
+                if c.get("title"): item["image"]["title"] = c["title"]
+                items.append(item)
+            elif "link" in c:
+                items.append({"link": {"start_time_ms": start, "duration_ms": duration, "url": c["link"]}})
+    cursor += dur + silence_ms
+
+# Every chapter's start_time_ms must be strictly less than the assembled
+# audio duration; nothing downstream can verify this.
+final_ms = ms('episode.mp3')
+last_chapter_ms = max(it["chapter"]["start_time_ms"] for it in items if "chapter" in it)
+assert last_chapter_ms < final_ms, (
+    f"last chapter at {last_chapter_ms} ms >= episode duration {final_ms} ms"
+)
+
+Path('timeline.json').write_text(json.dumps({"items": items}, indent=2))
+```
+
+The agent passes `timeline.json` to `save-to-spotify --json timeline set --episode-id <EP_ID> --from-file timeline.json`. The CLI uploads each local image file to Spotify's image store and swaps the path for the returned upload token before PUT-ing the timeline.
+
+## Standard workflow (used by all recipes)
+
+```
+1. User provides: topic + sources + voice preferences + companion-image source (sourced / AI-generated / mixed / skip)
+2. Agent writes: structured script broken into segments, with source URL(s) and image hint per segment
+3. Agent generates: one audio file per segment via TTS provider
+4. Agent generates: silence files for pauses/transitions
+5. Agent assembles: concatenate segments into single .mp3
+6. Agent normalizes: volume levels
+7. Agent gathers companion images: download from source and/or generate with DALL-E/SD
+8. Agent calculates: chapter timestamps from segment durations
+9. Agent builds: timeline.json with chapters + spotify_entity companions + link companions (source URLs) + image companions
+10. Agent saves: save-to-spotify --json upload ...
+11. Agent sets timeline: save-to-spotify --json timeline set ...
+12. Agent polls: episodes status until READY
+```
+
+Recipes define steps 1-2 (what to write, which URLs and images to gather). This reference covers steps 3-9. The main SKILL.md covers steps 10-12.

--- a/plugins/save-to-spotify/skills/save-to-spotify/references/cli-usage.md
+++ b/plugins/save-to-spotify/skills/save-to-spotify/references/cli-usage.md
@@ -1,0 +1,405 @@
+# Save to Spotify
+
+## CLI Usage
+
+Reference for the `save-to-spotify` binary: installation, authentication, commands, flags, JSON mode, error handling, and common agent workflows.
+
+## Installation
+
+### One-line install
+
+```shell
+curl -fsSL https://saveto.spotify.com/install.sh | bash
+```
+
+Detects OS and architecture, downloads the binary from GitHub Releases, verifies the SHA256 checksum, and installs to `/usr/local/bin` (or `~/.local/bin` if not writable).
+
+In Cline, treat installation as a user action. Show this command and wait for the user to run it, or run it only when the user explicitly asks Cline to execute the command in the current session.
+
+Pin a version or change the install directory:
+
+```shell
+# Specific version
+curl -fsSL https://saveto.spotify.com/install.sh | bash -s -- --version 0.1.1
+
+# Custom directory
+curl -fsSL https://saveto.spotify.com/install.sh | bash -s -- --dir ~/.local/bin
+
+# Via environment variables
+SAVE_TO_SPOTIFY_VERSION=0.1.1 SAVE_TO_SPOTIFY_INSTALL_DIR=~/.local/bin \
+  curl -fsSL https://saveto.spotify.com/install.sh | bash
+```
+
+### Download a binary manually
+
+Grab the selected release for the platform from [releases](https://github.com/spotify/save-to-spotify/releases). Prefer a pinned version when the user asks Cline to run the download:
+
+```shell
+# macOS Apple Silicon
+gh release download --repo spotify/save-to-spotify --pattern "save-to-spotify-darwin-arm64"
+chmod +x save-to-spotify-darwin-arm64
+sudo mv save-to-spotify-darwin-arm64 /usr/local/bin/save-to-spotify
+
+# macOS Intel
+gh release download --repo spotify/save-to-spotify --pattern "save-to-spotify-darwin-amd64"
+chmod +x save-to-spotify-darwin-amd64
+sudo mv save-to-spotify-darwin-amd64 /usr/local/bin/save-to-spotify
+
+# Linux x86_64
+gh release download --repo spotify/save-to-spotify --pattern "save-to-spotify-linux-amd64"
+chmod +x save-to-spotify-linux-amd64
+sudo mv save-to-spotify-linux-amd64 /usr/local/bin/save-to-spotify
+```
+
+### Build from source
+
+Requires Go 1.21+.
+
+```shell
+git clone https://github.com/spotify/save-to-spotify.git && cd save-to-spotify
+go build -ldflags "-X github.com/spotify/save-to-spotify/cmd.commit=$(git rev-parse --short HEAD)" \
+  -o save-to-spotify .
+sudo mv save-to-spotify /usr/local/bin/
+```
+
+Verify installation:
+
+```shell
+save-to-spotify version
+```
+
+## Authentication
+
+The user must authenticate once before any save. The CLI uses OAuth 2.0 with PKCE -- no client secret needed.
+
+### Interactive (user has a browser)
+
+```shell
+save-to-spotify auth login
+```
+
+This opens the browser, the user approves, and a token is saved to `~/.config/save-to-spotify/token.json`. Ask before starting OAuth because it opens a browser and writes local auth state.
+
+### Headless (remote server, CI, or agent environment)
+
+```shell
+save-to-spotify auth login --no-browser
+```
+
+This prints an authorization URL. The user visits it in any browser, approves, and pastes the redirect URL back into the terminal. The redirect URL will look like `http://127.0.0.1:8085/callback?code=...&state=...` -- it's fine if the page shows a connection error, the URL itself is what matters. Treat the redirect URL as sensitive.
+
+### Environment token (skip OAuth entirely)
+
+If the user already has a Spotify access token (e.g. from another tool or CI secret):
+
+```shell
+export SAVE_TO_SPOTIFY_AUTH_TOKEN="BQD..."
+```
+
+When this env var is set, the CLI uses it directly with no file I/O and no token refresh. The token must be kept fresh externally.
+
+### Check auth status
+
+```shell
+save-to-spotify --json auth status
+```
+
+Returns `{"authenticated": true, "token_valid": true, ...}` or `{"authenticated": false}`. In Cline workflows, run this only after the user confirms the plan because it can refresh local auth state.
+
+Token refresh is automatic -- if the saved token is expired, the CLI refreshes it silently on the next command. No action needed unless the refresh token itself is revoked, in which case the user must `auth login` again.
+
+### Print the access token
+
+```shell
+save-to-spotify token
+```
+
+Prints the current access token to stdout -- directly usable as a Spotify Web API bearer for requests against `api.spotify.com`. Useful for catalog lookups (searching album/track URIs, fetching release metadata) from inside recipes. Exits non-zero and prints a diagnostic to stderr when the stored token cannot be refreshed. Always check the exit code before piping into an `Authorization` header -- otherwise an empty token produces a misleading HTTP 400 from Spotify rather than a clean auth error.
+
+See [spotify-api.md](spotify-api.md) for the official `developer.spotify.com` references, OpenAPI spec URL, endpoint patterns, and URI-resolution helpers.
+
+## Saving media
+
+### Save with explicit show selection
+
+The `upload` command is the simplest path -- one command to create an episode and save the file. Always include either a user-confirmed `--show-id` or `--new-show`; do not rely on the CLI's implicit most-recent-show behavior.
+
+```shell
+save-to-spotify --json upload recording.mp3 \
+  --title "My Recording" \
+  --summary "Description here" \
+  --show-id spotify:show:xyz789 \
+  --image cover.jpg
+```
+
+Output:
+```json
+{"episode_uri": "spotify:episode:abc123", "title": "My Recording", "status": "PROCESSING"}
+```
+
+If the user has no shows yet, ask whether to create a new show and use `--new-show`. Do not let the CLI auto-create "My Podcast" unless the user explicitly asks for that default.
+
+### Save to a specific show
+
+```shell
+save-to-spotify --json upload lecture.m4a \
+  --title "Lecture 3: Distributed Systems" \
+  --summary "CS 307 Spring 2024" \
+  --show-id spotify:show:xyz789 \
+  --image cover.jpg
+```
+
+When `--show-id` is omitted, the CLI uses the most recently created show. Cline should avoid this except for direct user-requested raw command execution.
+
+### Create a new show and save in one step
+
+```shell
+save-to-spotify --json upload keynote.mp3 \
+  --title "2024 Keynote" \
+  --summary "Opening talk by <speaker>" \
+  --new-show "Conference Talks" \
+  --image cover.jpg
+```
+
+`--new-show` and `--show-id` are mutually exclusive.
+
+### Granular episode creation
+
+For more control, use `episodes create` instead of `upload`:
+
+```shell
+save-to-spotify --json episodes create \
+  --title "Episode Title" \
+  --file audio.mp3 \
+  --summary "Episode description" \
+  --show-id spotify:show:xyz789 \
+  --image episode-cover.jpg \
+  --language en
+```
+
+The difference: `episodes create` requires `--summary` and `--file` as explicit flags (not positional), and does not support `--new-show`.
+
+## Supported file formats
+
+| Extension | Type | MIME |
+|-----------|------|------|
+| `.mp3` | Audio | `audio/mpeg` |
+| `.m4a` | Audio | `audio/mp4` |
+| `.wav` | Audio | `audio/wav` |
+| `.ogg` | Audio | `audio/ogg` |
+
+Maximum file size: 1 GB.
+
+## Managing shows
+
+Shows are folders that group episodes. Every episode belongs to exactly one show.
+
+```shell
+# List all shows
+save-to-spotify --json shows
+
+# Create a show (always include --image)
+save-to-spotify --json shows create --title "My Lectures" --summary "University recordings" --image cover.jpg
+
+# Get show details
+save-to-spotify --json shows get <show_id>
+
+# Delete a show (and all its episodes)
+save-to-spotify --json shows delete <show_id>
+```
+
+`save-to-spotify --json shows` should be the first show-management command you run. Check what already exists before creating a new show.
+
+## Managing episodes
+
+```shell
+# List episodes in a show
+save-to-spotify --json episodes --show-id <show_id>
+
+# Check episode readiness
+save-to-spotify --json episodes status <episode_id>
+
+# Delete an episode
+save-to-spotify --json episodes delete <episode_id>
+```
+
+Show and episode metadata is immutable after creation. To change a title or description, delete and re-create.
+
+### Episode readiness
+
+After saving, poll for readiness before sharing:
+
+```shell
+save-to-spotify --json episodes status <EPISODE_ID>
+```
+
+Output:
+```json
+{"episode_uri": "spotify:episode:abc123", "readiness": "READY"}
+```
+
+Readiness values:
+- `READY` -- playable on Spotify
+- `PROCESSING` -- still being processed (wait and retry)
+- `FAILED` -- processing failed; check the episode metadata and re-save if needed
+
+Most episodes are ready within 1-2 minutes. For large files, allow up to 5 minutes.
+
+## IDs and URIs
+
+The CLI accepts both bare IDs and full Spotify URIs interchangeably, but agents should prefer the full Spotify URI form whenever possible:
+- `abc123def456` (bare ID)
+- `spotify:show:abc123def456` (full URI)
+
+JSON output always includes the full URI form.
+
+## JSON mode
+
+Always use `--json` when operating as an agent. It must appear before the command:
+
+```shell
+save-to-spotify --json <command> [flags]
+```
+
+In JSON mode:
+- All output is valid JSON on stdout
+- Errors are `{"error": "message"}` on stdout with exit code 1
+- Progress bars and activity indicators are suppressed
+- Informational messages to stderr are suppressed
+
+Without `--json`, output is human-readable text.
+
+## Timeout control
+
+The default API timeout is 30 seconds. For large file uploads, the upload itself has no timeout (separate HTTP client), but the episode creation API call does. Override if needed:
+
+```shell
+save-to-spotify --json --timeout 2m upload large-recording.mp3 --title "Long Episode" --show-id spotify:show:xyz789 --image cover.jpg
+```
+
+Or via environment variable:
+```shell
+export SAVE_TO_SPOTIFY_TIMEOUT=2m
+```
+
+## Common agent workflows
+
+### Create a rich-timeline episode end-to-end
+
+```shell
+# 1. Generate cover image (MANDATORY -- see cover-image.md)
+python3 generate_cover.py
+
+# 2. Save with cover image to a user-confirmed show
+SHOW_URI=spotify:show:xyz789
+RESULT=$(save-to-spotify --json upload episode.mp3 \
+  --title "Daily Digest - April 15, 2026" \
+  --summary "$(cat description.txt)" \
+  --show-id "$SHOW_URI" \
+  --image cover.jpg)
+EP_URI=$(echo "$RESULT" | jq -r .episode_uri)
+EP_ID=${EP_URI#spotify:episode:}
+
+# 3. Set timeline (chapters + image/link/Spotify companions in one call)
+save-to-spotify --json timeline set --episode-id "$EP_ID" --from-file timeline.json
+
+# 4. Poll until ready
+while true; do
+  STATUS=$(save-to-spotify --json episodes status "$EP_ID" | jq -r .readiness)
+  [ "$STATUS" = "READY" ] && break
+  [ "$STATUS" = "FAILED" ] && echo "Processing failed" && exit 1
+  sleep 15
+done
+
+echo "Episode ready: $EP_URI"
+```
+
+### Save a single file
+
+```shell
+SHOW_URI=spotify:show:xyz789
+URI=$(save-to-spotify --json upload recording.mp3 --title "My Recording" --summary "A recording" --show-id "$SHOW_URI" --image cover.jpg | jq -r .episode_uri)
+EP_ID=${URI#spotify:episode:}
+
+while true; do
+  STATUS=$(save-to-spotify --json episodes status "$EP_ID" | jq -r .readiness)
+  [ "$STATUS" = "READY" ] && break
+  [ "$STATUS" = "FAILED" ] && echo "Processing failed" && exit 1
+  sleep 15
+done
+```
+
+### Batch save multiple files to one show
+
+```shell
+SHOW_URI=$(save-to-spotify --json shows create --title "Conference Talks 2024" --image show-cover.jpg | jq -r .show_uri)
+
+for f in talks/*.mp3; do
+  TITLE=$(basename "$f" .mp3 | tr '-' ' ')
+  save-to-spotify --json upload "$f" --title "$TITLE" --summary "Conference talk" --show-id "$SHOW_URI" --image cover.jpg
+done
+```
+
+## Error handling
+
+With `--json`, every command returns exit code 0 on success and exit code 1 on error. Errors are returned as `{"error": "message"}`. Always check for errors after each command.
+
+```bash
+SHOW_URI=spotify:show:xyz789
+RESULT=$(save-to-spotify --json upload episode.mp3 --title "My Episode" --show-id "$SHOW_URI" --image cover.jpg)
+if echo "$RESULT" | jq -e .error > /dev/null 2>&1; then
+  echo "Failed: $(echo "$RESULT" | jq -r .error)"
+  exit 1
+fi
+EP_URI=$(echo "$RESULT" | jq -r .episode_uri)
+EP_ID=${EP_URI#spotify:episode:}
+
+while true; do
+  STATUS=$(save-to-spotify --json episodes status "$EP_ID")
+  READINESS=$(echo "$STATUS" | jq -r .readiness)
+  [ "$READINESS" = "READY" ] && break
+  [ "$READINESS" = "FAILED" ] && echo "Processing failed" && exit 1
+  sleep 15
+done
+```
+
+Common errors:
+
+| Error | Cause | Action |
+|-------|-------|--------|
+| `not authenticated` | No token file | Run `auth login` |
+| `token refresh failed` | Refresh token revoked | Run `auth login` again |
+| `unsupported file extension` | Wrong file type | Convert to a supported format |
+| `file too large` | Over 1 GB | Compress or split the file |
+| `image too large` | Over 1 MB | Resize the image |
+| `API error (429)` | Rate limited | Wait and retry after a delay |
+| `API error (401)` | Token expired mid-request | Retry (auto-refresh will kick in) |
+| `API error (403)` | Insufficient permissions | Re-authenticate with `auth login` |
+| `--new-show and --show-id are mutually exclusive` | Conflicting flags | Use one or the other |
+
+## Troubleshooting
+
+### Episode not appearing after saving
+Use `episodes status <id>` to check readiness. Processing can take a few minutes after the save completes.
+
+### Image upload fails
+Images must be `.jpg`, `.jpeg`, or `.png`, max 1 MB, with valid magic bytes (actual JPEG/PNG content, not just a renamed file).
+
+### "unsupported file extension" error
+Only `.mp3`, `.m4a`, `.wav`, and `.ogg` are supported. Convert other formats first (e.g., `ffmpeg -i input.webm output.mp3`).
+
+## Environment variables reference
+
+| Variable | Purpose |
+|----------|---------|
+| `SAVE_TO_SPOTIFY_AUTH_TOKEN` | Bearer token; skips OAuth entirely (no refresh, no expiry tracking) |
+| `SAVE_TO_SPOTIFY_BACKEND_URL` | Override backend URL |
+| `SAVE_TO_SPOTIFY_TIMEOUT` | API timeout duration (e.g. `30s`, `2m`) |
+
+## Content policy
+
+- No copyrighted music: Content that is classified as music by Spotify's moderation system will be taken down.
+- Moderation applies: Standard Spotify podcast moderation policies apply. Content that violates policies will be removed and the user will be notified via email.
+- No sensitive data: Do not save content containing passwords, credentials, PII of others, or confidential business information. The content is stored on Spotify's servers.
+- Save limits apply: There are per-user rate limits on saves (per hour and per week). If a limit is hit, the API returns an error -- wait and retry later.
+- Never fabricate URLs: Every source link in episode descriptions must come from actual content sourcing. If a URL isn't found, omit the link -- never invent one.

--- a/plugins/save-to-spotify/skills/save-to-spotify/references/content-quality.md
+++ b/plugins/save-to-spotify/skills/save-to-spotify/references/content-quality.md
@@ -1,0 +1,168 @@
+# Content Quality & Editorial Guidelines
+
+Reference for writing scripts that sound good when spoken aloud. Applies to all content recipes. Audio content has different constraints than written content -- these guidelines encode production learnings from hundreds of generated episodes.
+
+## The golden rule: write for the ear
+
+Text is forgiving. Readers can re-read a sentence, scan ahead, or slow down. Audio is linear and unforgiving -- if the listener misses something, it's gone. Every line must land on first hearing.
+
+## Voice and tone
+
+### Match voice to format
+
+| Format | Voice | Energy |
+|--------|-------|--------|
+| Factual summary | Sharp analyst | Confident, declarative, varied energy per segment |
+| Travel guide | Well-traveled friend | Conversational, specific, enthusiastic but honest |
+| Explainer | Patient teacher | Clear, builds from simple to complex |
+| Daily briefing | Briefing companion | Brisk, clear, energetic |
+| Language lesson | Encouraging tutor | Patient, repetitive, affirming |
+
+### Universal voice principles
+
+- Declarative beats tentative. "This matters because..." not "This could potentially be interesting..."
+- Concrete beats abstract. "They're trying to lock in developers" not "they're enhancing ecosystem engagement"
+- Short beats long. Mix short punchy sentences with longer analytical ones. Never more than two long sentences in a row
+- Active beats passive. "Sweden cut Chinese research ties" not "Chinese research ties were cut by Sweden"
+- Specific beats vague. "Expect to pay 15 euros for a main course" not "food is reasonably priced"
+
+## Transitions between segments
+
+This is the single most important audio production skill. Listeners cannot see segment boundaries. Without clear verbal signals, segments blur together into mush.
+
+Every segment must open with a clear transition. Vary these -- using the same transition every time is as bad as having none:
+
+- Subject lead: "Keychron just open-sourced their hardware..." / "The housing market is shifting..."
+- Framing hooks: "This is huge." / "Here's what caught my eye." / "Quick note:"
+- Topic shifts: "On the security side..." / "Turning to the economy..."
+- Related bridges: "That same dynamic is playing out in..."
+- Simple transitions: "Moving on." / "Meanwhile..." / "Next up..."
+- Travel transitions: "From there, head south to..." / "After lunch, the plan takes you to..."
+- Time markers: "Back in 1927..." / "Fast forward to today..."
+
+## Person context
+
+When introducing someone by name, briefly explain WHO they are. Listeners don't have hyperlinks -- they can't look someone up mid-sentence.
+
+- "Marie Curie, the first person to win Nobel Prizes in two sciences..."
+- "Ada Lovelace, the 19th-century mathematician often called the first computer programmer..."
+- "John Constable, one of England's greatest landscape painters..."
+
+One clause, not a bio. If the person isn't well-known, anchor them to something the listener knows, but with well-grounded facts.
+
+## Depth control
+
+Not every item deserves equal time. Classify content by importance and adjust depth accordingly:
+
+| Tier | Sentences | Approach |
+|------|-----------|----------|
+| A (major) | 4-6 | What happened -> strategic significance -> added context -> implication |
+| B (notable) | 3-4 | What happened -> why interesting -> one sentence context |
+| C (brief) | 1 | State the fact, move on. No analysis, no context |
+
+Use Tier C aggressively for: thin engagement-bait, celebrity amplification with no insight, opinion with no new information, promotional announcements. High engagement alone does NOT justify a high tier.
+
+## Default-off content categories
+
+These skills MUST NOT produce:
+
+- Instructions for self-harm or suicide methods
+- Instructions for drug synthesis, weapon construction, or similar harmful material
+- Sexually explicit content
+- Sexual content involving minors
+- Promotion or celebration of violent extremism
+- Instructions for harming others
+- Targeted harassment content involving real individuals
+
+## Sensitive-topic checkpoint
+
+Some topics deserve an explicit "are you sure?" before producing an authoritative-sounding episode. If the topic, source set, or destination touches:
+
+- Named living individuals' alleged misconduct
+- Active political, religious, or cultural controversy
+- Advisory content (medical treatment, investment decisions, legal processes)
+
+-- restate the planned angle and wait for explicit *go*. Not a refusal; a confirmation. Advisory topics also get a "not professional advice -- consult a qualified source" line in both script and description.
+
+## Describing visual content
+
+Podcast listeners can't see anything. You are their eyes. When the source material is visual (images, charts, GIFs, screenshots):
+
+- Describe what's happening: "A ring of rotating blades spirals around the log, stripping bark in ribbons"
+- Include emotional reaction: "It's almost hypnotic to watch"
+- Reference the source: "In a post on Example Site this week..."
+- Mention where to see it: "Link to the original is in the show notes"
+
+Never skip describing visual content -- if it matters to the segment, say what's in it.
+
+## Things to AVOID
+
+These patterns make AI-generated audio content sound generic and robotic:
+
+- "Let's dive in" / "Without further ado" / "Buckle up" -- cliche openings
+- "garnering over X likes" / "racking up views" -- engagement metrics as filler
+- Starting a segment with someone's full display name as the literal first word
+- Metrics without meaning -- only mention numbers when they're remarkable relative to context
+- Press-release language -- "We're thrilled to announce" / "innovative solutions"
+- Brochure language -- "A hidden gem" / "A must-visit destination" / "Something for everyone"
+- Trailing summaries -- don't recap what you just said. The listener heard it
+- Equal-time syndrome -- not every item needs the same depth. Be ruthless about tier assignment
+- Verbatim reproduction of sources -- paraphrase the substance. Direct quotes stay under two sentences and are labeled ("as the article puts it...")
+
+## Pacing and silence
+
+Don't fear strategic silence. Pauses between segments give the listener time to absorb.
+
+- 300ms -- minimum gap between segments within a section
+- 500ms+ -- between major topic shifts or chapter boundaries
+- 1-2 seconds -- before a significant reveal or after an emotional moment
+- 3-5 seconds -- for active recall pauses (flashcards, language drills)
+
+Vary the pacing within segments too: slow down for important analysis or emotional moments, keep it brisk for roundups and minor items.
+
+## Self-critique checklist
+
+After drafting any script, evaluate against these criteria:
+
+1. Does each segment explain WHY, not just WHAT? (digests) / Is each stop actually useful? (travel)
+2. Does the voice stay consistent throughout? No sudden shifts from casual to formal
+3. Does each segment clearly signal a transition? Read the first sentence of each segment aloud -- could a listener tell a new topic started?
+4. Is the pacing varied? Important parts get more space, minor ones stay brief
+5. Would this sound natural read aloud? Read it out loud. If you stumble, rewrite
+6. Are sources attributed naturally? "According to..." not footnotes
+7. Is visual content described? For every image referenced, does the script say what's in it?
+
+The critique must NEVER suggest cutting or removing any segment -- segment-to-source integrity is sacred. Instead, suggest how to improve the segment's framing, analysis, or writing.
+
+## Source linking
+
+Every piece of source content should have its original URL captured and preserved through the pipeline. The URL appears in the episode description as a clickable link.
+
+- An episode without source links is significantly less useful -- listeners learn about a segment but can't follow up
+- Never fabricate URLs -- if a URL isn't found, omit the link
+- Never fabricate facts -- if you can't verify a claim and aren't genuinely confident, skip it or say "the sources don't cover this." Applies to quotes, statistics, dates, studies, and prices. Same posture as "Never fabricate URLs", extended
+- AI-generated disclosure -- end every description with a content-describing line: *"AI-narrated audio assembled from the sources in this description"* or, for knowledge-only episodes, *"AI-narrated audio -- verify key facts before acting."*
+- Label links by platform: "read on Example", "see on Example.org", "visit site"
+- Front-load the description summary -- the first 1-2 sentences show as a preview in podcast apps. Don't waste them on boilerplate
+
+## Episode naming
+
+- Show name: Short, memorable, searchable. Avoid generic names that get lost in search results
+- Episode title: Include the date or episode number for recurring shows. Keep under ~60 characters to avoid truncation
+- Consistent format: Pick a pattern and stick with it: "Show Name - Date", "Show Name: Topic"
+
+## Episode length
+
+Match length to content density -- don't pad to hit a target:
+
+| Format | Typical length |
+|--------|---------------|
+| Daily digest | 3-6 min |
+| Weekly digest | 5-10 min |
+| Short fiction | 5-15 min |
+| Travel guide (per trip) | 5-10 min |
+| Deep dive / explainer | 15-30 min |
+| Daily briefing | 5-12 min |
+| Language lesson | 10-20 min |
+
+AI-narrated content is denser than conversational podcasts -- listeners absorb it faster. A tight 4-minute episode with strong content beats a padded 10-minute one.

--- a/plugins/save-to-spotify/skills/save-to-spotify/references/cover-image.md
+++ b/plugins/save-to-spotify/skills/save-to-spotify/references/cover-image.md
@@ -1,0 +1,184 @@
+# Cover Image
+
+Every show & every episode MUST have a cover image. Never save without `--image`.
+
+Format: JPG or PNG, max 1 MB, 1400x1400 square.
+
+## Paths (priority order)
+
+1. User-provided -- only when user supplies an image file and confirms they have rights to use/upload it. Skip otherwise. Resize to 1400x1400, apply strong overlay, add typography (unless user opts out).
+2. AI-generated -- only when the user explicitly opts in and accepts any provider cost/policy implications. Never use unvetted services. No overlay (prompt reserves negative space).
+3. CDN artwork -- terminal fallback only when the user accepts Spotify-provided base artwork. No overlay (built-in legibility).
+
+Fallthrough: AI fails -> ask before using CDN artwork.
+
+### Path 1: User-provided
+
+Skip this path entirely if the user did not provide an image file. Do not generate a substitute image -- proceed to Path 2.
+
+Accept JPG/PNG at any aspect ratio. Reject if below 600x600 or corrupted. Crop to square, resize to 1400x1400, compress to <1 MB (JPG 90%). Apply strong overlay, then add typography unless user opts out.
+
+Never: apply filters, AI enhancement, generate a stand-in image, or override with an agent-generated image.
+
+### Path 2: AI-generated
+
+Only use known image generation APIs: DALL-E (OpenAI), Stable Diffusion, or Midjourney after explicit user opt-in. Never use unvetted services (e.g., pollinations.ai) -- quality is unreliable and licensing unclear. If no known API key is available, ask before using CDN (Path 3).
+
+Never render text with the model -- composite with Pillow afterwards.
+
+Prompt pattern: `"{style} of {concrete subject}, {composition}, {palette}, square composition, negative space in lower third, no text, no logos"`
+
+Example: topic "Weekly Stockholm news briefing" -> `"Minimalist illustration of a Stockholm rooftop skyline at dusk, muted blue-grey palette, square composition, negative space in lower third, no text, no logos"`
+
+Every prompt must include: a specific concrete subject (not a concept), a composition direction, a palette descriptor, "square composition", "negative space in lower third", "no text, no logos".
+
+Style: photorealistic or clean illustration only. No collage, 3D renders, faces, or AI-generated likenesses.
+
+Never produce: podcast-meta imagery (mics, headphones), stock cliches (handshakes, lightbulbs), neon/HDR, baked-in text or logos.
+
+Skip AI if: topic is abstract, involves real named people, refers to events after the model's training cutoff, or user requested otherwise.
+
+See [timeline.md](timeline.md) for DALL-E / Stable Diffusion code examples.
+
+### Path 3: CDN artwork (terminal fallback)
+
+Pre-designed base artwork with Pillow typography. No overlay needed. 20 variants (`uts-01.png` through `uts-20.png`), selected by hash of show name. Ask the user before relying on this fallback because it fetches Spotify-hosted artwork and uploads the derived cover.
+
+CDN endpoint: `https://save-to-spotify.spotifycdn.com/assets/uts-{01..20}.png`
+
+## Typography
+
+Mandatory on every cover (unless user opted out in Path 1). Always composited with Pillow. Never rely on AI text rendering.
+
+Default copy: show name only. Add date/episode number only to disambiguate >1 episode per day.
+
+### Constraints
+
+- One label only. No subtitles, taglines, or descriptors.
+- Max 3 lines. If title doesn't fit, shorten: drop articles, use short forms. Full title preserved in metadata -- surface shortened title to user & offer to regenerate.
+- No widows. Don't strand a single short word on its own line.
+- Break on meaning. Keep concepts together. Pick the split producing the most balanced line widths.
+
+### Font & RTL
+
+| Script | Font | Alignment |
+| --- | --- | --- |
+| Latin (default) | Montserrat Bold | bottom-left |
+| Arabic | Tajawal Bold | bottom-right |
+| Hebrew | Noto Sans Hebrew Bold | bottom-right |
+
+All OFL-licensed Google Fonts. Downloaded and cached on first use (`~/.cache/save-to-spotify/fonts/`). Bold or heavier only. Never system defaults or decorative fonts.
+
+RTL detection: if any character has `unicodedata.bidirectional(ch) in ('R', 'AL', 'AN')`, use RTL font and right-alignment.
+
+No reshaper libraries. Do NOT use `arabic_reshaper` or `python-bidi` -- modern fonts handle shaping natively in Pillow.
+
+### Colour & effects
+
+- White text only. No accent colours, no exceptions.
+- No text effects. No drop shadows, strokes, outlines, glows.
+
+## Pillow compositing recipe
+
+Constants and thresholds are authoritative -- see code below for exact values.
+
+```python
+from PIL import Image, ImageDraw, ImageFont
+import os, hashlib, unicodedata, urllib.request
+
+CANVAS = 1400
+MARGIN = 64
+MAX_TEXT_WIDTH = int((CANVAS - 2 * MARGIN) * 0.85)
+MAX_TEXT_HEIGHT = CANVAS - MARGIN - CANVAS // 2  # 636px
+MIN_FONT_SIZE = 100
+MAX_FONT_SIZE = 400
+LEADING_FACTOR = 0.97
+
+FONT_CACHE = os.path.join(os.path.expanduser("~"), ".cache", "save-to-spotify", "fonts")
+FONTS = {
+    "latin":  ("Montserrat-Bold.ttf",       "https://raw.githubusercontent.com/JulietaUla/Montserrat/master/fonts/ttf/Montserrat-Bold.ttf"),
+    "arabic": ("Tajawal-Bold.ttf",           "https://raw.githubusercontent.com/google/fonts/main/ofl/tajawal/Tajawal-Bold.ttf"),
+    "hebrew": ("NotoSansHebrew-Bold.ttf",    "https://raw.githubusercontent.com/google/fonts/main/ofl/notosanshebrew/NotoSansHebrew-Bold.ttf"),
+}
+
+def detect_script(title):
+    for ch in title:
+        code = ord(ch)
+        if 0x0600 <= code <= 0x06FF or 0x0750 <= code <= 0x077F:
+            return "arabic"
+        if 0x0590 <= code <= 0x05FF:
+            return "hebrew"
+    return "latin"
+
+def load_font(size, title=""):
+    os.makedirs(FONT_CACHE, exist_ok=True)
+    fname, url = FONTS[detect_script(title)]
+    path = os.path.join(FONT_CACHE, fname)
+    if not os.path.exists(path):
+        urllib.request.urlretrieve(url, path)
+    return ImageFont.truetype(path, size)
+
+def measure_line(font, text):
+    if not text: return (0, 0)
+    b = font.getbbox(text)
+    return b[2] - b[0], b[3] - b[1]
+
+def _split_combos(words, n):
+    if n == 1: yield [words]; return
+    for i in range(1, len(words) - n + 2):
+        for rest in _split_combos(words[i:], n - 1):
+            yield [words[:i]] + rest
+
+def break_lines(title, font):
+    words = title.split()
+    if not words: return [title]
+    best, best_d = None, float("inf")
+    for n in range(1, min(len(words), 3) + 1):
+        for combo in _split_combos(words, n):
+            lines = [" ".join(p) for p in combo if p]
+            if not lines: continue
+            ws = [measure_line(font, l)[0] for l in lines]
+            if max(ws) > MAX_TEXT_WIDTH: continue
+            d = max(ws) - min(ws)
+            if d < best_d: best_d, best = d, lines
+    return best or [title]
+
+def fit_title(title):
+    if not title: title = "Untitled"
+    for sz in range(MAX_FONT_SIZE, MIN_FONT_SIZE - 1, -2):
+        font = load_font(sz, title)
+        lines = break_lines(title, font)
+        if len(lines) > 3: continue
+        if max(measure_line(font, l)[0] for l in lines) > MAX_TEXT_WIDTH: continue
+        lh = int(sz * LEADING_FACTOR)
+        total = lh * (len(lines) - 1) + font.getbbox(lines[-1])[3]
+        if total > MAX_TEXT_HEIGHT: continue
+        return font, lines, sz
+    f = load_font(MIN_FONT_SIZE, title)
+    return f, break_lines(title, f), MIN_FONT_SIZE
+
+def composite_title(img, title):
+    draw = ImageDraw.Draw(img)
+    font, lines, sz = fit_title(title)
+    lh = int(sz * LEADING_FACTOR)
+    total = lh * (len(lines) - 1) + font.getbbox(lines[-1])[3]
+    y = max(CANVAS - MARGIN - total, CANVAS // 2)
+    rtl = detect_script(title) != "latin"
+    for line in lines:
+        x = CANVAS - MARGIN - measure_line(font, line)[0] if rtl else MARGIN
+        draw.text((x, y), line, font=font, fill=(255, 255, 255))
+        y += lh
+    return img
+
+def strong_overlay(img):
+    ov = Image.new("RGBA", img.size, (0, 0, 0, 0))
+    d = ImageDraw.Draw(ov)
+    start = int(CANVAS * 0.40)
+    for y in range(start, CANVAS):
+        d.line([(0, y), (CANVAS, y)], fill=(0, 0, 0, int((y - start) / (CANVAS - start) * 230)))
+    return Image.alpha_composite(img.convert("RGBA"), ov).convert("RGB")
+```
+
+## QA checklist
+
+Verify: 1400x1400 JPG/PNG <1 MB, typography present with correct font/alignment/white/margins, overlay on user-provided only, no faces/text/logos in AI output. If any check fails, fall through to next path.

--- a/plugins/save-to-spotify/skills/save-to-spotify/references/episode-description.md
+++ b/plugins/save-to-spotify/skills/save-to-spotify/references/episode-description.md
@@ -1,0 +1,63 @@
+# Episode Description Format
+
+Reference for building the HTML description that appears in the Spotify show-notes panel. Spotify auto-links `(M:SS)` timestamps for in-app seeking.
+
+## Format
+
+The description uses HTML `<p>` tags with timestamped entries on a single line (no literal newlines in the final string):
+
+```html
+<p>Summary of today's episode themes in 1-2 sentences.</p><p>(0:00) - Introduction</p><p>(0:18) - First segment title - <a href='https://example.com/article-1'>source</a></p><p>(1:42) - Second segment title - <a href='https://example.com/article-2'>source</a></p><p>(4:30) - Sign-off</p>
+```
+
+## Build it from the timeline
+
+Read chapter entries from `timeline.json` (ignore image, link, and `spotify_entity` companions -- those appear in the player, not the show notes):
+
+```python
+import json
+from html import escape
+from urllib.parse import urlparse
+
+timeline = json.load(open('timeline.json'))
+chapters = [item['chapter'] for item in timeline['items'] if 'chapter' in item]
+# source_links maps chapter title -> original article URL (from sourcing phase)
+source_links = {"Segment title": "https://source.url/article"}
+
+parts = ['<p>Summary of episode themes.</p>']
+for ch in chapters:
+    ms = ch['start_time_ms']
+    ts = f"({ms // 60000}:{(ms % 60000) // 1000:02d})"
+    raw_title = ch['title']
+    title = escape(raw_title)
+    url = source_links.get(raw_title)
+    parsed = urlparse(url) if url else None
+    if parsed and parsed.scheme in {"http", "https"} and parsed.netloc:
+        safe_url = escape(url, quote=True)
+        parts.append(f"<p>{ts} - {title} - <a href='{safe_url}'>source</a></p>")
+    else:
+        parts.append(f"<p>{ts} - {title}</p>")
+
+description = ''.join(parts)
+```
+
+## Rules
+
+1. Every entry wrapped in its own `<p>...</p>` block
+2. Do NOT use `<br>` tags -- they render as literal text on the Spotify desktop app
+3. Timestamps as plain text `(M:SS)` in parentheses -- Spotify auto-links these for seeking. Do NOT wrap timestamps in `<a>` tags
+4. No leading zero on minutes, always two-digit seconds: `(0:05)`, `(1:42)`, `(12:30)`
+5. External source links use HTML anchors: `<a href='URL'>source</a>`. Only include valid HTTP(S) URLs, and HTML-escape titles and URLs before upload
+6. Use single quotes inside `href` to avoid shell escaping issues
+7. Entire description must be a single line with NO literal newlines
+8. Start with a 1-2 sentence summary paragraph
+9. Use `-` (hyphen) not `--` (em dash) to avoid shell encoding issues
+10. Include Introduction and Sign-off entries (no source links for these)
+11. Every entry with a known source URL MUST include the link -- never fabricate URLs
+12. `<b>`, `<i>` for emphasis (sparingly)
+
+## Naming (per Spotify guidelines)
+
+- Show name: Short, memorable, and searchable. Avoid generic names that get lost in search results
+- Episode title: Include the date or episode number for recurring shows. Keep under ~60 characters so it doesn't truncate in the app
+- Description summary: The first 1-2 sentences appear as a preview in podcast apps -- front-load the most interesting hook, don't waste it on boilerplate

--- a/plugins/save-to-spotify/skills/save-to-spotify/references/spotify-api.md
+++ b/plugins/save-to-spotify/skills/save-to-spotify/references/spotify-api.md
@@ -1,0 +1,139 @@
+# Spotify Web API (catalog lookups)
+
+Use this reference when a segment names something that already exists on Spotify and the timeline should include a `spotify_entity` companion. This file covers the `save-to-spotify`-specific wiring: how to get a bearer token from the CLI, how to resolve names to `spotify:...` URIs, and when to omit a low-confidence entity.
+
+Treat Spotify for Developers as the source of truth for endpoint shapes, parameters, schemas, and policy. Use the Spotify Web API rather than third-party catalogs, because timeline entries need Spotify URIs rather than cross-platform tap-throughs.
+
+## Start with Spotify for Developers
+
+Before scripting Web API calls, load the official developer context:
+
+- `https://developer.spotify.com/llms.txt` - LLM-ready entrypoint for Spotify's developer platform.
+- `https://developer.spotify.com/documentation/web-api/tutorials/building-with-ai` - Web API guidance for AI coding assistants and agents.
+- `https://developer.spotify.com/reference/web-api/open-api-schema.yaml` - full OpenAPI 3.0 schema for the Spotify Web API.
+
+The OpenAPI schema declares the base server (`https://api.spotify.com/v1`), paths, parameters, response schemas, and OAuth requirements. If the official docs or schema disagree with this local reference, follow `developer.spotify.com`.
+
+Quick spec workflow:
+
+```shell
+SPEC_URL="https://developer.spotify.com/reference/web-api/open-api-schema.yaml"
+curl -fsSL "$SPEC_URL" -o spotify-openapi.yaml
+rg -n "^  /search:|operationId: search|get-an-album|get-an-artists-albums" spotify-openapi.yaml
+```
+
+## Getting a bearer token
+
+`save-to-spotify token` prints the current access token to stdout. That token has been verified to work as a Spotify Web API `Bearer` token for requests against `api.spotify.com`, so agents do not need a separate app registration for the catalog lookups below.
+
+Guard the call because it exits non-zero when the stored token cannot be refreshed:
+
+```shell
+if ! TOKEN=$(save-to-spotify token); then
+  echo "not authenticated; run: save-to-spotify auth login" >&2
+  exit 1
+fi
+```
+
+For a quick auth smoke test against the catalog API:
+
+```shell
+curl -sfG "https://api.spotify.com/v1/search" \
+  -H "Authorization: Bearer $TOKEN" \
+  --data-urlencode "q=artist:The Beatles" \
+  --data-urlencode "type=artist" \
+  --data-urlencode "limit=1" >/dev/null
+```
+
+No extra scope grant is needed for public catalog search and metadata lookups. Check the OpenAPI `security` entries before using user-private data or mutating endpoints.
+
+## Resolving names to Spotify URIs
+
+Pattern: `GET /v1/search?q=<query>&type=<entity>&limit=5`, then pick the best match from `.<entity>s.items`.
+
+For albums and tracks, use field-qualified queries (`artist:X album:Y` or `artist:X track:Y`) for higher precision than free text:
+
+```shell
+TOKEN=$(save-to-spotify token) || exit 1
+curl -sG "https://api.spotify.com/v1/search" \
+  -H "Authorization: Bearer $TOKEN" \
+  --data-urlencode "q=artist:The Beatles album:Abbey Road" \
+  --data-urlencode "type=album" \
+  --data-urlencode "limit=5" \
+| jq '.albums.items[] | {uri, name, release_date, artists: [.artists[].name]}'
+```
+
+Minimal dependency-free Python wrapper:
+
+```python
+import json
+import subprocess
+from urllib.parse import urlencode
+from urllib.request import Request, urlopen
+
+API = "https://api.spotify.com/v1"
+
+def spotify_token():
+    return subprocess.run(
+        ["save-to-spotify", "token"],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+
+def spotify_get(path, params):
+    url = f"{API}{path}?{urlencode(params)}"
+    req = Request(url, headers={"Authorization": f"Bearer {spotify_token()}"})
+    with urlopen(req, timeout=20) as resp:
+        return json.load(resp)
+
+def spotify_search(query, entity_type, limit=5):
+    data = spotify_get("/search", {"q": query, "type": entity_type, "limit": limit})
+    return data.get(f"{entity_type}s", {}).get("items", [])
+```
+
+For ambiguous names (self-titled albums, common words, cover-versus-original tracks), score each result before accepting it. Weight artist-name overlap, title overlap, and entity-specific metadata like `album_type`, `release_date`, `show.name`, or track duration. Drop the `spotify_entity` companion rather than ship a wrong URI when no result scores confidently.
+
+### Entity query patterns
+
+Albums and tracks support the field-qualified form above. Artists, playlists, shows, and episodes take free-text queries; feed the user-visible name and change the `type=` parameter:
+
+| Entity   | Query                      | `type=`    | Response path        | Output URI             |
+|----------|----------------------------|------------|----------------------|------------------------|
+| Album    | `artist:X album:Y`         | `album`    | `.albums.items[]`    | `spotify:album:...`    |
+| Track    | `artist:X track:Y`         | `track`    | `.tracks.items[]`    | `spotify:track:...`    |
+| Artist   | `X` (name)                 | `artist`   | `.artists.items[]`   | `spotify:artist:...`   |
+| Playlist | `X` (name)                 | `playlist` | `.playlists.items[]` | `spotify:playlist:...` |
+| Show     | `X` (name)                 | `show`     | `.shows.items[]`     | `spotify:show:...`     |
+| Episode  | `show title episode title` | `episode`  | `.episodes.items[]`  | `spotify:episode:...`  |
+
+Podcast episode results are noisier than track and album search; verify the top hit's `show.name` field before accepting.
+
+## Useful catalog endpoints
+
+Use the OpenAPI schema before expanding this list, but these are the common calls for timeline entity resolution:
+
+| Need                                      | Endpoint                                                                          |
+|-------------------------------------------|-----------------------------------------------------------------------------------|
+| Search any catalog type                   | `GET /v1/search?q=...&type=album,track,artist,playlist,show,episode`              |
+| Full album / track / artist metadata      | `GET /v1/albums/{id}`, `GET /v1/tracks/{id}`, or `GET /v1/artists/{id}`           |
+| Artist's recent albums, excluding singles | `GET /v1/artists/{id}/albums?include_groups=album&limit=50`                       |
+| Playlist metadata and tracks              | `GET /v1/playlists/{id}`                                                          |
+| Show / episode metadata                   | `GET /v1/shows/{id}` or `GET /v1/episodes/{id}` with `market=<ISO country>`       |
+| Show's episode list                       | `GET /v1/shows/{id}/episodes?market=<ISO country>&limit=50`                       |
+| New Releases, editorial albums only       | `GET /v1/browse/new-releases?country=US&limit=50`                                 |
+
+For endpoints with a `market` parameter, use an ISO 3166-1 alpha-2 country code when needed. With a valid user access token, the country associated with the user account takes priority over the query parameter; see the OpenAPI `QueryMarket` parameter before adding market-specific logic.
+
+## Fallbacks and non-Spotify data
+
+When sourcing a Spotify-native reference, the fallback hierarchy is:
+
+1. Spotify Web API - primary. Always try it first when auth is valid.
+2. No entity - omit the `spotify_entity` companion rather than invent or guess a URI.
+
+If Spotify auth fails, fix auth first with `save-to-spotify auth login`. Do not substitute for other third-party catalogs as the timeline destination just because auth failed. Those sources can help verify dates, credits, or artwork, but they do not produce the `spotify:...` URI the Now Playing View needs.
+
+## Rate limits
+
+Spotify's Web API is rate-limited per token; a sensible guardrail is about 10 req/s with small jitter. On HTTP 429, honor the `Retry-After` header. A typical episode's 10-20 lookups are well under the limit.

--- a/plugins/save-to-spotify/skills/save-to-spotify/references/timeline.md
+++ b/plugins/save-to-spotify/skills/save-to-spotify/references/timeline.md
@@ -1,0 +1,161 @@
+# Timeline Format
+
+Reference for building `timeline.json` -- the chapter markers and in-player companion content (images, external source links, Spotify entity cards) that ride alongside every episode.
+
+## Save the timeline
+
+After saving, push a single `timeline.json` that carries chapters and all companions in one call:
+
+```shell
+save-to-spotify --json timeline set \
+  --episode-id <EPISODE_URI> \
+  --from-file timeline.json
+```
+
+Verify: `save-to-spotify --json timeline get <EPISODE_ID>`. Delete: `save-to-spotify --json timeline delete <EPISODE_ID>`.
+
+## Verifying a pushed timeline
+
+Three backend behaviors make a successful `timeline set` look like a failure. Expect all three:
+
+1. `timeline set` returns an empty body on success. The response is `{"items":null}`, not an echo of what was stored. Do not infer from this response whether companions landed -- call `timeline get` to check.
+2. Companions propagate slower than chapters. `episodes status = READY` only confirms the audio is processable. Chapter markers appear shortly after, but `link`, `image`, and `spotify_entity` companions can take an additional 60-90 seconds. A `timeline get` immediately after `READY` may show chapters without their companions -- that's propagation lag, not data loss. Wait 60-90 seconds past `READY` before fetching.
+3. `timeline get` does not echo `url` fields. For image and link companions, the CLI response omits `url` and keeps the opaque `"companion_uri": "time-synced:companion-external-link:<hash>"`. The URL is stored on the backend and clients tap through to it correctly - it is just not echoed back on read. A non-empty `companion_uri` at the expected timestamp is the proof the link is live. Do not diff the fetched URL against what you sent.
+
+If links or images are genuinely missing after a 2-3 minute wait, re-push `timeline set` -- the endpoint is idempotent and replaces the full timeline on PUT.
+
+## Data model
+
+Each entry in `items` is one of four kinds: `chapter`, `image`, `link`, or `spotify_entity`. A single time window (say, one chapter's span) can contain *multiple* companion items; they only have to not overlap in time with each other. Chapters are independent and do not overlap with companions.
+
+```json
+{
+  "items": [
+    {"chapter": {"title": "Course intro & syllabus", "start_time_ms": 0}},
+    {"chapter": {"title": "Lecture 3: Backpropagation", "start_time_ms": 18000}},
+    {"image":   {"start_time_ms": 25000, "duration_ms": 15000, "image": "img_01_a.jpg", "url": "https://example.edu/cs231n/lecture3", "title": "Slide: chain rule diagram"}},
+    {"spotify_entity": {"start_time_ms": 45000, "duration_ms": 20000, "uri": "spotify:episode:2abc3def4ghi"}},
+    {"image":   {"start_time_ms": 70000, "duration_ms": 20000, "image": "img_01_b.jpg", "title": "Slide: computation graph"}},
+    {"chapter": {"title": "Worked example: 2-layer net", "start_time_ms": 102000}},
+    {"spotify_entity": {"start_time_ms": 110000, "uri": "spotify:track:4uLU6hMCjMI75M1A2tKUQC"}},
+    {"link":    {"start_time_ms": 130000, "duration_ms": 25000, "url": "https://example.edu/readings/goodfellow-ch6.pdf"}},
+    {"image":   {"start_time_ms": 160000, "duration_ms": 20000, "image": "img_02_a.jpg"}},
+    {"chapter": {"title": "Recap & problem set", "start_time_ms": 270000}}
+  ]
+}
+```
+
+## Validation rules
+
+Rules are checked both client-side and on the backend:
+
+- Chapters: at least 2, first at `0 ms`, strictly increasing `start_time_ms`, `title` required, `description` optional. Every `start_time_ms` must be strictly less than the episode's audio duration -- the CLI and backend can't verify this, so compute timestamps from cumulative segment durations and assert against the assembled MP3 before `timeline set` (see [audio-providers.md](audio-providers.md) "Timeline timestamp calculation").
+- Images: positive `duration_ms`, local file path in `image` (`.jpg`/`.png`, <= 1 MB, dimensions 1x1..4096x4096). Optional `url` (tap-through) and `title` (alt text). Only include images the user has rights to upload to Spotify's image store. When an image is tied to one canonical source URL, default to setting that URL here.
+- Links: positive `duration_ms`, valid HTTP(S) `url`.
+- Spotify entities: `uri` is required and must be a full `spotify:...` URI. `duration_ms` is optional, but when present it must be positive. Use this for Spotify-native references such as tracks, albums, artists, playlists, shows, episodes, and audiobook/catalog entities.
+- Companion non-overlap: sort images, links, and `spotify_entity` items by `start_time_ms`; each item's `start + duration` must be <= the next item's `start`. A `spotify_entity` without `duration_ms` behaves like an instantaneous card at that timestamp. Chapters are *not* included in this check -- a chapter can start at any time, including inside a companion's window.
+- URI format: in `timeline.json`, `spotify_entity.uri` must be a full Spotify URI (`spotify:track:...`, `spotify:artist:...`, `spotify:episode:...`). Do not use bare IDs or `open.spotify.com` URLs there.
+- Titles on chapters should match the description timestamps (they land in the show-notes HTML).
+
+## Companion selection rules
+
+Preference order: if the thing you want listeners to open already exists on Spotify, add a `spotify_entity`. Keep `link` for off-Spotify destinations, and include both when you want listeners to have both the Spotify destination and the original source/article.
+
+No duplicate artwork: when a `spotify_entity` is present, do NOT add an `image` of the same entity's artwork -- the card already renders it. Only pair an `image` with a `spotify_entity` when the image is editorially distinct (chart, infographic, screenshot).
+
+Image + link default: if you have a representative image plus one canonical source URL for the same story, prefer one `image` item with `url` set. Use standalone `link` for additional URLs, or when there is no good image. Use standalone `image` only when there is no meaningful destination.
+
+## Placing companions inside a chapter
+
+For a chapter spanning `[chapter_start, chapter_end)`, place N companions by dividing the window into N equal slots (or picking natural anchor points in the script). Keep a short buffer (e.g., 1 second) between companions to avoid edge-case overlaps. A practical helper is in [audio-providers.md](audio-providers.md) under "Timeline timestamp calculation".
+
+## Companion images: sourced, AI-generated, or mixed
+
+The agent asked the user in the interview where companion images should come from. Follow that choice consistently across the episode:
+
+- AI-generated -- after scripting, generate images from a themed prompt derived from each segment's content. Use this only when the user explicitly opts in to image generation and any provider cost/policy implications. Use the DALL-E / Stable Diffusion code under "Batch generation for timeline companions" below. Use the same naming pattern as above.
+- Mixed -- sourced where the user has reuse/upload rights, AI-generated fill only when the user explicitly opted into generation. Aim for at least one image per chapter.
+- Sourced -- user-provided or authorized source images only.
+- Skip -- emit a timeline with chapters plus Spotify and external-link companions only.
+
+If the mode is `Sourced` or `Mixed`, attempt image extraction only from user-provided material or sources the user has rights to reuse and upload. When a usable authorized source image is found, include it in the timeline unless the user explicitly opted out later. Only omit an image companion when the source genuinely has no meaningful authorized visual, or the user chose `Skip`.
+
+The CLI's `timeline set` uploads each local image file to Spotify's image store, swaps the file path for the returned upload token, and sends the timeline to the backend. No separate image-upload step is needed, so treat every timeline image as published account content.
+
+## AI image generation
+
+When the user explicitly picks `AI-generated` or opts into generated fill for `Mixed`, generate images with their preferred model. Constraints for timeline companions: JPEG/PNG, up to 4096x4096, max 1 MB each.
+
+### OpenAI DALL-E
+
+```python
+from openai import OpenAI
+client = OpenAI()
+response = client.images.generate(
+    model="dall-e-3",
+    prompt="A clean, minimal illustration of distributed systems architecture, dark background, tech aesthetic",
+    size="1024x1024",
+    quality="standard",
+    n=1,
+)
+import urllib.request
+urllib.request.urlretrieve(response.data[0].url, "img.png")
+```
+
+### Stable Diffusion (local)
+
+```shell
+python3 -c "
+from diffusers import StableDiffusionPipeline
+pipe = StableDiffusionPipeline.from_pretrained('stabilityai/stable-diffusion-xl-base-1.0')
+image = pipe('A clean illustration of neural networks, minimal, dark background').images[0]
+image.save('img.png')
+"
+```
+
+### Resizing with ffmpeg
+
+```shell
+# Square companion under 1 MB, within 4096x4096
+ffmpeg -i raw.png -vf "scale=1400:1400:force_original_aspect_ratio=decrease" -q:v 3 img_01_a.jpg
+```
+
+### Batch generation for timeline companions
+
+Generate one or more images per chapter from a themed prompt. File naming must match what the timeline builder expects: `img_<chapter_index>_<slot>.jpg` (slots `a`, `b`, `c` for multiple images inside one chapter).
+
+```python
+from openai import OpenAI
+import urllib.request, subprocess, string
+
+client = OpenAI()
+
+# One entry per chapter; each item lists the visual prompts for that chapter's slots
+chapter_images = [
+    ("Introduction",             []),  # no companions for intro
+    ("Chapter A",                [
+        "Neutral map of Eastern Europe, minimal, muted colors",
+        "Wide shot of a damaged street, documentary photo, no text",
+    ]),
+    ("Chapter B",                [
+        "Empty supermarket shelves, documentary photo, overcast light",
+    ]),
+    ("Sign-off",                 []),
+]
+
+for idx, (_, prompts) in enumerate(chapter_images):
+    for slot_letter, prompt in zip(string.ascii_lowercase, prompts):
+        resp = client.images.generate(model="dall-e-3", prompt=prompt,
+                                      size="1024x1024", quality="standard", n=1)
+        tmp = f"/tmp/raw_{idx}_{slot_letter}.png"
+        urllib.request.urlretrieve(resp.data[0].url, tmp)
+        out = f"img_{idx:02d}_{slot_letter}.jpg"
+        # Downsize + re-encode to guarantee <= 1 MB, <= 4096x4096, .jpg
+        subprocess.check_call([
+            "ffmpeg", "-y", "-i", tmp,
+            "-vf", "scale=1400:1400:force_original_aspect_ratio=decrease",
+            "-q:v", "3", out,
+        ])
+```
+
+For Stable Diffusion, swap the `client.images.generate` call for `pipe(prompt).images[0].save(tmp)` from the SDXL example above. Keep the same file-naming convention so the timeline builder in [audio-providers.md](audio-providers.md) picks the files up automatically.


### PR DESCRIPTION
## Save to Spotify

This adds a `save-to-spotify` plugin for turning source material into polished audio episodes and saving them to Spotify through the `save-to-spotify` CLI.

The plugin is intentionally skills-only. Installing it does not register MCP servers, start local services, write MCP settings, or run the Spotify CLI. It gives Cline a detailed workflow pack for interviewing the user, planning an episode, producing narrated audio, building show notes, preparing cover art, creating rich timeline companions, resolving Spotify catalog URIs, and uploading once the user has explicitly confirmed the destination and actions.

## Cline Primitives

- `skills`: bundles the `save-to-spotify` skill plus reference docs for CLI usage, Spotify Web API catalog lookup, TTS/audio assembly, cover image generation, timeline construction, episode description HTML, and content quality guidance.

The copied workflow is adapted for Cline with extra safety guidance around installer commands, OAuth, access tokens, uploads, show creation, timeline updates, paid TTS/image generation, third-party source fetching, source rights, and generated media handling.

## Requirements

Users need the `save-to-spotify` CLI installed before any real upload workflow can run. The skill shows install options, but Cline should not run remote installer commands unless the user explicitly asks it to run that exact command.

Spotify authentication is handled by the CLI. OAuth and token commands are treated as sensitive because they can open a browser, write local auth state, refresh tokens, or print bearer tokens.

Generated audio workflows require a user-selected TTS provider plus `ffmpeg`/`ffprobe`. Paid or external providers such as OpenAI, ElevenLabs, image APIs, or cloud TTS must be explicitly selected by the user before commands run.

Uploads require rights to transform the source content and upload any media/images to Spotify. The workflow avoids implicit show selection: Cline should use a user-confirmed `--show-id` or `--new-show`, not the CLI's most-recent-show fallback.
