### PR TITLE
feat: add serena plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Each plugin lives in `plugins/<slug>`. The directory name is the install keyword
 | `linear` | Linear SDK scripting skill for issue, project, team, cycle, and comment workflows. |
 | `mac-notify` | macOS notifications when a Cline run completes. |
 | `nanobanana` | Image generation through OpenRouter and Gemini image models. |
+| `serena` | Serena semantic code analysis MCP server for symbol-aware codebase navigation. |
 | `speak` | Speaks completed Cline replies with ElevenLabs text to speech. |
 | `typescript-lsp` | TypeScript language service `goto_definition` support. |
 | `weather-metrics` | Demo weather tool plus runtime metrics hooks. |

--- a/plugins/serena/README.md
+++ b/plugins/serena/README.md
@@ -1,0 +1,49 @@
+# serena
+
+Use Serena from Cline for semantic code analysis, symbol-aware navigation, and refactoring assistance through an MCP server.
+
+## What It Does
+
+This plugin registers the `serena` MCP server. The server runs in the current workspace so its codebase navigation and symbol-analysis tools inspect the user's project rather than the installed plugin package.
+
+## Install
+
+```bash
+cline plugin install serena
+```
+
+For local development from this repository:
+
+```bash
+cline plugin install ./plugins/serena --cwd .
+```
+
+## Example Usage
+
+After installation, ask Cline:
+
+```text
+Use Serena to inspect the symbol relationships around this service before we refactor it.
+```
+
+```text
+Use Serena to find likely callers of this function and summarize the safest change plan.
+```
+
+Cline can call Serena MCP tools when it needs symbol-aware codebase navigation and semantic context.
+
+## Requirements
+
+Requires `uvx` on the user's PATH. The MCP server runs through:
+
+```bash
+uvx --from serena-agent==1.5.3 serena start-mcp-server
+```
+
+First use can require network access while `uvx` downloads the pinned `serena-agent` package and its Python dependencies.
+
+## Security Notes
+
+Serena inspects the current workspace through language-server-style analysis and may provide refactoring guidance. Review proposed source edits normally before applying them to sensitive or untrusted projects.
+
+The plugin does not store credentials or write MCP settings outside Cline's plugin-owned MCP registration flow.

--- a/plugins/serena/index.ts
+++ b/plugins/serena/index.ts
@@ -1,0 +1,36 @@
+import type { AgentPlugin } from "@cline/sdk"
+
+const plugin: AgentPlugin = {
+	name: "serena",
+	manifest: {
+		capabilities: ["mcp"],
+	},
+
+	setup(api, ctx) {
+		const workspaceRoot = ctx.workspaceInfo?.rootPath
+		if (!workspaceRoot) {
+			return
+		}
+
+		api.registerMcpServer({
+			name: "serena",
+			transport: {
+				type: "stdio",
+				command: "uvx",
+				args: [
+					"--from",
+					"serena-agent==1.5.3",
+					"serena",
+					"start-mcp-server",
+				],
+				cwd: workspaceRoot,
+			},
+			metadata: {
+				description:
+					"Semantic code analysis, symbol-aware codebase navigation, and refactoring assistance for the current workspace.",
+			},
+		})
+	},
+}
+
+export default plugin


### PR DESCRIPTION
## Serena

This adds a Cline-native `serena` plugin that exposes Serena's semantic code analysis MCP server to Cline. The server runs with the current Cline workspace as its working directory, so symbol-aware navigation and codebase analysis target the user's project rather than the installed plugin package.

The port is intentionally MCP-only. Serena already provides the tool surface; the Cline plugin keeps the local shape small and avoids adding extra commands, skills, hooks, or prompt rules around it.

## Cline Primitives

- `mcp`: registers the `serena` MCP server over stdio using `uvx --from serena-agent==1.5.3 serena start-mcp-server`.

## Requirements

Requires `uvx` on the user's PATH. First use can require network access while `uvx` downloads the pinned `serena-agent` package and its Python dependencies.

Serena inspects the current workspace through language-server-style analysis and can provide refactoring guidance. Users should review proposed source edits normally before applying them to sensitive or untrusted projects. The plugin does not store credentials or write MCP settings outside Cline's plugin-owned MCP registration flow.
