### PR TITLE
feat: add servicenow-sdk plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Each plugin lives in `plugins/<slug>`. The directory name is the install keyword
 | `linear` | Linear SDK scripting skill for issue, project, team, cycle, and comment workflows. |
 | `mac-notify` | macOS notifications when a Cline run completes. |
 | `nanobanana` | Image generation through OpenRouter and Gemini image models. |
+| `servicenow-sdk` | ServiceNow Fluent SDK documentation guidance through the `now-sdk` explain workflow. |
 | `speak` | Speaks completed Cline replies with ElevenLabs text to speech. |
 | `typescript-lsp` | TypeScript language service `goto_definition` support. |
 | `weather-metrics` | Demo weather tool plus runtime metrics hooks. |

--- a/plugins/servicenow-sdk/README.md
+++ b/plugins/servicenow-sdk/README.md
@@ -1,0 +1,43 @@
+# servicenow-sdk
+
+Bundle ServiceNow Fluent SDK documentation guidance as an installable Cline plugin.
+
+## What It Does
+
+Installs the `now-sdk-explain` skill. The skill guides Cline to use `npx @servicenow/sdk explain` before creating, editing, building, or deploying ServiceNow Fluent SDK applications, with a peek-first workflow to avoid loading the wrong documentation topic.
+
+## Install
+
+```bash
+cline plugin install servicenow-sdk
+```
+
+For local development from this repository:
+
+```bash
+cline plugin install ./plugins/servicenow-sdk --cwd .
+```
+
+## Example Usage
+
+After installation, ask Cline:
+
+```text
+Use the ServiceNow SDK docs to add a BusinessRule to this Fluent app.
+```
+
+```text
+Explain the right Fluent SDK structure before we create a new table.
+```
+
+Cline automatically uses the `now-sdk-explain` skill when ServiceNow, Fluent, or `now-sdk` work comes up.
+
+## Requirements
+
+- Node and `npx` available.
+- `@servicenow/sdk` version 4.6.0 or newer when using the `explain` command.
+- ServiceNow credentials or instance access only when the user asks to authenticate, deploy, transform, or perform other live instance operations.
+
+## Security Notes
+
+The documentation lookup command can download the ServiceNow SDK package through `npx`. ServiceNow instance URLs, credentials, OAuth tokens, and generated app artifacts should be treated as sensitive and should not be printed, committed, or persisted without explicit user approval.

--- a/plugins/servicenow-sdk/index.ts
+++ b/plugins/servicenow-sdk/index.ts
@@ -1,0 +1,10 @@
+import type { AgentPlugin } from "@cline/sdk"
+
+const plugin: AgentPlugin = {
+	name: "servicenow-sdk",
+	manifest: {
+		capabilities: ["skills"],
+	},
+}
+
+export default plugin

--- a/plugins/servicenow-sdk/package.json
+++ b/plugins/servicenow-sdk/package.json
@@ -1,0 +1,19 @@
+{
+	"name": "servicenow-sdk",
+	"version": "0.0.0",
+	"private": true,
+	"type": "module",
+	"description": "Cline plugin that bundles ServiceNow Fluent SDK documentation guidance.",
+	"cline": {
+		"plugins": [
+			{
+				"paths": [
+					"./index.ts"
+				],
+				"capabilities": [
+					"skills"
+				]
+			}
+		]
+	}
+}

--- a/plugins/servicenow-sdk/skills/now-sdk-explain/SKILL.md
+++ b/plugins/servicenow-sdk/skills/now-sdk-explain/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: now-sdk-explain
+description: Use whenever the user mentions ServiceNow Fluent, ServiceNow SDK, or now-sdk, OR when the user prompts for edits within a ServiceNow Fluent application (identified by a now.config.json at the project root). Fetches SDK documentation via now-sdk explain - covers API types, metadata conventions, skills, and project structure. Pass a topic to read it directly, or omit to browse available topics.
+---
+
+
+## Usage
+
+IMPORTANT: Never open a full topic without first viewing the summary via the `--peek` option. This will prevent you from accidentally opening the wrong topic and wasting context space.
+
+To show all available topics with their related tags:
+```bash
+npx @servicenow/sdk explain --list --format=raw
+```
+
+To search for topics, showing the descriptions of all matches:
+```bash
+npx @servicenow/sdk explain <topic> --list --peek --format=raw
+```
+
+To preview topics using the `--peek` option:
+```bash
+npx @servicenow/sdk explain <topic> --peek --format=raw
+```
+
+Once you are certain you want to read the full topic, open it like this:
+```bash
+npx @servicenow/sdk explain <topic> --format=raw
+```
+
+## What to Search for
+
+- Metadata types - `BusinessRule`, `Table`, `Acl`, `Flow`, `ScriptInclude`, `ClientScript`
+- Skills - workflows like `build`, `transform`, `deploy`, `auth`
+- Conventions - `naming`, `structure`, `scoping`, `file-layout`
+
+## Prerequisite knowledge and guidelines
+
+- The first time this skill is invoked in a session, please familiarize yourself with general ServiceNow Fluent development by reading everything under `npx @servicenow/sdk explain quickstart --list --format=raw`.
+- Always use the `npx @servicenow/sdk` CLI commands whenever possible to create, build, and deploy ServiceNow Fluent projects.
+- If the `npx @servicenow/sdk explain` command fails, check the version of the SDK and upgrade if necessary. `explain` is mandatory for this skill and only available in versions >= `4.6.0`.
+
+## For any task - always start here
+
+- Start by searching for topics using `npx @servicenow/sdk explain <search-term> --list --format=raw`.
+- Continue by reading the relevant topics, always using `npx @servicenow/sdk explain <topic> --peek --format=raw`, to preview the description before committing to read the full topic.
+- Provided the description is relevant, continue to read the full topic using `npx @servicenow/sdk explain <topic> --format=raw`.
+- Many items are spread out across multiple topics. As such, it is very important to read all relevant topics before making any changes.
+
+## If a now-sdk command fails
+
+- `No documentation found for "<topic>"` - wrong topic name, try `--list`
+- `No match for "<topic>"` - use a different search term
+
+## Cline safety notes
+
+- Ask before installing or upgrading the ServiceNow SDK package globally or changing project dependencies. Using `npx @servicenow/sdk explain ...` for documentation lookup is acceptable because it is the documented command path for this workflow.
+- Ask before running ServiceNow commands that authenticate, deploy, transform, create records on an instance, or otherwise mutate a ServiceNow environment.
+- Treat ServiceNow instance URLs, credentials, OAuth tokens, and generated app artifacts as sensitive. Do not print, commit, or persist them without explicit user approval.


### PR DESCRIPTION
## ServiceNow SDK

This adds a Cline-native `servicenow-sdk` plugin for ServiceNow Fluent SDK work. It bundles a `now-sdk-explain` skill that guides Cline to use the ServiceNow SDK's `explain` command before creating, editing, building, or deploying Fluent applications.

The skill is intentionally documentation-first: it tells Cline to list and peek at relevant `now-sdk explain` topics before loading the full topic, so ServiceNow app changes are grounded in SDK docs instead of guessed from memory.

## Cline Primitives

- `skills`: bundles `now-sdk-explain`, a ServiceNow Fluent SDK workflow skill for discovering SDK documentation topics, previewing topic summaries, reading full docs only after confirming relevance, and using the SDK CLI for Fluent project workflows.

## Requirements

Requires Node and `npx`. The `explain` workflow requires `@servicenow/sdk` version 4.6.0 or newer, and the documentation lookup command can download the SDK package through `npx`.

Live ServiceNow work can require instance access, credentials, or OAuth tokens. The skill asks before authentication, deploys, transforms, record creation, or other live instance mutations, and treats ServiceNow instance URLs, credentials, tokens, and generated app artifacts as sensitive.
