### PR TITLE
feat: add session-report plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ Each plugin lives in `plugins/<slug>`. The directory name is the install keyword
 | `linear` | Linear SDK scripting skill for issue, project, team, cycle, and comment workflows. |
 | `mac-notify` | macOS notifications when a Cline run completes. |
 | `nanobanana` | Image generation through OpenRouter and Gemini image models. |
+| `session-report` | Static HTML usage report from local Cline session artifacts. |
 | `speak` | Speaks completed Cline replies with ElevenLabs text to speech. |
 | `typescript-lsp` | TypeScript language service `goto_definition` support. |
 | `weather-metrics` | Demo weather tool plus runtime metrics hooks. |

--- a/plugins/session-report/LICENSE
+++ b/plugins/session-report/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/plugins/session-report/README.md
+++ b/plugins/session-report/README.md
@@ -1,0 +1,29 @@
+# session-report
+
+Generate a static HTML report from local Cline session artifacts.
+
+## What It Does
+
+This plugin bundles the `session-report` skill with a local Node analyzer and an HTML template. When the user asks for a report, Cline can scan local session message files, summarize token usage, cache behavior, expensive prompts, subagent sessions, project totals, and slash-command/tool activity, then write a self-contained HTML file in the current workspace.
+
+## Requirements
+
+- Local Cline session artifacts under `CLINE_SESSION_DATA_DIR` or `~/.cline/data/sessions`.
+- Node.js to run the bundled analyzer.
+- No API keys, MCP servers, network access, or third-party services.
+
+## Privacy
+
+The analyzer reads local persisted Cline message files. Reports can include user prompts and nearby transcript context, so review the generated HTML before sharing it.
+
+## Install
+
+```bash
+cline plugin install session-report
+```
+
+For local development from this repository:
+
+```bash
+cline plugin install ./plugins/session-report --cwd .
+```

--- a/plugins/session-report/index.ts
+++ b/plugins/session-report/index.ts
@@ -1,0 +1,10 @@
+import type { AgentPlugin } from "@cline/sdk"
+
+const plugin: AgentPlugin = {
+	name: "session-report",
+	manifest: {
+		capabilities: ["skills"],
+	},
+}
+
+export default plugin

--- a/plugins/session-report/package.json
+++ b/plugins/session-report/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "session-report",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Cline plugin that bundles a local session usage report skill.",
+  "cline": {
+    "plugins": [
+      {
+        "paths": [
+          "./index.ts"
+        ],
+        "capabilities": [
+          "skills"
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/session-report/skills/session-report/SKILL.md
+++ b/plugins/session-report/skills/session-report/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: session-report
+description: Generate an explorable HTML report of local Cline session usage from persisted session artifacts.
+---
+
+# Session Report
+
+Produce a self-contained HTML report of local Cline usage and save it to the current working directory.
+
+## Steps
+
+1. Get data. Run the bundled analyzer. The default window is the last 7 days; honor a different range if the user passed one, such as `24h`, `30d`, or `all`. The script `analyze-sessions.mjs` lives in the same directory as this SKILL.md, so use its absolute path:
+   ```sh
+   REPORT_JSON=$(mktemp "${TMPDIR:-/tmp}/cline-session-report.XXXXXX.json")
+   node <skill-dir>/analyze-sessions.mjs --json --since 7d > "$REPORT_JSON"
+   ```
+   For all-time, pass `--since all`.
+
+   The analyzer reads `CLINE_SESSION_DATA_DIR` when set, otherwise `~/.cline/data/sessions`. Use `--dir <path>` only when the user explicitly points you at a different Cline session data directory.
+
+2. Read `$REPORT_JSON`. Skim `scan`, `overall`, `by_project`, `by_subagent_type`, `by_skill`, `cache_breaks`, and `top_prompts`. If `scan.message_files_read` is `0`, tell the user which directory was scanned and stop unless they provide a different Cline session data directory.
+
+3. Copy the template, which is also bundled alongside this SKILL.md, to the output path in the current working directory:
+   ```sh
+   cp <skill-dir>/template.html ./session-report-$(date +%Y%m%d-%H%M).html
+   ```
+
+4. Edit the output file. Preserve the template's JS/CSS:
+   - Replace the contents of `<script id="report-data" type="application/json">` with the full JSON from step 1. The page's JS renders the hero total, all tables, bars, and drill-downs from this blob automatically.
+   - Fill the `<!-- AGENT: anomalies -->` block with 3-5 one-line findings. Express figures as a percentage of total tokens wherever possible. Total tokens are `overall.input_tokens.total + overall.output_tokens`. One line per finding, exact markup:
+     ```html
+     <div class="take bad"><div class="fig">41.2%</div><div class="txt"><b>cc-monitor</b> consumed 41% of the week across just 3 sessions</div></div>
+     ```
+     Classes: `.take bad` for waste/anomalies (red), `.take good` for healthy signals (green), `.take info` for neutral facts (blue). The `.fig` is one short number (a %, a count, or a multiplier like `12x`). The `.txt` is one plain-English sentence naming the project/skill/prompt; wrap the subject in `<b>`. Look for: a project or skill eating a disproportionate share, cache-hit <85%, a single prompt >2% of total, subagent types averaging >1M tokens/call, cache breaks clustering.
+   - Fill the `<!-- AGENT: optimizations -->` block (at the bottom of the page) with 1-4 `<div class="callout">` suggestions tied to specific rows (e.g. "`/weekly-status` spawned 7 subagents for 8.1% of total - scope it to fewer parallel agents").
+   - Do not restructure existing sections.
+
+5. Report the saved file path to the user. Do not open it or render it.
+6. Delete `$REPORT_JSON` after the HTML report has been written.
+
+## Notes
+
+- The template is the source of interactivity (sorting, expand/collapse, block-char bars). Your job is data + narrative, not markup.
+- Keep commentary terse and specific - reference actual project names, numbers, timestamps from the JSON.
+- The analyzer JSON is escaped for safe embedding in an HTML script tag. Preserve those escape sequences when copying it into the template.
+- `top_prompts` attributes assistant metric rows to the closest preceding user message in the same persisted session.
+- Cline's `inputTokens` is already normalized as full input size. Do not add `cacheReadTokens` or `cacheWriteTokens` back on top when calculating totals.
+- If the JSON is >2MB, trim `top_prompts` to 100 entries and `cache_breaks` to 100 before embedding (they should already be capped).

--- a/plugins/session-report/skills/session-report/analyze-sessions.mjs
+++ b/plugins/session-report/skills/session-report/analyze-sessions.mjs
@@ -1,0 +1,571 @@
+#!/usr/bin/env node
+/* eslint-disable */
+/**
+ * Scans local Cline session artifacts and reports token usage, cache behavior,
+ * session timelines, subagent sessions, and expensive prompts.
+ *
+ * The analyzer reads the local file-session store:
+ *   $CLINE_SESSION_DATA_DIR or ~/.cline/data/sessions
+ *
+ * It intentionally does not query Cline cloud history. If the local session
+ * index is absent, the report is empty and explains which directory was read.
+ */
+
+import fs from "node:fs"
+import os from "node:os"
+import path from "node:path"
+
+const argv = process.argv.slice(2)
+
+function flag(name, dflt) {
+  const i = argv.indexOf(name)
+  if (i === -1) return dflt
+  const v = argv[i + 1]
+  return v === undefined || v.startsWith("--") ? true : v
+}
+
+const DEFAULT_ROOT =
+  process.env.CLINE_SESSION_DATA_DIR?.trim() ||
+  path.join(os.homedir(), ".cline", "data", "sessions")
+const ROOT = path.resolve(String(flag("--dir", DEFAULT_ROOT)))
+const AS_JSON = argv.includes("--json")
+const TOP_N = parseInt(String(flag("--top", "15")), 10)
+const SINCE_LABEL = flag("--since", "7d")
+const SINCE = parseSince(SINCE_LABEL)
+const CACHE_BREAK_THRESHOLD = parseInt(String(flag("--cache-break", "100000")), 10)
+
+function parseSince(value) {
+  if (!value || value === "all") return null
+  const m = /^(\d+)([dh])$/.exec(String(value))
+  if (m) {
+    const unitMs = m[2] === "d" ? 86400000 : 3600000
+    return new Date(Date.now() - Number(m[1]) * unitMs)
+  }
+  const d = new Date(String(value))
+  return Number.isNaN(d.getTime()) ? null : d
+}
+
+function readJson(file) {
+  try {
+    return JSON.parse(fs.readFileSync(file, "utf8"))
+  } catch {
+    return undefined
+  }
+}
+
+function num(value) {
+  return typeof value === "number" && Number.isFinite(value) ? value : 0
+}
+
+function pct(numerator, denominator) {
+  return denominator > 0 ? Number((100 * numerator / denominator).toFixed(1)) : 0
+}
+
+function hours(ms) {
+  return Number(Math.max(0, ms / 3600000).toFixed(2))
+}
+
+function projectName(row) {
+  return row?.workspaceRoot || row?.workspace_root || row?.cwd || "(unknown workspace)"
+}
+
+function rowStartedMs(row) {
+  const ms = Date.parse(row?.startedAt || row?.started_at || "")
+  return Number.isNaN(ms) ? undefined : ms
+}
+
+function rowEndedMs(row) {
+  const ms = Date.parse(row?.endedAt || row?.ended_at || row?.updatedAt || "")
+  return Number.isNaN(ms) ? undefined : ms
+}
+
+function rowSessionId(row) {
+  return row?.sessionId || row?.session_id || ""
+}
+
+function rowIsSubagent(row) {
+  return Boolean(row?.isSubagent || row?.is_subagent)
+}
+
+function rowAgentId(row) {
+  return row?.agentId || row?.agent_id || ""
+}
+
+function rowTeamName(row) {
+  return row?.teamName || row?.team_name || ""
+}
+
+function messageTs(message, fallbackMs) {
+  if (typeof message?.ts === "number" && Number.isFinite(message.ts)) {
+    return message.ts
+  }
+  const raw = message?.timestamp || message?.createdAt
+  const ms = Date.parse(raw || "")
+  return Number.isNaN(ms) ? fallbackMs : ms
+}
+
+function messageText(message) {
+  const content = message?.content
+  if (typeof content === "string") return content.trim()
+  if (!Array.isArray(content)) return ""
+  return content
+    .map((block) => {
+      if (typeof block === "string") return block
+      if (block?.type === "text" && typeof block.text === "string") return block.text
+      if (block?.text && typeof block.text === "string") return block.text
+      return ""
+    })
+    .filter(Boolean)
+    .join("\n")
+    .trim()
+}
+
+function toolNames(message) {
+  const content = message?.content
+  if (!Array.isArray(content)) return []
+  const names = []
+  for (const block of content) {
+    const name = block?.name || block?.toolName || block?.tool_name
+    if (
+      (block?.type === "tool_use" || block?.type === "tool-call" || block?.type === "tool_call") &&
+      typeof name === "string" &&
+      name.trim()
+    ) {
+      names.push(name.trim())
+    }
+  }
+  return names
+}
+
+function emptyStats() {
+  return {
+    sessionIds: new Set(),
+    api_calls: 0,
+    input_tokens: {
+      total: 0,
+      uncached: 0,
+      cache_create: 0,
+      cache_read: 0,
+      pct_cached: 0,
+    },
+    output_tokens: 0,
+    cost: 0,
+    human_messages: 0,
+    wall_ms: 0,
+    cache_breaks_over_100k: 0,
+    subagent: {
+      calls: 0,
+      tokens: 0,
+      avg_tokens_per_call: 0,
+    },
+    span_from: undefined,
+    span_to: undefined,
+  }
+}
+
+function touchSpan(stats, ms) {
+  if (!Number.isFinite(ms)) return
+  const iso = new Date(ms).toISOString()
+  if (!stats.span_from || iso < stats.span_from) stats.span_from = iso
+  if (!stats.span_to || iso > stats.span_to) stats.span_to = iso
+}
+
+function addSession(stats, row, sessionTokens) {
+  stats.sessionIds.add(rowSessionId(row) || "(unknown)")
+  const started = rowStartedMs(row)
+  const ended = rowEndedMs(row) ?? started
+  if (started !== undefined && ended !== undefined) {
+    stats.wall_ms += Math.max(0, ended - started)
+    touchSpan(stats, started)
+    touchSpan(stats, ended)
+  }
+  if (rowIsSubagent(row)) {
+    stats.subagent.calls += 1
+    stats.subagent.tokens += sessionTokens
+  }
+}
+
+function addUsage(stats, usage) {
+  stats.api_calls += 1
+  stats.input_tokens.total += usage.input
+  stats.input_tokens.uncached += usage.uncached
+  stats.input_tokens.cache_create += usage.cacheWrite
+  stats.input_tokens.cache_read += usage.cacheRead
+  stats.output_tokens += usage.output
+  stats.cost += usage.cost
+  if (usage.uncached >= CACHE_BREAK_THRESHOLD) {
+    stats.cache_breaks_over_100k += 1
+  }
+  touchSpan(stats, usage.ts)
+}
+
+function addPromptMessage(stats) {
+  stats.human_messages += 1
+}
+
+function finalizeStats(stats) {
+  const input = stats.input_tokens
+  input.pct_cached = pct(input.cache_read, input.total)
+  stats.sessions = stats.sessionIds.size
+  delete stats.sessionIds
+  stats.hours = {
+    wall_clock: hours(stats.wall_ms),
+    active: hours(stats.wall_ms),
+  }
+  delete stats.wall_ms
+  stats.subagent.avg_tokens_per_call =
+    stats.subagent.calls > 0
+      ? Math.round(stats.subagent.tokens / stats.subagent.calls)
+      : 0
+  stats.span = stats.span_from && stats.span_to
+    ? { from: stats.span_from, to: stats.span_to }
+    : null
+  delete stats.span_from
+  delete stats.span_to
+  return stats
+}
+
+function usageFromMessage(message, fallbackTs) {
+  const metrics = message?.metrics
+  if (!metrics) return undefined
+  const input = Math.max(0, num(metrics.inputTokens))
+  const output = Math.max(0, num(metrics.outputTokens))
+  const cacheRead = Math.max(0, num(metrics.cacheReadTokens))
+  const cacheWrite = Math.max(0, num(metrics.cacheWriteTokens))
+  if (input === 0 && output === 0 && cacheRead === 0 && cacheWrite === 0) {
+    return undefined
+  }
+  return {
+    input,
+    output,
+    cacheRead,
+    cacheWrite,
+    uncached: Math.max(0, input - cacheRead - cacheWrite),
+    cost: Math.max(0, num(metrics.cost)),
+    ts: messageTs(message, fallbackTs),
+  }
+}
+
+function slashCommand(text) {
+  const match = /^\/([a-zA-Z0-9][\w:-]*)\b/.exec(text.trim())
+  return match ? `/${match[1]}` : undefined
+}
+
+function contextAround(users, index) {
+  if (index < 0) return []
+  return users.slice(Math.max(0, index - 2), index + 3).map((item) => ({
+    text: item.text.slice(0, 1200),
+    ts: new Date(item.ts).toISOString(),
+    calls: item.calls,
+    here: item.index === index,
+  }))
+}
+
+function makeBucket(map, key) {
+  if (!map[key]) map[key] = emptyStats()
+  return map[key]
+}
+
+function sessionRowsFromIndex(root) {
+  const index = readJson(path.join(root, "sessions.index.json"))
+  if (index?.sessions && typeof index.sessions === "object") {
+    return Object.values(index.sessions)
+  }
+  const rows = []
+  for (const entry of safeReadDir(root)) {
+    if (!entry.isDirectory()) continue
+    const sessionId = entry.name
+    const manifestPath = path.join(root, sessionId, `${sessionId}.json`)
+    const manifest = readJson(manifestPath)
+    if (!manifest || typeof manifest !== "object") continue
+    rows.push(manifestToRow(manifest, sessionId))
+  }
+  return rows
+}
+
+function safeReadDir(dir) {
+  try {
+    return fs.readdirSync(dir, { withFileTypes: true })
+  } catch {
+    return []
+  }
+}
+
+function manifestToRow(manifest, fallbackSessionId) {
+  return {
+    ...manifest,
+    sessionId: manifest.sessionId || manifest.session_id || fallbackSessionId,
+    startedAt: manifest.startedAt || manifest.started_at,
+    endedAt: manifest.endedAt || manifest.ended_at,
+    updatedAt: manifest.updatedAt || manifest.updated_at,
+    workspaceRoot: manifest.workspaceRoot || manifest.workspace_root,
+    teamName: manifest.teamName || manifest.team_name,
+    agentId: manifest.agentId || manifest.agent_id,
+    isSubagent: manifest.isSubagent || manifest.is_subagent,
+    messagesPath: manifest.messagesPath || manifest.messages_path,
+  }
+}
+
+function discoverMessagePath(root, row) {
+  const configuredPath =
+    typeof row.messagesPath === "string" && row.messagesPath.trim()
+      ? row.messagesPath.trim()
+      : typeof row.messages_path === "string" && row.messages_path.trim()
+        ? row.messages_path.trim()
+        : ""
+  if (configuredPath) {
+    const absolute = path.isAbsolute(configuredPath)
+      ? configuredPath
+      : path.resolve(root, configuredPath)
+    if (fs.existsSync(absolute)) return absolute
+  }
+  const id = rowSessionId(row)
+  if (!id) return undefined
+  const candidate = path.join(root, id, `${id}.messages.json`)
+  return fs.existsSync(candidate) ? candidate : undefined
+}
+
+function loadSessions(root) {
+  const rows = sessionRowsFromIndex(root)
+  return rows.map((row) => ({
+    row,
+    messagesPath: discoverMessagePath(root, row),
+  }))
+}
+
+function dayKey(ms) {
+  return new Date(ms).toISOString().slice(0, 10)
+}
+
+function dayName(isoDate) {
+  return new Date(`${isoDate}T00:00:00.000Z`).toLocaleDateString("en-US", {
+    weekday: "short",
+    timeZone: "UTC",
+  })
+}
+
+function minuteOfDay(ms) {
+  const d = new Date(ms)
+  return d.getHours() * 60 + d.getMinutes()
+}
+
+function addDaySession(days, row, tokens) {
+  const started = rowStartedMs(row)
+  if (started === undefined) return
+  const ended = rowEndedMs(row) ?? started
+  const key = dayKey(started)
+  const bucket = days.get(key) || {
+    date: key,
+    dow: dayName(key),
+    tokens: 0,
+    sessions: [],
+    peak: 0,
+    peak_at_min: 0,
+  }
+  bucket.tokens += tokens
+  bucket.sessions.push({
+    id: rowSessionId(row),
+    project: projectName(row),
+    start_min: minuteOfDay(started),
+    end_min: Math.max(minuteOfDay(started) + 1, minuteOfDay(ended)),
+    tokens,
+  })
+  days.set(key, bucket)
+}
+
+function computePeaks(day) {
+  const events = []
+  for (const s of day.sessions) {
+    events.push([s.start_min, 1])
+    events.push([s.end_min, -1])
+  }
+  let cur = 0
+  for (const [minute, delta] of events.sort((a, b) => a[0] - b[0] || b[1] - a[1])) {
+    cur += delta
+    if (cur > day.peak) {
+      day.peak = cur
+      day.peak_at_min = minute
+    }
+  }
+  day.sessions.sort((a, b) => a.start_min - b.start_min)
+  return day
+}
+
+const overall = emptyStats()
+const byProject = {}
+const bySubagentType = {}
+const bySkill = {}
+const promptMap = new Map()
+const cacheBreaks = []
+const days = new Map()
+
+let rowsSeen = 0
+let filesRead = 0
+let messagesSeen = 0
+
+for (const { row, messagesPath } of loadSessions(ROOT)) {
+  rowsSeen += 1
+  const started = rowStartedMs(row)
+  if (SINCE && started !== undefined && started < SINCE.getTime()) {
+    continue
+  }
+
+  const payload = messagesPath ? readJson(messagesPath) : undefined
+  const messages = Array.isArray(payload?.messages) ? payload.messages : []
+  if (messagesPath && Array.isArray(payload?.messages)) filesRead += 1
+  messagesSeen += messages.length
+
+  const project = projectName(row)
+  const projectStats = makeBucket(byProject, project)
+  const subagentLabel = rowIsSubagent(row)
+    ? (rowAgentId(row) || rowTeamName(row) || row.source || "subagent")
+    : undefined
+  const subagentStats = subagentLabel
+    ? makeBucket(bySubagentType, subagentLabel)
+    : undefined
+
+  const users = []
+  let currentUserIndex = -1
+  let sessionTokens = 0
+
+  for (const message of messages) {
+    const fallbackTs = started ?? Date.now()
+    if (message?.role === "user") {
+      const text = messageText(message)
+      if (text) {
+        currentUserIndex = users.length
+        users.push({
+          index: currentUserIndex,
+          text,
+          ts: messageTs(message, fallbackTs),
+          calls: 0,
+        })
+        addPromptMessage(overall)
+        addPromptMessage(projectStats)
+        if (subagentStats) addPromptMessage(subagentStats)
+      }
+      continue
+    }
+
+    if (message?.role !== "assistant") continue
+    const usage = usageFromMessage(message, fallbackTs)
+    const tools = toolNames(message)
+    if (usage) {
+      sessionTokens += usage.input + usage.output
+      addUsage(overall, usage)
+      addUsage(projectStats, usage)
+      if (subagentStats) addUsage(subagentStats, usage)
+
+      const user = users[currentUserIndex]
+      if (user) {
+        user.calls += 1
+        const sessionId = rowSessionId(row)
+        const key = `${sessionId || "session"}:${user.index}`
+        const prompt = promptMap.get(key) || {
+          text: user.text,
+          ts: new Date(user.ts).toISOString(),
+          project,
+          session: sessionId,
+          api_calls: 0,
+          subagent_calls: rowIsSubagent(row) ? 1 : 0,
+          input: { uncached: 0, cache_create: 0, cache_read: 0 },
+          output: 0,
+          total_tokens: 0,
+          context: [],
+        }
+        prompt.api_calls += 1
+        prompt.input.uncached += usage.uncached
+        prompt.input.cache_create += usage.cacheWrite
+        prompt.input.cache_read += usage.cacheRead
+        prompt.output += usage.output
+        prompt.total_tokens += usage.input + usage.output
+        prompt.context = contextAround(users, user.index)
+        promptMap.set(key, prompt)
+
+        const command = slashCommand(user.text)
+        if (command) {
+          const commandStats = makeBucket(bySkill, command)
+          commandStats.human_messages += 1
+          addUsage(commandStats, usage)
+          commandStats.sessionIds.add(sessionId)
+        }
+
+        if (usage.uncached >= CACHE_BREAK_THRESHOLD) {
+          cacheBreaks.push({
+            ts: new Date(usage.ts).toISOString(),
+            session: sessionId,
+            project,
+            kind: rowIsSubagent(row) ? "subagent" : "main",
+            agentType: subagentLabel,
+            uncached: usage.uncached,
+            total: usage.input,
+            context: contextAround(users, user.index),
+          })
+        }
+      }
+    }
+
+    for (const tool of tools) {
+      const toolStats = makeBucket(bySkill, `tool:${tool}`)
+      toolStats.sessionIds.add(rowSessionId(row))
+      toolStats.api_calls += 1
+    }
+  }
+
+  addSession(overall, row, sessionTokens)
+  addSession(projectStats, row, sessionTokens)
+  if (subagentStats) addSession(subagentStats, row, sessionTokens)
+  addDaySession(days, row, sessionTokens)
+}
+
+const result = {
+  generated_at: new Date().toISOString(),
+  root: ROOT,
+  since: SINCE_LABEL === "all" ? null : SINCE_LABEL,
+  source: "cline-local-sessions",
+  scan: {
+    rows_seen: rowsSeen,
+    message_files_read: filesRead,
+    messages_seen: messagesSeen,
+  },
+  overall: finalizeStats(overall),
+  by_project: Object.fromEntries(
+    Object.entries(byProject).map(([key, value]) => [key, finalizeStats(value)])
+  ),
+  by_subagent_type: Object.fromEntries(
+    Object.entries(bySubagentType).map(([key, value]) => [key, finalizeStats(value)])
+  ),
+  by_skill: Object.fromEntries(
+    Object.entries(bySkill).map(([key, value]) => [key, finalizeStats(value)])
+  ),
+  by_day: [...days.values()].map(computePeaks).sort((a, b) => a.date.localeCompare(b.date)),
+  top_prompts: [...promptMap.values()]
+    .sort((a, b) => b.total_tokens - a.total_tokens)
+    .slice(0, TOP_N),
+  cache_breaks: cacheBreaks
+    .sort((a, b) => b.uncached - a.uncached)
+    .slice(0, 100),
+}
+
+function safeJsonForHtml(value) {
+  return JSON.stringify(value, null, 2)
+    .replace(/</g, "\\u003c")
+    .replace(/>/g, "\\u003e")
+    .replace(/&/g, "\\u0026")
+    .replace(/\u2028/g, "\\u2028")
+    .replace(/\u2029/g, "\\u2029")
+}
+
+if (AS_JSON) {
+  process.stdout.write(`${safeJsonForHtml(result)}\n`)
+} else {
+  const total = result.overall.input_tokens.total + result.overall.output_tokens
+  process.stdout.write([
+    `Cline session report source: ${ROOT}`,
+    `Sessions: ${result.overall.sessions}`,
+    `API calls: ${result.overall.api_calls}`,
+    `Tokens: ${total}`,
+    `Cache read: ${result.overall.input_tokens.pct_cached}% of input`,
+    `Message files read: ${result.scan.message_files_read}`,
+  ].join("\n") + "\n")
+}

--- a/plugins/session-report/skills/session-report/template.html
+++ b/plugins/session-report/skills/session-report/template.html
@@ -1,0 +1,566 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>cline usage</title>
+<style>
+  :root {
+    /* Cline terminal report palette */
+    --ivory: #FAF9F5;
+    --term-bg: #1a1918;
+    --term-fg: #d1cfc5;
+    --titlebar: #252321;
+    --outline: rgba(255,255,255,0.08);
+    --hover: rgba(255,255,255,0.035);
+    --clay: #D97757;
+    --dim: rgb(136,136,136);
+    --subtle: rgb(80,80,80);
+    --green: rgb(78,186,101);
+    --red: rgb(255,107,128);
+    --blue: rgb(177,185,249);
+    --yellow: rgb(255,193,7);
+    --mono: 'SF Mono', ui-monospace, Menlo, Monaco, Consolas, monospace;
+  }
+
+  * { box-sizing: border-box; }
+  html { background: var(--ivory); }
+  body {
+    margin: 0; padding: 48px 24px 80px;
+    font: 13px/1.55 var(--mono);
+    font-variant-numeric: tabular-nums;
+    color: var(--term-fg);
+  }
+
+  /* terminal window chrome */
+  .term {
+    max-width: 1180px; margin: 0 auto;
+    background: var(--term-bg);
+    border-radius: 8px;
+    outline: 1px solid var(--outline);
+    box-shadow: 0 20px 60px rgba(20,20,19,0.22);
+  }
+  .titlebar {
+    background: var(--titlebar);
+    border-radius: 8px 8px 0 0;
+    border-bottom: 1px solid var(--outline);
+    padding: 11px 14px;
+    display: flex; align-items: center; gap: 7px;
+  }
+  .titlebar .dot { width: 11px; height: 11px; border-radius: 50%; background: #3a3836; }
+  .titlebar .path { margin-left: 14px; color: var(--dim); font-size: 11px; }
+  .term-body { padding: 22px 30px 30px; }
+
+  /* command + hero */
+  .cmd { color: var(--dim); margin-bottom: 6px; }
+  .cmd .prompt { color: var(--clay); }
+  .cmd .flag { color: var(--blue); }
+  #meta-line { color: var(--subtle); font-size: 11px; }
+
+  #hero { margin: 14px 0 6px; }
+  #hero-total { font-size: 56px; font-weight: 700; line-height: 1; }
+  #hero-total .unit { color: var(--clay); }
+  #hero-total .label { font-size: 18px; font-weight: 400; color: var(--dim); margin-left: 8px; }
+  #hero-split { color: var(--dim); margin-top: 8px; }
+  #hero-split b { color: var(--term-fg); font-weight: 500; }
+  #hero-split .ok { color: var(--green); }
+  #hero-split .warn { color: var(--yellow); }
+
+  /* sections */
+  section { margin-top: 26px; }
+  .hr { color: var(--subtle); overflow: hidden; white-space: nowrap;
+        user-select: none; margin-bottom: 8px; }
+  .hr::after { content: '────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────'; }
+  h2 { all: unset; display: block; color: var(--clay); font-weight: 500; }
+  h2::before { content: '▸ '; }
+  h2 .hint { color: var(--subtle); font-size: 11px; font-weight: 400; margin-left: 10px; }
+  .section-body { margin-top: 10px; }
+
+  /* overall stat grid */
+  #overall-grid { display: grid; gap: 4px 28px;
+                  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); }
+  .stat { padding: 4px 0; }
+  .stat .label { font-size: 11px; color: var(--dim); }
+  .stat .val { font-size: 20px; font-weight: 500; }
+  .stat .detail { font-size: 11px; color: var(--subtle); }
+
+  /* takeaways */
+  .take { display: grid; grid-template-columns: 9ch 1fr; gap: 18px;
+          padding: 6px 0; align-items: baseline; }
+  .take .fig { text-align: right; font-weight: 700; font-size: 15px; }
+  .take .txt { color: var(--dim); }
+  .take .txt b { color: var(--term-fg); font-weight: 500; }
+  .take.bad  .fig { color: var(--red); }
+  .take.good .fig { color: var(--green); }
+  .take.info .fig { color: var(--blue); }
+
+  /* callouts (recommendations) */
+  .callout { padding: 6px 0 6px 14px; border-left: 2px solid var(--subtle);
+             color: var(--dim); margin: 6px 0; }
+  .callout b, .callout code { color: var(--term-fg); }
+
+  /* day pills + session gantt */
+  .days { display: flex; gap: 8px; flex-wrap: wrap; margin-bottom: 14px; }
+  .dpill { flex: 1; min-width: 84px; max-width: 140px; background: none;
+           border: 1px solid var(--subtle); border-radius: 4px;
+           padding: 9px 6px; font: inherit; color: var(--dim);
+           cursor: pointer; text-align: center; }
+  .dpill:hover { border-color: var(--dim); background: var(--hover); }
+  .dpill .dow { font-size: 10px; color: var(--subtle); display: block; }
+  .dpill .date { font-size: 11px; color: var(--term-fg); font-weight: 500;
+                 display: block; margin: 2px 0 4px; }
+  .dpill .pct { font-size: 16px; font-weight: 700; color: var(--term-fg); display: block; }
+  .dpill .ns { font-size: 10px; color: var(--subtle); display: block; margin-top: 2px; }
+  .dpill.heaviest .pct { color: var(--clay); }
+  .dpill.sel { border-color: var(--clay); background: rgba(217,119,87,0.10); }
+  .gantt-hd { display: flex; justify-content: space-between; align-items: baseline;
+              margin-bottom: 6px; }
+  .gantt-hd .day { color: var(--term-fg); font-weight: 500; }
+  .gantt-hd .stats { font-size: 11px; color: var(--dim); }
+  .gantt-hd .stats b { color: var(--clay); }
+  .gantt { position: relative; border-top: 1px solid var(--outline);
+           border-bottom: 1px solid var(--outline); min-height: 32px; }
+  .lane { position: relative; height: 16px;
+          border-bottom: 1px dashed rgba(255,255,255,0.04); }
+  .seg { position: absolute; top: 2px; height: 12px; border-radius: 2px;
+         opacity: .85; cursor: crosshair; }
+  .seg:hover { opacity: 1; outline: 1px solid var(--term-fg); z-index: 2; }
+  .gantt-rule { position: absolute; top: 0; bottom: 0; width: 0;
+                border-left: 1px dashed var(--subtle); opacity: .4;
+                pointer-events: none; }
+  .gantt-axis { display: flex; justify-content: space-between;
+                font-size: 10px; color: var(--subtle); padding: 4px 0; }
+  .gantt-leg { font-size: 10px; color: var(--subtle); margin-top: 8px;
+               display: flex; gap: 14px; flex-wrap: wrap; }
+  .gantt-leg .sw { display: inline-block; width: 14px; height: 10px;
+                   border-radius: 2px; vertical-align: middle; margin-right: 4px; }
+
+  /* block-char bars */
+  .bar { display: grid; grid-template-columns: 26ch 1fr 8ch; gap: 14px;
+         padding: 2px 0; align-items: center; }
+  .bar .name { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .bar .blocks { color: var(--clay); white-space: pre; overflow: hidden; }
+  .bar .blocks .empty { color: var(--subtle); }
+  .bar .pct { text-align: right; color: var(--dim); }
+  .bar:hover .name { color: var(--clay); }
+
+  /* drill-down lists (top prompts, cache breaks) */
+  .drill details { border-top: 1px solid var(--outline); }
+  .drill details:last-of-type { border-bottom: 1px solid var(--outline); }
+  .drill summary { list-style: none; cursor: pointer;
+    display: grid; grid-template-columns: 8ch 1fr; gap: 16px;
+    padding: 9px 4px; align-items: baseline; }
+  .drill summary::-webkit-details-marker { display: none; }
+  .drill summary:hover { background: var(--hover); }
+  .drill .amt { font-weight: 700; text-align: right; color: var(--clay); }
+  .drill .desc { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+  .drill .meta { grid-column: 2; font-size: 11px; color: var(--subtle); }
+  .drill details[open] summary .desc { white-space: normal; }
+  .drill .body { padding: 4px 4px 14px calc(8ch + 20px); font-size: 12px; color: var(--dim); }
+
+  /* transcript context (+/-2 user messages), light inset for legibility */
+  .ctx { margin: 8px 0 12px; padding: 10px 14px;
+         background: #F0EEE6; color: #1a1918;
+         border-radius: 6px; font-size: 12px; }
+  .ctx-msg { padding: 4px 0; white-space: pre-wrap; }
+  .ctx-msg .who { color: #87867F; font-size: 11px; }
+  .ctx-msg .ts { color: #87867F; font-size: 10px; margin-left: 8px; }
+  .ctx-msg.here { margin: 2px -14px; padding: 6px 11px 6px 14px;
+                  border-left: 3px solid var(--clay);
+                  background: rgba(217,119,87,0.10); }
+  .ctx-msg.here .who { color: var(--clay); font-weight: 500; }
+  .ctx-gap { color: #87867F; font-size: 11px; padding: 3px 0 3px 7ch; }
+  .ctx-gap::before { content: '⟨ '; }
+  .ctx-gap::after  { content: ' ⟩'; }
+  .ctx-break { margin: 2px -14px; padding: 8px 11px 8px 14px;
+               border-left: 3px solid #BD5E6D;
+               background: rgba(189,94,109,0.12); color: #A63244; }
+  .ctx-break b { color: #1a1918; margin-right: 6px; }
+
+  .more-btn { display: block; width: 100%; margin-top: 10px; padding: 9px;
+              background: none; border: 1px dashed var(--subtle); cursor: pointer;
+              font: 500 11px/1 var(--mono); letter-spacing: 0.06em;
+              color: var(--dim); }
+  .more-btn:hover { border-color: var(--dim); color: var(--term-fg); }
+
+  /* tables */
+  .scroll { max-height: 440px; overflow: auto;
+            border-top: 1px solid var(--outline); border-bottom: 1px solid var(--outline); }
+  table { width: 100%; border-collapse: collapse; font-size: 12px; }
+  th, td { text-align: left; padding: 6px 10px; }
+  td { border-top: 1px solid rgba(255,255,255,0.04); }
+  th { position: sticky; top: 0; background: var(--term-bg); z-index: 1;
+       font-weight: 500; font-size: 11px; color: var(--subtle);
+       cursor: pointer; user-select: none;
+       border-bottom: 1px solid var(--outline); }
+  th:hover { color: var(--dim); }
+  th.sorted { color: var(--clay); }
+  th.sorted::after { content: ' ↓'; }
+  th.sorted.asc::after { content: ' ↑'; }
+  td.num, th.num { text-align: right; }
+  tbody tr:hover td { background: var(--hover); }
+
+  footer { margin-top: 28px; color: var(--subtle); font-size: 11px;
+           display: flex; justify-content: space-between; gap: 16px; flex-wrap: wrap; }
+
+  code { color: var(--blue); }
+  a { color: var(--clay); }
+  ::selection { background: var(--clay); color: var(--term-bg); }
+
+  @media (max-width: 760px) {
+    body { padding: 20px 12px 48px; }
+    .term-body { padding: 16px 16px 24px; }
+    #hero-total { font-size: 40px; }
+    .bar { grid-template-columns: 14ch 1fr 7ch; gap: 8px; }
+    .drill summary { grid-template-columns: 6ch 1fr; }
+    .drill .body { padding-left: 12px; }
+    .take { grid-template-columns: 7ch 1fr; gap: 12px; }
+  }
+</style>
+</head>
+<body>
+
+<div class="term">
+  <div class="titlebar">
+    <span class="dot"></span><span class="dot"></span><span class="dot"></span>
+    <span class="path" id="title-path">~/.cline/data/sessions - session-report</span>
+  </div>
+  <div class="term-body">
+
+    <div class="cmd"><span class="prompt">&gt;</span> cline usage <span id="cmd-flags"></span></div>
+    <div id="meta-line">loading…</div>
+
+    <div id="hero">
+      <div id="hero-total">-</div>
+      <div id="hero-split"></div>
+    </div>
+
+    <!-- ====================================================================
+         FINDINGS - agent fills this. 3-5 one-line takeaways. Use .bad for
+         waste/anomalies, .good for healthy signals, .info for neutral.
+         ==================================================================== -->
+    <section>
+      <div class="hr"></div>
+      <h2>findings</h2>
+      <div class="section-body" id="takeaways">
+        <!-- AGENT: anomalies -->
+        <div class="take"><div class="fig">-</div><div class="txt">No findings generated yet.</div></div>
+        <!-- /AGENT -->
+      </div>
+    </section>
+
+    <!-- ====================================================================
+         Everything below renders automatically from #report-data.
+         ==================================================================== -->
+    <section>
+      <div class="hr"></div>
+      <h2>summary</h2>
+      <div class="section-body" id="overall-grid"></div>
+    </section>
+
+    <section>
+      <div class="hr"></div>
+      <h2>tokens by project<span class="hint">share of total</span></h2>
+      <div class="section-body" id="project-bars"></div>
+    </section>
+
+    <section id="timeline-section">
+      <div class="hr"></div>
+      <h2>session timeline by day<span class="hint">click a day · ←/→ to navigate</span></h2>
+      <div class="section-body">
+        <div class="days" id="day-pills"></div>
+        <div class="gantt-hd">
+          <span class="day" id="g-day">-</span>
+          <span class="stats" id="g-stats"></span>
+        </div>
+        <div class="gantt-axis"><span>00:00</span><span>06:00</span><span>12:00</span><span>18:00</span><span>24:00</span></div>
+        <div class="gantt" id="gantt"></div>
+        <div class="gantt-leg" id="gantt-leg"></div>
+      </div>
+    </section>
+
+    <section>
+      <div class="hr"></div>
+      <h2>most expensive prompts<span class="hint">click to expand context</span></h2>
+      <div class="section-body drill" id="top-prompts"></div>
+    </section>
+
+    <section>
+      <div class="hr"></div>
+      <h2>cache breaks<span class="hint">&gt;100k uncached · click for context</span></h2>
+      <div class="section-body drill" id="cache-breaks"></div>
+    </section>
+
+    <section>
+      <div class="hr"></div>
+      <h2>projects</h2>
+      <div class="section-body scroll"><table id="tbl-projects"></table></div>
+    </section>
+
+    <section>
+      <div class="hr"></div>
+      <h2>subagent types</h2>
+      <div class="section-body scroll"><table id="tbl-subagents"></table></div>
+    </section>
+
+    <section>
+      <div class="hr"></div>
+      <h2>slash commands &amp; tool calls</h2>
+      <div class="section-body scroll"><table id="tbl-skills"></table></div>
+    </section>
+
+    <section>
+      <div class="hr"></div>
+      <h2>recommendations</h2>
+      <div class="section-body">
+        <!-- AGENT: optimizations -->
+        <div class="callout">No suggestions generated yet.</div>
+        <!-- /AGENT -->
+      </div>
+    </section>
+
+    <footer>
+      <span id="foot-gen"></span>
+      <span id="foot-stats"></span>
+    </footer>
+
+  </div>
+</div>
+
+<!-- ========================================================================
+     DATA - agent replaces the {} below with the full --json output.
+     ======================================================================== -->
+<script id="report-data" type="application/json">{}</script>
+
+<script>
+(function() {
+  const DATA = JSON.parse(document.getElementById('report-data').textContent || '{}');
+  const $ = id => document.getElementById(id);
+  const fmt = n => n>=1e9 ? (n/1e9).toFixed(2)+'B' : n>=1e6 ? (n/1e6).toFixed(2)+'M'
+              : n>=1e3 ? (n/1e3).toFixed(1)+'k' : String(n);
+  const pct = (a,b) => b>0 ? ((100*a/b).toFixed(1)+'%') : '-';
+  const esc = s => String(s).replace(/[&<>"]/g, c =>
+    ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;'}[c]));
+  const short = p => String(p||'').replace(/^-Users-[^-]+-/,'').replace(/^code-/,'');
+  const MON = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
+  const niceDate = iso => { const d = new Date(iso); return isNaN(d) ? '' :
+    `${MON[d.getMonth()]} ${d.getDate()} · ${String(d.getHours()).padStart(2,'0')}:${String(d.getMinutes()).padStart(2,'0')}`; };
+
+  if (!DATA.overall) { $('meta-line').textContent = 'no data - embed JSON in #report-data.'; return; }
+
+  // header + hero
+  const o = DATA.overall, it = o.input_tokens;
+  const GRAND = it.total + o.output_tokens;
+  const share = n => GRAND>0 ? (100*n/GRAND).toFixed(1)+'%' : '-';
+  const span = o.span;
+  $('cmd-flags').innerHTML = DATA.since
+    ? `<span class="flag">--since</span> ${esc(DATA.since)}` : '';
+  $('meta-line').textContent =
+    (span ? `${span.from.slice(0,10)} → ${span.to.slice(0,10)}` : '') +
+    ` · ${DATA.root || ''}`;
+  $('foot-gen').textContent = `generated ${DATA.generated_at?.slice(0,16).replace('T',' ') || ''}`;
+  $('foot-stats').textContent =
+    `${o.sessions} sessions · ${o.api_calls} api calls · ${o.human_messages} prompts`;
+
+  const num = fmt(GRAND), m = num.match(/^([\d.]+)([A-Za-z]*)$/);
+  $('hero-total').innerHTML =
+    `${m?m[1]:num}<span class="unit">${m?m[2]:''}</span><span class="label">tokens</span>`;
+  const cacheCls = it.pct_cached>=85 ? 'ok' : 'warn';
+  $('hero-split').innerHTML =
+    `<b>${fmt(it.total)}</b> input <span class="${cacheCls}">(${it.pct_cached}% cache-read)</span> · `+
+    `<b>${fmt(o.output_tokens)}</b> output · all figures below are % of this total`;
+
+  // overall stat grid
+  $('overall-grid').innerHTML = [
+    ['sessions', o.sessions],
+    ['api calls', o.api_calls],
+    ['human msgs', o.human_messages],
+    ['active hours', o.hours.active, `${o.hours.wall_clock} wall-clock`],
+    ['cache breaks', o.cache_breaks_over_100k, '>100k uncached'],
+    ['subagent calls', o.subagent.calls, `avg ${fmt(o.subagent.avg_tokens_per_call)}`],
+  ].map(([l,v,d]) =>
+    `<div class="stat"><div class="label">${l}</div>`+
+    `<div class="val">${typeof v==='number'&&v>=1e4?fmt(v):v}</div>`+
+    (d?`<div class="detail">${d}</div>`:'')+`</div>`).join('');
+
+  // session timeline by day
+  (function() {
+    const days = (DATA.by_day||[]).slice(-14);
+    if (!days.length) { $('timeline-section').style.display='none'; return; }
+    const PCOL = ['rgb(177,185,249)','rgb(78,186,101)','#D97757','rgb(255,193,7)',
+                  'rgb(255,107,128)','#9b8cff','#6ec1d6','#c792ea'];
+    const dayTotal = days.reduce((a,d)=>a+d.tokens,0) || 1;
+    const tokMax = Math.max(...days.map(d=>d.tokens));
+    const projects = [...new Set(days.flatMap(d=>d.sessions.map(s=>s.project)))];
+    const colorOf = p => PCOL[projects.indexOf(p)%PCOL.length];
+    const hhmm = m => (m>=1440?`+${Math.floor(m/1440)}d `:'') +
+      `${String(Math.floor(m/60)%24).padStart(2,'0')}:${String(m%60).padStart(2,'0')}`;
+    const md = iso => { const [,mo,da]=iso.split('-'); return `${MON[+mo-1]} ${+da}`; };
+    let sel = days.findIndex(d=>d.tokens===tokMax);
+
+    function pills() {
+      $('day-pills').innerHTML = days.map((d,i)=>
+        `<button class="dpill${d.tokens===tokMax?' heaviest':''}${i===sel?' sel':''}" data-i="${i}">`+
+        `<span class="dow">${esc(d.dow)}</span>`+
+        `<span class="date">${esc(md(d.date))}</span>`+
+        `<span class="pct">${(100*d.tokens/dayTotal).toFixed(1)}%</span>`+
+        `<span class="ns">${d.sessions.length} sess</span></button>`
+      ).join('');
+      $('day-pills').querySelectorAll('.dpill').forEach(el=>
+        el.onclick=()=>{sel=+el.dataset.i;pills();gantt();});
+    }
+    function gantt() {
+      const d = days[sel], DAY = 1440;
+      $('g-day').textContent = `${d.dow} ${md(d.date)}`;
+      $('g-stats').innerHTML = `${d.sessions.length} sessions · ${fmt(d.tokens)} tokens`+
+        ` · peak <b>${d.peak}</b> concurrent at <b>${hhmm(d.peak_at_min)}</b>`;
+      const lanes = [];
+      for (const s of d.sessions) {
+        let placed = false;
+        for (const L of lanes) if (L[L.length-1].end_min <= s.start_min) { L.push(s); placed=true; break; }
+        if (!placed) lanes.push([s]);
+      }
+      let h = '';
+      for (let t=0;t<=24;t+=6) h += `<div class="gantt-rule" style="left:${100*t/24}%"></div>`;
+      h += lanes.map(L=>`<div class="lane">${L.map(s=>{
+        const end = Math.min(s.end_min, DAY);
+        const w = Math.max(0.15, 100*(end-s.start_min)/DAY);
+        const tip = `folder: ${short(s.project)}\n`+
+          `${hhmm(s.start_min)}-${hhmm(s.end_min)} · ${fmt(s.tokens)} tokens\n`+
+          `session ${s.id}`;
+        return `<span class="seg" style="left:${100*s.start_min/DAY}%;width:${w}%;`+
+          `background:${colorOf(s.project)}" title="${esc(tip)}"></span>`;
+      }).join('')}</div>`).join('');
+      $('gantt').innerHTML = h || '<div class="callout">no sessions</div>';
+    }
+    document.addEventListener('keydown',e=>{
+      if (e.key==='ArrowRight'&&sel<days.length-1){sel++;pills();gantt();e.preventDefault();}
+      if (e.key==='ArrowLeft'&&sel>0){sel--;pills();gantt();e.preventDefault();}
+    });
+    $('gantt-leg').innerHTML = projects.slice(0,12).map(p=>
+      `<span><span class="sw" style="background:${colorOf(p)}"></span>${esc(short(p))}</span>`).join('');
+    pills(); gantt();
+  })();
+
+  // block-char project bars
+  (function() {
+    const W = 48;
+    const rows = Object.entries(DATA.by_project||{})
+      .map(([k,v]) => [k, v.input_tokens.total + v.output_tokens])
+      .sort((a,b)=>b[1]-a[1]).slice(0,15);
+    const max = rows[0]?.[1] || 1;
+    $('project-bars').innerHTML = rows.map(([k,v]) => {
+      const n = Math.max(1, Math.round(W*v/max));
+      return `<div class="bar"><span class="name" title="${esc(k)} - ${fmt(v)}">${esc(short(k))}</span>`+
+        `<span class="blocks">${'█'.repeat(n)}<span class="empty">${'░'.repeat(W-n)}</span></span>`+
+        `<span class="pct">${share(v)}</span></div>`;
+    }).join('');
+  })();
+
+  // ±2 user-message transcript context
+  function renderContext(ctx, mark) {
+    if (!ctx || !ctx.length) return '<div class="ctx-gap">no transcript context available</div>';
+    let h = '<div class="ctx">';
+    ctx.forEach((m, i) => {
+      const who = m.here ? '&gt; user' : '  user';
+      h += `<div class="ctx-msg${m.here?' here':''}">`+
+           `<span class="who">${who}</span>  ${esc(m.text||'(non-text)')}`+
+           `<span class="ts">${niceDate(m.ts)}</span></div>`;
+      if (m.here && mark) h += mark;
+      if (i < ctx.length-1 || m.here)
+        h += `<div class="ctx-gap">${m.calls} api call${m.calls===1?'':'s'}</div>`;
+    });
+    return h + '</div>';
+  }
+
+  // expandable drill-down list with "show N more" toggle
+  function drillList(hostId, items, rowFn, empty) {
+    const SHOW = 5;
+    const host = $(hostId);
+    if (!items.length) { host.innerHTML = `<div class="callout">${empty}</div>`; return; }
+    const head = items.slice(0,SHOW).map(rowFn).join('');
+    const rest = items.slice(SHOW).map(rowFn).join('');
+    host.innerHTML = head + (rest
+      ? `<div hidden>${rest}</div><button class="more-btn">show ${items.length-SHOW} more</button>`
+      : '');
+    const btn = host.querySelector('.more-btn');
+    if (btn) btn.onclick = () => {
+      const r = btn.previousElementSibling; r.hidden = !r.hidden;
+      btn.textContent = r.hidden ? `show ${items.length-SHOW} more` : 'show less';
+    };
+  }
+
+  drillList('top-prompts', (DATA.top_prompts||[]).slice(0,100), p => {
+    const inTot = p.input.uncached+p.input.cache_create+p.input.cache_read;
+    return `<details><summary>`+
+      `<span class="amt">${share(p.total_tokens)}</span>`+
+      `<span class="desc">${esc(p.text)}</span>`+
+      `<span class="meta">${niceDate(p.ts)} · ${esc(short(p.project))} · ${p.api_calls} calls`+
+        (p.subagent_calls?` · ${p.subagent_calls} subagents`:'')+
+        ` · ${pct(p.input.cache_read,inTot)} cached</span>`+
+      `</summary><div class="body">`+
+      renderContext(p.context)+
+      `<div>session <code>${esc(p.session)}</code></div>`+
+      `<div>in: uncached ${fmt(p.input.uncached)} · cache-create ${fmt(p.input.cache_create)} · `+
+      `cache-read ${fmt(p.input.cache_read)} · out ${fmt(p.output)}</div>`+
+      `</div></details>`;
+  }, 'No prompts in range.');
+
+  drillList('cache-breaks', (DATA.cache_breaks||[]).slice(0,100), b =>
+    `<details><summary>`+
+    `<span class="amt">${fmt(b.uncached)}</span>`+
+    `<span class="desc">${esc(short(b.project))} · `+
+      `${b.kind==='subagent'?esc(b.agentType||'subagent'):'main'}</span>`+
+    `<span class="meta">${niceDate(b.ts)} · ${pct(b.uncached,b.total)} of ${fmt(b.total)} uncached</span>`+
+    `</summary><div class="body">`+
+    renderContext(b.context,
+      `<div class="ctx-break"><b>${fmt(b.uncached)}</b> uncached `+
+      `(${pct(b.uncached,b.total)} of ${fmt(b.total)}) - cache break here</div>`)+
+    `<div>session <code>${esc(b.session)}</code></div>`+
+    `</div></details>`,
+  'No cache breaks over threshold.');
+
+  // sortable table
+  function table(el, cols, rows) {
+    let sortIdx = cols.findIndex(c=>c.sort), asc = false;
+    function render() {
+      const sorted = rows.slice().sort((a,b)=>{
+        const va=a[sortIdx], vb=b[sortIdx];
+        return (asc?1:-1)*(typeof va==='number' ? va-vb : String(va).localeCompare(String(vb)));
+      });
+      el.innerHTML = `<thead><tr>${cols.map((c,i)=>
+        `<th class="${c.num?'num':''} ${i===sortIdx?'sorted'+(asc?' asc':''):''}" data-i="${i}">${c.h}</th>`
+      ).join('')}</tr></thead><tbody>${sorted.map(r=>
+        `<tr>${r.map((v,i)=>`<td class="${cols[i].num?'num':''}">${
+          cols[i].fmt?cols[i].fmt(v):esc(v)}</td>`).join('')}</tr>`
+      ).join('')}</tbody>`;
+      el.querySelectorAll('th').forEach(th=>th.onclick=()=>{
+        const i=+th.dataset.i; if(i===sortIdx)asc=!asc; else{sortIdx=i;asc=false;} render();
+      });
+    }
+    render();
+  }
+
+  function statRows(obj) {
+    return Object.entries(obj||{}).map(([k,v])=>[
+      short(k), GRAND>0 ? 100*(v.input_tokens.total+v.output_tokens)/GRAND : 0,
+      v.sessions, v.api_calls, v.human_messages,
+      v.input_tokens.total, v.input_tokens.pct_cached, v.output_tokens,
+      v.hours.active, v.cache_breaks_over_100k,
+      v.subagent.calls, v.subagent.avg_tokens_per_call,
+    ]);
+  }
+  const statCols = [
+    {h:'name'},{h:'% total',num:1,sort:1,fmt:v=>v.toFixed(1)+'%'},
+    {h:'sess',num:1},{h:'calls',num:1},{h:'msgs',num:1},
+    {h:'input',num:1,fmt:fmt},{h:'%cached',num:1,fmt:v=>v+'%'},
+    {h:'output',num:1,fmt:fmt},{h:'active h',num:1},{h:'breaks',num:1},
+    {h:'subagents',num:1},{h:'avg sub tok',num:1,fmt:fmt},
+  ];
+  table($('tbl-projects'), statCols, statRows(DATA.by_project));
+  table($('tbl-subagents'), statCols, statRows(DATA.by_subagent_type));
+  table($('tbl-skills'), statCols, statRows(DATA.by_skill));
+})();
+</script>
+</body>
+</html>


### PR DESCRIPTION
## session-report

Adds a local Cline usage report plugin. The plugin helps users turn persisted Cline session artifacts into a self-contained HTML report showing token usage, cache behavior, expensive prompts, project totals, subagent sessions, and slash-command/tool activity.

## Cline Primitives

This is a skills-only package plugin. It bundles the `session-report` skill, a local Node analyzer, and a static HTML template.

The skill guides Cline through generating the report on demand. The analyzer reads local session manifests and message files from `CLINE_SESSION_DATA_DIR` or `~/.cline/data/sessions`, including both current per-session manifest layouts and indexed file-session stores. The template renders the JSON into an interactive local report with sortable tables, timeline views, prompt drilldowns, and recommendations filled in by Cline.

## Requirements

Users need local Cline session artifacts and Node.js. There are no MCP servers, no API keys, no network services, and no install-time setup. The generated report may include user prompts and transcript context, so the plugin documents the privacy boundary and avoids external fonts or other remote assets in the HTML output.
