### PR TITLE
feat: add swift lsp plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Each plugin lives in `plugins/<slug>`. The directory name is the install keyword
 | `mac-notify` | macOS notifications when a Cline run completes. |
 | `nanobanana` | Image generation through OpenRouter and Gemini image models. |
 | `speak` | Speaks completed Cline replies with ElevenLabs text to speech. |
+| `swift-lsp` | Swift definition lookup through SourceKit-LSP. |
 | `typescript-lsp` | TypeScript language service `goto_definition` support. |
 | `weather-metrics` | Demo weather tool plus runtime metrics hooks. |
 | `web-search` | Exa-backed web search as a Cline tool. |

--- a/plugins/swift-lsp/LICENSE.swift-lsp
+++ b/plugins/swift-lsp/LICENSE.swift-lsp
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/plugins/swift-lsp/README.md
+++ b/plugins/swift-lsp/README.md
@@ -1,0 +1,31 @@
+# swift-lsp
+
+Adds Swift definition lookup through SourceKit-LSP.
+
+## What It Does
+
+Registers `swift_goto_definition(file, line, column?)`. The tool starts `sourcekit-lsp` on demand, opens the target Swift file over the Language Server Protocol, and asks SourceKit for symbol definitions. If `column` is omitted, the tool checks the Swift identifiers on the requested line and returns any external definitions it can resolve.
+
+Relative file paths are resolved from the active Cline workspace. Absolute paths are accepted only when they stay inside that workspace.
+
+## Install
+
+```bash
+cline plugin install swift-lsp
+```
+
+For local development from this repository:
+
+```bash
+cline plugin install ./plugins/swift-lsp --cwd .
+```
+
+## Requirements
+
+- A Swift workspace.
+- `sourcekit-lsp` available on `PATH`, usually from Xcode or the Swift toolchain.
+- Set `SOURCEKIT_LSP=/absolute/path/to/sourcekit-lsp` if the binary is not on `PATH`.
+
+## Security Notes
+
+The tool starts the local `sourcekit-lsp` binary only when called and reads Swift project files through the language server. Use normal workspace trust rules before enabling it on untrusted projects.

--- a/plugins/swift-lsp/index.ts
+++ b/plugins/swift-lsp/index.ts
@@ -1,0 +1,534 @@
+import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process"
+import { existsSync, readFileSync, realpathSync } from "node:fs"
+import { dirname, isAbsolute, join, relative, resolve } from "node:path"
+import { fileURLToPath, pathToFileURL } from "node:url"
+import type { AgentPlugin } from "@cline/sdk"
+
+type SwiftGotoDefinitionInput = {
+	file?: string
+	line?: number
+	column?: number
+}
+
+type LspResponse<T = unknown> = {
+	id?: number
+	result?: T
+	error?: { code?: number; message?: string }
+}
+
+type LspRange = {
+	start: { line: number; character: number }
+	end?: { line: number; character: number }
+}
+
+type LspLocation = {
+	uri: string
+	range: LspRange
+}
+
+type LspLocationLink = {
+	targetUri: string
+	targetSelectionRange?: LspRange
+	targetRange?: LspRange
+}
+
+type DefinitionTarget = {
+	file: string
+	line: number
+	column: number
+}
+
+const SWIFT_KEYWORDS = new Set([
+	"associatedtype",
+	"break",
+	"case",
+	"catch",
+	"class",
+	"continue",
+	"default",
+	"defer",
+	"deinit",
+	"do",
+	"else",
+	"enum",
+	"extension",
+	"fallthrough",
+	"false",
+	"fileprivate",
+	"for",
+	"func",
+	"guard",
+	"if",
+	"import",
+	"in",
+	"init",
+	"inout",
+	"internal",
+	"is",
+	"let",
+	"nil",
+	"open",
+	"operator",
+	"private",
+	"protocol",
+	"public",
+	"repeat",
+	"return",
+	"self",
+	"static",
+	"struct",
+	"subscript",
+	"super",
+	"switch",
+	"throw",
+	"throws",
+	"true",
+	"try",
+	"typealias",
+	"var",
+	"where",
+	"while",
+])
+
+const MAX_IDENTIFIER_LOOKUPS = 5
+let sessionWorkspaceRoot: string | undefined
+
+function asObject(value: unknown): Record<string, unknown> {
+	return value && typeof value === "object"
+		? (value as Record<string, unknown>)
+		: {}
+}
+
+function asPositiveInteger(value: unknown): number | undefined {
+	return typeof value === "number" && Number.isInteger(value) && value > 0
+		? value
+		: undefined
+}
+
+function isInsidePath(parent: string, child: string): boolean {
+	const rel = relative(parent, child)
+	return rel === "" || (!rel.startsWith("..") && !isAbsolute(rel))
+}
+
+function findProjectRoot(startDir: string, boundary?: string): string {
+	let dir = startDir
+	while (true) {
+		if (existsSync(join(dir, "Package.swift")) || existsSync(join(dir, ".git"))) {
+			return dir
+		}
+		if (boundary && dir === boundary) {
+			return boundary
+		}
+		const parent = dirname(dir)
+		if (parent === dir) {
+			return boundary ?? startDir
+		}
+		dir = parent
+	}
+}
+
+function findIdentifiersOnLine(text: string, line: number) {
+	const lines = text.split(/\r?\n/)
+	const content = lines[line - 1]
+	if (content === undefined) {
+		return []
+	}
+
+	const identifiers: Array<{ symbol: string; character: number }> = []
+	const seen = new Set<string>()
+	const matcher = /\b[A-Za-z_][A-Za-z0-9_]*\b/g
+	for (const match of content.matchAll(matcher)) {
+		const symbol = match[0]
+		if (SWIFT_KEYWORDS.has(symbol) || seen.has(symbol)) {
+			continue
+		}
+		seen.add(symbol)
+		const index = match.index ?? 0
+		identifiers.push({
+			symbol,
+			character: index + Math.min(1, Math.max(0, symbol.length - 1)),
+		})
+		if (identifiers.length >= MAX_IDENTIFIER_LOOKUPS) {
+			break
+		}
+	}
+	return identifiers
+}
+
+function normalizeDefinitionTarget(
+	location: LspLocation | LspLocationLink,
+): DefinitionTarget | undefined {
+	const uri = "uri" in location ? location.uri : location.targetUri
+	const range =
+		"range" in location
+			? location.range
+			: (location.targetSelectionRange ?? location.targetRange)
+	if (!uri || !range?.start) {
+		return undefined
+	}
+
+	let file: string
+	try {
+		file = fileURLToPath(uri)
+	} catch {
+		return undefined
+	}
+
+	return {
+		file,
+		line: range.start.line + 1,
+		column: range.start.character + 1,
+	}
+}
+
+function normalizeDefinitionResult(result: unknown): DefinitionTarget[] {
+	const locations = Array.isArray(result)
+		? result
+		: result && typeof result === "object"
+			? [result]
+			: []
+	return locations
+		.map((location) =>
+			normalizeDefinitionTarget(location as LspLocation | LspLocationLink),
+		)
+		.filter((target): target is DefinitionTarget => !!target)
+}
+
+class SwiftLspClient {
+	private child: ChildProcessWithoutNullStreams
+	private nextId = 1
+	private buffer = Buffer.alloc(0)
+	private stderr = ""
+	private pending = new Map<
+		number,
+		{
+			resolve: (value: unknown) => void
+			reject: (error: Error) => void
+			timer: ReturnType<typeof setTimeout>
+		}
+	>()
+
+	constructor(
+		private readonly projectRoot: string,
+		private readonly command = process.env.SOURCEKIT_LSP || "sourcekit-lsp",
+	) {
+		this.child = spawn(this.command, [], {
+			cwd: this.projectRoot,
+			env: process.env,
+			stdio: ["pipe", "pipe", "pipe"],
+		})
+
+		this.child.stdout.on("data", (chunk: Buffer) => this.onStdout(chunk))
+		this.child.stderr.on("data", (chunk: Buffer) => {
+			this.stderr = `${this.stderr}${chunk.toString("utf8")}`.slice(-4000)
+		})
+		this.child.on("error", (error) => this.rejectAll(error))
+		this.child.on("close", (code, signal) => {
+			this.rejectAll(
+				new Error(
+					`${this.command} exited before responding (code ${code ?? "null"}, signal ${signal ?? "null"})${this.stderr ? `: ${this.stderr.trim()}` : ""}`,
+				),
+			)
+		})
+	}
+
+	async initialize() {
+		await this.request(
+			"initialize",
+			{
+				processId: process.pid,
+				rootUri: pathToFileURL(this.projectRoot).toString(),
+				capabilities: {},
+				clientInfo: { name: "cline-swift-lsp" },
+				workspaceFolders: [
+					{
+						uri: pathToFileURL(this.projectRoot).toString(),
+						name: "workspace",
+					},
+				],
+			},
+			7_000,
+		)
+		this.notify("initialized", {})
+	}
+
+	openSwiftFile(file: string, text: string) {
+		this.notify("textDocument/didOpen", {
+			textDocument: {
+				uri: pathToFileURL(file).toString(),
+				languageId: "swift",
+				version: 1,
+				text,
+			},
+		})
+	}
+
+	definition(file: string, line: number, character: number) {
+		return this.request(
+			"textDocument/definition",
+			{
+				textDocument: { uri: pathToFileURL(file).toString() },
+				position: { line: line - 1, character },
+			},
+			3_000,
+		)
+	}
+
+	async dispose() {
+		try {
+			await this.request("shutdown", null, 1000)
+			this.notify("exit", null)
+		} catch {
+			this.child.kill()
+		}
+	}
+
+	private request(method: string, params: unknown, timeoutMs: number) {
+		const id = this.nextId++
+		const message = { jsonrpc: "2.0", id, method, params }
+		return new Promise<unknown>((resolve, reject) => {
+			const timer = setTimeout(() => {
+				this.pending.delete(id)
+				reject(new Error(`${method} timed out after ${timeoutMs}ms`))
+			}, timeoutMs)
+			this.pending.set(id, { resolve, reject, timer })
+			try {
+				this.send(message)
+			} catch (error) {
+				clearTimeout(timer)
+				this.pending.delete(id)
+				reject(error instanceof Error ? error : new Error(String(error)))
+			}
+		})
+	}
+
+	private notify(method: string, params: unknown) {
+		this.send({ jsonrpc: "2.0", method, params })
+	}
+
+	private send(message: unknown) {
+		const body = JSON.stringify(message)
+		this.child.stdin.write(
+			`Content-Length: ${Buffer.byteLength(body, "utf8")}\r\n\r\n${body}`,
+			"utf8",
+		)
+	}
+
+	private onStdout(chunk: Buffer) {
+		this.buffer = Buffer.concat([this.buffer, chunk])
+		while (true) {
+			const headerEnd = this.buffer.indexOf("\r\n\r\n")
+			if (headerEnd < 0) {
+				return
+			}
+			const header = this.buffer.slice(0, headerEnd).toString("utf8")
+			const match = header.match(/Content-Length:\s*(\d+)/i)
+			if (!match) {
+				this.buffer = this.buffer.slice(headerEnd + 4)
+				continue
+			}
+			const length = Number(match[1])
+			const bodyStart = headerEnd + 4
+			const bodyEnd = bodyStart + length
+			if (this.buffer.length < bodyEnd) {
+				return
+			}
+			const body = this.buffer.slice(bodyStart, bodyEnd).toString("utf8")
+			this.buffer = this.buffer.slice(bodyEnd)
+			this.handleMessage(body)
+		}
+	}
+
+	private handleMessage(body: string) {
+		let response: LspResponse
+		try {
+			response = JSON.parse(body) as LspResponse
+		} catch {
+			return
+		}
+		if (typeof response.id !== "number") {
+			return
+		}
+		const pending = this.pending.get(response.id)
+		if (!pending) {
+			return
+		}
+		clearTimeout(pending.timer)
+		this.pending.delete(response.id)
+		if (response.error) {
+			pending.reject(
+				new Error(response.error.message ?? `LSP error ${response.error.code}`),
+			)
+			return
+		}
+		pending.resolve(response.result)
+	}
+
+	private rejectAll(error: Error) {
+		for (const [id, pending] of this.pending) {
+			clearTimeout(pending.timer)
+			pending.reject(error)
+			this.pending.delete(id)
+		}
+	}
+}
+
+async function resolveSwiftDefinitions(input: SwiftGotoDefinitionInput) {
+	const fileInput = typeof input.file === "string" ? input.file.trim() : ""
+	const line = asPositiveInteger(input.line)
+	const explicitColumn = asPositiveInteger(input.column)
+
+	if (!fileInput) {
+		return { error: "swift_goto_definition requires a file path." }
+	}
+	if (!line) {
+		return { error: "swift_goto_definition requires a 1-based line number." }
+	}
+
+	let workspaceRoot: string | undefined
+	if (sessionWorkspaceRoot) {
+		try {
+			workspaceRoot = realpathSync(sessionWorkspaceRoot)
+		} catch {}
+	}
+
+	const candidateFile = isAbsolute(fileInput)
+		? fileInput
+		: resolve(workspaceRoot ?? process.cwd(), fileInput)
+	const file = existsSync(candidateFile)
+		? realpathSync(candidateFile)
+		: resolve(candidateFile)
+
+	if (!existsSync(file)) {
+		return { error: `File does not exist: ${file}` }
+	}
+	if (workspaceRoot && !isInsidePath(workspaceRoot, file)) {
+		return {
+			error: `File is outside the active Cline workspace: ${file}`,
+			workspaceRoot,
+		}
+	}
+	if (!file.endsWith(".swift")) {
+		return { error: `Expected a .swift file: ${file}` }
+	}
+
+	const text = readFileSync(file, "utf8")
+	const positions = explicitColumn
+		? [{ symbol: "<position>", character: explicitColumn - 1 }]
+		: findIdentifiersOnLine(text, line)
+
+	if (positions.length === 0) {
+		return {
+			found: false,
+			file,
+			line,
+			message: "No Swift identifiers found on this line.",
+		}
+	}
+
+	const projectRoot = findProjectRoot(dirname(file), workspaceRoot)
+	const client = new SwiftLspClient(projectRoot)
+	try {
+		await client.initialize()
+		client.openSwiftFile(file, text)
+
+		const results: Array<{ symbol: string; definitions: DefinitionTarget[] }> =
+			[]
+		const seen = new Set<string>()
+		for (const position of positions) {
+			const definitionResult = await client.definition(
+				file,
+				line,
+				position.character,
+			)
+			const definitions = normalizeDefinitionResult(definitionResult).filter(
+				(target) => !(target.file === file && target.line === line),
+			)
+			const uniqueDefinitions = definitions.filter((target) => {
+				const key = `${target.file}:${target.line}:${target.column}`
+				if (seen.has(key)) {
+					return false
+				}
+				seen.add(key)
+				return true
+			})
+			if (uniqueDefinitions.length > 0) {
+				results.push({
+					symbol: position.symbol,
+					definitions: uniqueDefinitions,
+				})
+			}
+		}
+
+		if (results.length === 0) {
+			return {
+				found: false,
+				query: { file, line, column: explicitColumn },
+				projectRoot,
+				message:
+					"Swift identifiers were found, but SourceKit-LSP did not return external definitions.",
+			}
+		}
+
+		return {
+			found: true,
+			query: { file, line, column: explicitColumn },
+			projectRoot,
+			results,
+		}
+	} catch (error) {
+		return {
+			error:
+				error instanceof Error
+					? error.message
+					: `SourceKit-LSP failed: ${String(error)}`,
+			hint: "Install the Swift toolchain and ensure sourcekit-lsp is on PATH, or set SOURCEKIT_LSP to its full path.",
+		}
+	} finally {
+		await client.dispose()
+	}
+}
+
+const plugin: AgentPlugin = {
+	name: "swift-lsp",
+	manifest: {
+		capabilities: ["tools"],
+	},
+
+	setup(api, ctx) {
+		sessionWorkspaceRoot = ctx.workspaceInfo?.rootPath
+		api.registerTool({
+			name: "swift_goto_definition",
+			description:
+				"Find Swift symbol definitions using SourceKit-LSP. Given a .swift file and 1-based line number, resolves identifiers on that line. Provide column for a specific position.",
+			inputSchema: {
+				type: "object",
+				properties: {
+					file: {
+						type: "string",
+						description: "Absolute or workspace-relative path to a .swift file.",
+					},
+					line: {
+						type: "integer",
+						description: "Line number, 1-based.",
+					},
+					column: {
+						type: "integer",
+						description:
+							"Optional column number, 1-based. If omitted, all identifiers on the line are checked.",
+					},
+				},
+				required: ["file", "line"],
+				additionalProperties: false,
+			},
+			timeoutMs: 30_000,
+			retryable: false,
+			async execute(input: unknown) {
+				return resolveSwiftDefinitions(asObject(input) as SwiftGotoDefinitionInput)
+			},
+		})
+	},
+}
+
+export { plugin, resolveSwiftDefinitions }
+export default plugin


### PR DESCRIPTION
## Swift LSP

Adds Swift definition lookup for Cline through SourceKit-LSP.

The plugin exposes a single tool, `swift_goto_definition(file, line, column?)`. Given a Swift file and 1-based line number, it starts `sourcekit-lsp` on demand, opens the file over the Language Server Protocol, and returns any symbol definitions SourceKit can resolve. When `column` is omitted, it checks up to five identifiers on the requested line so the agent can use the tool similarly to the existing TypeScript definition lookup plugin.

## Cline Primitives

This is a tool-only plugin:

- `tools`: registers `swift_goto_definition`.

It does not register MCP servers, write MCP settings, install hooks, or start SourceKit during plugin installation. The language server process is short-lived and starts only when the tool is called.

## Requirements

Users need a Swift workspace and `sourcekit-lsp` available on `PATH`, usually from Xcode or the Swift toolchain. If the binary is elsewhere, set `SOURCEKIT_LSP=/absolute/path/to/sourcekit-lsp`.

Relative file paths resolve from the active Cline workspace. Absolute file paths are accepted only when they stay inside that workspace, so the tool does not accidentally launch SourceKit against unrelated local projects. In nested Swift package repos, the tool starts SourceKit from the nearest `Package.swift` or git root within the workspace.
