### PR TITLE
feat: add teamcity-cli plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Each plugin lives in `plugins/<slug>`. The directory name is the install keyword
 | `mac-notify` | macOS notifications when a Cline run completes. |
 | `nanobanana` | Image generation through OpenRouter and Gemini image models. |
 | `speak` | Speaks completed Cline replies with ElevenLabs text to speech. |
+| `teamcity-cli` | TeamCity CLI skill for build investigation, logs, pipelines, agents, and CI troubleshooting. |
 | `typescript-lsp` | TypeScript language service `goto_definition` support. |
 | `weather-metrics` | Demo weather tool plus runtime metrics hooks. |
 | `web-search` | Exa-backed web search as a Cline tool. |

--- a/plugins/teamcity-cli/LICENSE.teamcity-cli
+++ b/plugins/teamcity-cli/LICENSE.teamcity-cli
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 JetBrains s.r.o.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/plugins/teamcity-cli/README.md
+++ b/plugins/teamcity-cli/README.md
@@ -1,0 +1,24 @@
+# TeamCity CLI
+
+This plugin bundles a Cline skill for working with TeamCity through the user-installed `teamcity` CLI.
+
+It helps Cline inspect builds, diagnose failed runs, read logs and tests, reason about snapshot dependency chains, validate Kotlin DSL and pipeline YAML, and guide safer TeamCity CLI usage.
+
+## Cline Primitives
+
+- Skill: `teamcity-cli` provides TeamCity command reference, output-format guidance, and CI troubleshooting workflows.
+- Rule: `teamcity-cli-safety` keeps TeamCity operations read-first and requires explicit confirmation for server mutations, secrets, remote agent access, and build/pipeline changes.
+
+## Requirements
+
+Install and authenticate the TeamCity CLI before using the skill:
+
+```bash
+teamcity auth status
+```
+
+The plugin does not install the CLI, register MCP servers, store credentials, or contact TeamCity during installation.
+
+## Attribution
+
+The bundled TeamCity CLI skill material is derived from JetBrains TeamCity CLI guidance, licensed under Apache-2.0. See `LICENSE.teamcity-cli`.

--- a/plugins/teamcity-cli/index.ts
+++ b/plugins/teamcity-cli/index.ts
@@ -1,0 +1,25 @@
+import type { AgentPlugin } from "@cline/sdk"
+
+const teamcitySafetyRule = [
+	"TeamCity CLI workflows can read CI data, mutate server state, start or cancel builds, edit pipelines, manage secrets, and open remote agent shells.",
+	"When using the teamcity CLI, prefer read-only discovery first: auth status, list, view, log, tests, changes, tree, and validate commands.",
+	"Ask for explicit user confirmation before TeamCity mutations: run start/restart/cancel/pin/unpin/tag/untag/comment, queue approve/remove/top, job/project/parameter edits, connection/VCS/pool/agent changes, project token put/get, pipeline create/push/delete, raw API writes, artifact downloads outside a temp or user-approved path, or remote agent exec/term/reboot.",
+	"Do not paste or print TeamCity tokens, GitHub personal access tokens, Docker registry passwords, or retrieved secure-token values. Prefer stdin, service accounts, TeamCity project tokens, and GitHub App connections.",
+	"Never delete or skip tests, disable linting/static analysis, commit, push, force-push, or repeat the same CI fix loop without explicit user approval and a fresh diagnosis.",
+].join("\n")
+
+const plugin: AgentPlugin = {
+	name: "teamcity-cli",
+	manifest: {
+		capabilities: ["skills", "rules"],
+	},
+	setup(api) {
+		api.registerRule({
+			id: "teamcity-cli-safety",
+			source: "teamcity-cli",
+			content: teamcitySafetyRule,
+		})
+	},
+}
+
+export default plugin

--- a/plugins/teamcity-cli/package.json
+++ b/plugins/teamcity-cli/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "teamcity-cli",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "Cline plugin that bundles TeamCity CLI workflow guidance.",
+  "cline": {
+    "plugins": [
+      {
+        "paths": [
+          "./index.ts"
+        ],
+        "capabilities": [
+          "skills",
+          "rules"
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/teamcity-cli/skills/teamcity-cli/SKILL.md
+++ b/plugins/teamcity-cli/skills/teamcity-cli/SKILL.md
@@ -1,0 +1,72 @@
+---
+name: teamcity-cli
+version: 1.0.0
+description: Use when working with TeamCity CI/CD or when a user provides a TeamCity build URL - drives the `teamcity` CLI for builds, logs, jobs, queues, agents, pools, projects, and pipelines.
+---
+
+# TeamCity CLI (`teamcity`)
+
+## Quick Start
+
+```bash
+teamcity auth status                    # Check authentication
+teamcity run list --status failure      # Find failed builds
+teamcity run log <id> --failed --raw    # Full failure diagnostics
+```
+
+__Do not guess flags or syntax.__ Use the [command reference](references/commands.md) or `teamcity <command> --help`. Builds are __runs__ (`teamcity run`); build configurations are __jobs__ (`teamcity job`). Never use `--count` - use `--limit` (or `-n`).
+
+## Gotchas
+
+- __Composite builds have empty logs__ - drill into child builds for the actual failure.
+- __Build chains fail bottom-up__ - deepest failed dependency is the root cause. Use `teamcity run tree <id>`.
+- __`--local-changes` excludes Kotlin DSL__ - push `.teamcity/` changes before running.
+- __`TEAMCITY_URL` alone bypasses stored auth__ - set both `TEAMCITY_URL` and `TEAMCITY_TOKEN`, or leave unset.
+- __Logs__: use `--raw` and dump to a temp file. __Builds__: use `--watch` when starting them.
+- __VCS triggers aren't always wired up__ - after pushing a fix you may need to start builds manually.
+- __`pipeline push` does not validate__ - always `teamcity pipeline validate` first.
+- __GitHub VCS roots: use a GitHub App connection.__ Never paste a PAT via `--auth password`. See [workflows](references/workflows.md).
+
+## Cline Compatibility
+
+- This skill assumes the user has installed and authenticated the `teamcity` CLI. Do not install it, run auth flows, or contact TeamCity unless the user asks.
+- Start with read-only commands whenever possible: `auth status`, `list`, `view`, `log`, `tests`, `changes`, `tree`, `settings status`, and validation commands.
+- Ask before mutating TeamCity state: starting/restarting/canceling builds, pin/tag/comment metadata changes, queue changes, job/project/parameter edits, project token put/get, connection/VCS changes, pipeline pushes/deletes, agent enable/disable/exec/term/reboot, raw API writes, or artifact downloads outside a temp/user-approved path.
+- Ask before committing or pushing repository changes, even when a TeamCity verification workflow recommends it.
+- Use temp files for large logs and artifacts unless the user asks to write them into the workspace.
+- The source background build-monitoring agent is intentionally not installed here. Use the "Monitoring Builds Until Green" workflow as an explicit, user-steered loop.
+
+## Core Commands
+
+| Area      | Commands                                                                                          |
+|-----------|---------------------------------------------------------------------------------------------------|
+| Auth      | `auth login`, `logout`, `status`                                                                  |
+| Builds    | `run list`, `view`, `start`, `watch`, `log`, `cancel`, `restart`, `tests`, `changes`, `tree`      |
+| Artifacts | `run artifacts`, `run download`                                                                   |
+| Metadata  | `run pin/unpin`, `run tag/untag`, `run comment`                                                   |
+| Jobs      | `job list`, `view`, `create`, `tree`, `pause/resume`, `step list/view/add/delete`, `param list/get/set/delete`, `settings list/get/set` |
+| Projects  | `project list`, `view`, `create`, `tree`, `param`, `token put/get`, `settings export/status`      |
+| VCS/Conn  | `project vcs list/view/create/delete`, `project connection list/create/authorize/delete`          |
+| Queue     | `queue list`, `approve`, `remove`, `top`                                                          |
+| Agents    | `agent list`, `view`, `enable/disable`, `authorize/deauthorize`, `exec`, `term`, `reboot`, `move` |
+| Pools     | `pool list`, `view`, `link/unlink`                                                                |
+| Pipelines | `pipeline list`, `view`, `create`, `validate`, `pull`, `push`, `schema`, `delete`                 |
+| API       | `teamcity api <endpoint>` - raw REST access                                                       |
+| Link      | `teamcity link` - bind repo via `teamcity.toml`                                                   |
+
+## Quick Workflows
+
+See [Workflows](references/workflows.md) for full details on each.
+
+- __Investigate failure__: `run list --status failure` -> `run log <id> --failed --raw` -> `run tests <id> --failed`
+- __Debug build chain__: `run tree <id>` -> drill to deepest failed child
+- __Fix and verify__: edit -> push -> `run start --watch` (use `--local-changes` for personal builds)
+- __Pipeline lifecycle__: `pipeline pull <id>` -> edit -> `pipeline validate` -> `pipeline push <id>`, `pipeline schema` to get the actual schema from the server
+- __GitHub VCS__: `connection create github-app` -> `connection authorize` -> install App on repo -> `vcs create --auth token --connection-id <id>`
+- __Docker registry__: `echo $TOKEN | connection create docker -p <id> --name X --url https://ghcr.io --username U --stdin`
+
+## References
+
+- [Command reference](references/commands.md) - all commands and flags
+- [Workflows](references/workflows.md) - failure investigation, build chains, connections, pipelines
+- [Output formats](references/output.md) - JSON, plain text, scripting

--- a/plugins/teamcity-cli/skills/teamcity-cli/references/commands.md
+++ b/plugins/teamcity-cli/skills/teamcity-cli/references/commands.md
@@ -1,0 +1,538 @@
+# Command Reference
+
+## Contents
+
+- Authentication (`teamcity auth`)
+- Builds/Runs (`teamcity run`)
+- Jobs (`teamcity job`)
+- Projects (`teamcity project`)
+- Queue (`teamcity queue`)
+- Agents (`teamcity agent`)
+- Agent Pools (`teamcity pool`)
+- Pipelines (`teamcity pipeline`)
+- Configuration (`teamcity config`)
+- Direct API (`teamcity api`)
+- Global Flags
+- List Output Flags
+
+## Authentication (`teamcity auth`)
+
+| Command                        | Description                       |
+|--------------------------------|-----------------------------------|
+| `teamcity auth login -s <url>` | Authenticate with TeamCity server |
+| `teamcity auth logout`         | Log out from current server       |
+| `teamcity auth status`         | Show auth status and server info  |
+
+Login options:
+- `-s, --server <url>` - TeamCity server URL
+- `-t, --token <token>` - Access token
+- `--insecure-storage` - Store token in plain text config file instead of system keyring
+
+Environment override note:
+- `TEAMCITY_URL` + `TEAMCITY_TOKEN` should be set together when overriding auth in scripts
+- `TEAMCITY_URL` alone bypasses stored `teamcity auth login` credentials
+- `TEAMCITY_HEADER_*` adds an HTTP header to every request: `TEAMCITY_HEADER_FOO_BAR=baz` sends `Foo-Bar: baz`. Use this for proxies that gate access (Cloudflare Access, Google IAP). Values are redacted in `--verbose` output.
+
+## Builds/Runs (`teamcity run`)
+
+| Command                          | Description              |
+|----------------------------------|--------------------------|
+| `teamcity run list`              | List recent builds       |
+| `teamcity run view <id>`         | View build details       |
+| `teamcity run start <job-id>`    | Start a new build        |
+| `teamcity run cancel <id>`       | Cancel a build           |
+| `teamcity run restart <id>`      | Restart a build          |
+| `teamcity run watch <id>`        | Watch build in real-time |
+| `teamcity run log <id>`          | View build log           |
+| `teamcity run tests <id>`        | View test results        |
+| `teamcity run changes <id>`      | View VCS changes         |
+| `teamcity run artifacts <id>`    | List artifacts           |
+| `teamcity run download <id>`     | Download artifacts       |
+| `teamcity run pin <id>`          | Pin build                |
+| `teamcity run unpin <id>`        | Unpin build              |
+| `teamcity run tag <id> <tags>`   | Add tags                 |
+| `teamcity run untag <id> <tags>` | Remove tags              |
+| `teamcity run comment <id>`      | Manage comments          |
+| `teamcity run tree <id>`        | Show snapshot dependency tree for a run |
+
+### Flags for `teamcity run list`
+
+Shows all branches and all build states (including canceled, personal, composite sub-builds) by default - matching the TeamCity UI. Use `--branch` to narrow to a specific branch, or `--branch @this` to use the current git branch.
+
+- `-j, --job <id>` - Filter by job
+- `-b, --branch <name>` - Filter by branch (`@this` = current git branch)
+- `--status <status>` - Filter: success, failure, running, queued, error, unknown
+- `-u, --user <name>` - Filter by user
+- `--favorites` - Show favorite builds for the current user
+- `-p, --project <id>` - Filter by project
+- `-n, --limit <n>` - Limit results (default: 30)
+- `--since <time>` - Since time (e.g., 24h, 7d, 2w, 2026-01-01)
+- `--until <time>` - Until time (e.g., 12h, 7d, 2026-01-02)
+- `--json` - JSON output (use `--json=` to list fields, `--json=f1,f2` for specific)
+- `--plain` - Plain text output for scripting
+- `--no-header` - Omit header row (use with --plain)
+- `-w, --web` - Open in browser
+
+### Flags for `teamcity run start`
+
+- `-b, --branch <name>` - Branch to build
+- `--revision <sha>` - Pin build to a specific Git commit SHA
+- `-P, --param <k=v>` - Build parameter (repeatable)
+- `-S, --system <k=v>` - System property (repeatable)
+- `-E, --env <k=v>` - Environment variable (repeatable)
+- `-t, --tag <tag>` - Add tag (repeatable)
+- `-m, --comment <text>` - Run comment
+- `--watch` - Watch after starting
+- `-i, --interval <s>` - Refresh interval in seconds when watching (default: 3)
+- `--timeout <duration>` - Timeout when watching (e.g., 30m, 1h); implies --watch
+- `--clean` - Clean checkout
+- `--agent <id>` - Run on specific agent
+- `--personal` - Run as personal build
+- `-l, --local-changes` - Include local changes (git, -, or path)
+- `--no-push` - Skip auto-push of branch to remote
+- `--rebuild-deps` - Rebuild all dependencies
+- `--rebuild-failed-deps` - Rebuild failed/incomplete dependencies
+- `--reuse-deps <id,...>` - Reuse existing builds as snapshot dependencies (comma-separated IDs)
+- `--top` - Add to top of queue
+- `--dry-run` - Show what would be triggered without running
+- `--json` - Output as JSON (for scripting)
+- `-w, --web` - Open run in browser
+
+### Flags for `teamcity run log`
+
+- `--failed` - Show failure summary (problems and failed tests)
+- `-j, --job <id>` - Get log for latest run of this job
+- `-f, --follow` - Stream log output in real-time until build finishes
+- `--tail <N>` - Show last N log messages
+- `--raw` - Show raw log without formatting
+- `--json` - Output as JSON
+- `-w, --web` - Open build log in browser
+
+### Flags for `teamcity run watch`
+
+- `-i, --interval <s>` - Refresh interval in seconds
+- `--logs` - Stream build logs while watching
+- `--quiet` - Minimal output, show only state changes and result
+- `--json` - Wait for completion and output result as JSON
+- `--timeout <duration>` - Timeout duration (e.g., 30m, 1h)
+
+### Flags for `teamcity run view`
+
+- `--json` - Output as JSON
+- `-w, --web` - Open in browser
+
+### Flags for `teamcity run tests`
+
+- `--failed` - Show only failed tests, excluding muted failures
+- `--muted` - Show only muted failed tests
+- `-j, --job <id>` - Get tests for latest run of this job
+- `--json` - Output as JSON
+- `-n, --limit <n>` - Maximum number of tests to show
+
+### Flags for `teamcity run changes`
+
+- `--json` - Output as JSON
+- `--no-files` - Hide file list, show commits only
+
+### Flags for `teamcity run artifacts`
+
+- `-j, --job <id>` - List artifacts from latest run of this job
+- `-p, --path <subdir>` - Browse artifacts under this subdirectory
+- `--json` - Output as JSON
+
+### Flags for `teamcity run download`
+
+- `-a, --artifact <pattern>` - Artifact name pattern to filter (matches full path and basename)
+- `-p, --path <subdir>` - Download artifacts under this subdirectory
+- `-o, --output <path>` - Local directory to save artifacts to
+
+### Flags for `teamcity run cancel`
+
+- `--comment <text>` - Comment for cancellation
+- `-y, --yes` - Skip confirmation prompt
+
+### Flags for `teamcity run restart`
+
+- `--watch` - Watch the new run after restarting
+- `-i, --interval <s>` - Refresh interval in seconds when watching (default: 3)
+- `--timeout <duration>` - Timeout when watching (e.g., 30m, 1h); implies --watch
+- `-w, --web` - Open run in browser
+
+### Flags for `teamcity run pin`
+
+- `-m, --comment <text>` - Comment explaining why the run is pinned
+
+### Flags for `teamcity run comment`
+
+- `--delete` - Delete the comment
+
+### Flags for `teamcity run tree`
+
+- `-d, --depth <n>` - Limit tree depth (0 = unlimited)
+- `--json` - Output as JSON
+
+## Jobs (`teamcity job`)
+
+| Command                              | Description               |
+|--------------------------------------|---------------------------|
+| `teamcity job create <name>`               | Create a job                   |
+| `teamcity job list`                        | List build configurations      |
+| `teamcity job view <id>`                   | View job details               |
+| `teamcity job tree <id>`                   | Show snapshot dependency tree  |
+| `teamcity job pause <id>`                  | Pause job                      |
+| `teamcity job resume <id>`                 | Resume job                     |
+| `teamcity job param list <id>`             | List parameters                |
+| `teamcity job param get <id> <name>`       | Get parameter                  |
+| `teamcity job param set <id> <name> <val>` | Set parameter                  |
+| `teamcity job param delete <id> <name>`    | Delete parameter               |
+| `teamcity job step list <id>`              | List build steps               |
+| `teamcity job step view <id> <step-id>`    | View build step details        |
+| `teamcity job step add <id> --type <r>`    | Add a build step               |
+| `teamcity job step delete <id> <step-id>`  | Delete a build step            |
+| `teamcity job settings list <id>`             | List settings                  |
+| `teamcity job settings get <id> <name>`       | Get a setting value            |
+| `teamcity job settings set <id> <name> <val>` | Set a setting value            |
+
+### Flags for `teamcity job create`
+
+- `-p, --project <id>` - Parent project ID (or `TEAMCITY_PROJECT` / linked project)
+- `--id <id>` - Explicit job ID (default: auto-generated from name)
+- `--template <id>` - Create from an existing template ID
+- `--json` - Output as JSON
+- `-w, --web` - Open in browser after creation
+
+### Flags for `teamcity job list`
+
+- `--json` - JSON output (use `--json=` to list fields, `--json=f1,f2` for specific)
+- `-n, --limit <n>` - Maximum number of jobs
+- `-p, --project <id>` - Filter by project ID
+
+### Flags for `teamcity job view`
+
+- `--json` - Output as JSON
+- `-w, --web` - Open in browser
+
+### Flags for `teamcity job tree`
+
+- `-d, --depth <n>` - Limit tree depth (0 = unlimited)
+- `--only <type>` - Show only `dependents` or `dependencies`
+
+### Flags for `teamcity job param list`
+
+- `--json` - Output as JSON
+
+### Flags for `teamcity job param set`
+
+- `--secure` - Mark as secure/password parameter
+
+### Flags for `teamcity job step add`
+
+- `--type <runner-id>` - Runner type ID as used by the REST API: `simpleRunner` (Command Line), `gradle-runner` (Gradle), `Maven2` (Maven), ... (required). Find IDs via `teamcity job step view`.
+- `--name <name>` - Step name
+- `--param <key=value>` - Step parameter (repeatable)
+- `--json` - Output as JSON
+
+The `<id>` (job) positional is optional when the repo is linked; `delete` accepts `remove`/`rm` aliases.
+
+## Projects (`teamcity project`)
+
+| Command                                        | Description                  |
+|------------------------------------------------|------------------------------|
+| `teamcity project list`                        | List projects                |
+| `teamcity project view <id>`                   | View project details         |
+| `teamcity project create <name>`               | Create a project             |
+| `teamcity project tree [id]`                   | Show project hierarchy tree  |
+| `teamcity project vcs list --project <id>`     | List VCS roots               |
+| `teamcity project vcs view <id>`              | View VCS root details        |
+| `teamcity project vcs create --project <id>`  | Create VCS root (interactive or flag-driven) |
+| `teamcity project vcs delete <id>`            | Delete a VCS root            |
+| `teamcity project connection list -p <id>`    | List project connections     |
+| `teamcity project connection create github-app -p <id>` | Register GitHub App (manifest flow) |
+| `teamcity project connection create docker -p <id>`    | Register Docker registry credentials |
+| `teamcity project connection authorize <conn-id> -p <id>` | Per-user OAuth dance for an OAuth connection |
+| `teamcity project connection delete <conn-id> -p <id>` | Delete a connection         |
+| `teamcity project param list <id>`             | List parameters              |
+| `teamcity project param get <id> <name>`       | Get parameter                |
+| `teamcity project param set <id> <name> <val>` | Set parameter                |
+| `teamcity project param delete <id> <name>`    | Delete parameter             |
+| `teamcity project token put <id>`              | Store secret, get token      |
+| `teamcity project token get <id> <token>`      | Retrieve secret              |
+| `teamcity project settings export <id>`        | Export settings as ZIP       |
+| `teamcity project settings status <id>`        | Show versioned settings sync |
+| `teamcity project settings validate [path]`    | Validate Kotlin DSL config   |
+
+### Flags for `teamcity project tree`
+
+- `-d, --depth <n>` - Limit tree depth (0 = unlimited)
+- `--no-jobs` - Hide build configurations
+
+### Flags for `teamcity project list`
+
+- `--json` - JSON output (use `--json=` to list fields, `--json=f1,f2` for specific)
+- `-n, --limit <n>` - Maximum number of projects
+- `-p, --parent <id>` - Filter by parent project ID
+
+### Flags for `teamcity project view`
+
+- `--json` - Output as JSON
+- `-w, --web` - Open in browser
+
+### Flags for `teamcity project create`
+
+- `--id <id>` - Explicit project ID (default: auto-generated from name)
+- `-p, --parent <id>` - Parent project ID (default: `_Root`)
+- `--json` - Output as JSON
+- `-w, --web` - Open in browser after creation
+
+### Flags for `teamcity project vcs list`
+
+- `--json` - JSON output (use `--json=` to list fields, `--json=f1,f2` for specific)
+- `-n, --limit <n>` - Maximum number of VCS roots
+- `-p, --project <id>` - Project ID (required)
+
+### Flags for `teamcity project vcs view`
+
+- `--json` - Output as JSON
+- `-w, --web` - Open in browser
+
+### Flags for `teamcity project vcs delete`
+
+- `-y, --yes` - Skip confirmation prompt
+
+### Flags for `teamcity project param list`
+
+- `--json` - Output as JSON
+
+### Flags for `teamcity project param set`
+
+- `--secure` - Mark as secure/password parameter
+
+### Flags for `teamcity project settings export`
+
+- `--kotlin` - Export as Kotlin DSL (default)
+- `--xml` - Export as XML
+- `-o, --output <path>` - Output file path (default: projectSettings.zip)
+- `--relative-ids` - Use relative IDs in exported settings
+
+### Flags for `teamcity project settings status`
+
+- `--json` - Output as JSON
+
+### Flags for `teamcity project settings validate`
+
+- `--verbose` - Show full Maven output
+- Positional argument: optional filesystem path to `.teamcity` (not a project ID/name; there is no `--dir` flag)
+
+### Flags for `teamcity project token put`
+
+- `--stdin` - Read value from stdin
+
+## Queue (`teamcity queue`)
+
+| Command                       | Description           |
+|-------------------------------|-----------------------|
+| `teamcity queue list`         | List queued builds    |
+| `teamcity queue remove <id>`  | Remove from queue     |
+| `teamcity queue top <id>`     | Move to top of queue  |
+| `teamcity queue approve <id>` | Approve waiting build |
+
+### Flags for `teamcity queue list`
+
+- `-j, --job <id>` - Filter by job ID
+- `--json` - JSON output (use `--json=` to list fields, `--json=f1,f2` for specific)
+- `-n, --limit <n>` - Maximum number of queued runs
+
+### Flags for `teamcity queue remove`
+
+- `-y, --yes` - Skip confirmation prompt
+
+## Agents (`teamcity agent`)
+
+| Command                           | Description                       |
+|-----------------------------------|-----------------------------------|
+| `teamcity agent list`             | List build agents                 |
+| `teamcity agent view <id>`        | View agent details                |
+| `teamcity agent authorize <id>`   | Authorize agent to run builds     |
+| `teamcity agent deauthorize <id>` | Revoke agent authorization        |
+| `teamcity agent enable <id>`      | Enable agent                      |
+| `teamcity agent disable <id>`     | Disable agent                     |
+| `teamcity agent move <id> <pool>` | Move agent to different pool      |
+| `teamcity agent jobs <id>`        | List compatible/incompatible jobs |
+| `teamcity agent exec <id> <cmd>`  | Execute command on agent          |
+| `teamcity agent term <id>`        | Open interactive shell on agent   |
+| `teamcity agent reboot <id>`      | Reboot a build agent              |
+
+### Flags for `teamcity agent list`
+
+- `-p, --pool <name>` - Filter by agent pool
+- `--connected` - Show only connected agents
+- `--enabled` - Show only enabled agents
+- `--authorized` - Show only authorized agents
+- `-n, --limit <n>` - Limit results
+- `--json` - JSON output (use `--json=` to list fields, `--json=f1,f2` for specific)
+
+### Flags for `teamcity agent view`
+
+- `--json` - Output as JSON
+- `-w, --web` - Open in browser
+
+### Flags for `teamcity agent jobs`
+
+- `--incompatible` - Show incompatible jobs with reasons
+- `--json` - Output as JSON
+
+### Flags for `teamcity agent exec`
+
+- `--timeout <duration>` - Command timeout
+
+### Flags for `teamcity agent reboot`
+
+- `--graceful` - Wait for current build to finish before rebooting
+- `-y, --yes` - Skip confirmation prompt
+
+## Agent Pools (`teamcity pool`)
+
+| Command                          | Description              |
+|----------------------------------|--------------------------|
+| `teamcity pool list`                   | List agent pools         |
+| `teamcity pool view <id>`              | View pool details        |
+| `teamcity pool link <id> <project>`    | Link project to pool     |
+| `teamcity pool unlink <id> <project>`  | Unlink project from pool |
+
+### Flags for `teamcity pool list`
+
+- `--json` - JSON output (use `--json=` to list fields, `--json=f1,f2` for specific)
+
+### Flags for `teamcity pool view`
+
+- `--json` - Output as JSON
+- `-w, --web` - Open in browser
+
+## Pipelines (`teamcity pipeline`)
+
+Pipelines are YAML-first build configurations. Each pipeline is a project that can contain multiple jobs defined in a `.teamcity.yml` file. Pipelines differ from jobs/build configs: they use YAML for configuration and can be stored in VCS or on the server.
+
+| Command                                  | Description                              |
+|------------------------------------------|------------------------------------------|
+| `teamcity pipeline list`                 | List pipelines                           |
+| `teamcity pipeline view <id>`            | View pipeline details                    |
+| `teamcity pipeline create <name>`        | Create pipeline from YAML                |
+| `teamcity pipeline validate [file]`      | Validate pipeline YAML against schema    |
+| `teamcity pipeline pull <id>`            | Download pipeline YAML                   |
+| `teamcity pipeline push <id> [file]`     | Upload pipeline YAML                     |
+| `teamcity pipeline delete <id>`          | Delete a pipeline                        |
+
+### Flags for `teamcity pipeline list`
+
+- `-p, --project <id>` - Filter by project ID
+- `-n, --limit <n>` - Maximum number of items (default: 30)
+- `--json` - JSON output (use `--json=` to list fields, `--json=f1,f2` for specific)
+- `--plain` - Plain text output for scripting
+- `--no-header` - Omit header row
+
+### Flags for `teamcity pipeline view`
+
+- `--json` - Output as JSON
+- `-w, --web` - Open in browser
+
+### Flags for `teamcity pipeline create`
+
+- `-p, --project <id>` - Parent project ID __(required)__
+- `--vcs-root <id>` - VCS root ID (interactive selection if omitted)
+- `-f, --file <path>` - Pipeline YAML file (default: `.teamcity.yml`)
+
+### Flags for `teamcity pipeline validate`
+
+- `--schema <path>` - Local JSON schema file (overrides server schema)
+- `--refresh-schema` - Force re-fetch schema from server
+
+### Flags for `teamcity pipeline pull`
+
+- `-o, --output <path>` - Write YAML to file instead of stdout
+
+### Flags for `teamcity pipeline delete`
+
+- `-y, --yes` - Skip confirmation prompt
+
+## Configuration (`teamcity config`)
+
+| Command                               | Description                    |
+|---------------------------------------|--------------------------------|
+| `teamcity config list`                | List all configuration values  |
+| `teamcity config get <key>`           | Get a configuration value      |
+| `teamcity config set <key> <value>`   | Set a configuration value      |
+
+Valid keys: `default_server`, `guest`, `ro`, `token_expiry`.
+
+Per-server keys (`guest`, `ro`, `token_expiry`) use `--server <url>` to target a specific server. Without `--server`, the default server is used.
+
+### Flags for `teamcity config list`
+
+- `--json` - Output as JSON
+
+### Flags for `teamcity config get` and `set`
+
+- `-s, --server <url>` - Server URL for per-server settings
+
+### Examples
+
+```bash
+# Switch default server
+teamcity config set default_server tc.example.com
+
+# Enable read-only mode
+teamcity config set ro true --server tc.example.com
+
+# Check current default server
+teamcity config get default_server
+```
+
+## Direct API (`teamcity api`)
+
+For features not covered by specific commands. Endpoints always start with `/app/rest/`.
+Pass only the endpoint path as the first argument (never include `GET`, `POST`, etc. in the path).
+
+```bash
+# GET request
+teamcity api '/app/rest/server'
+
+# POST request
+teamcity api '/app/rest/buildQueue' -X POST -f 'buildType=id:MyBuild'
+
+# With pagination
+teamcity api '/app/rest/builds' --paginate --slurp
+
+# Browse artifact subdirectory
+teamcity api '/app/rest/builds/id:BUILD_ID/artifacts/children/SUBPATH'
+```
+
+### Flags
+
+- `-X, --method <method>` - HTTP method
+- `-H, --header <h>` - Custom header (repeatable)
+- `-f, --field <k=v>` - Body field (builds JSON)
+- `--input <file>` - Read body from file (use - for stdin)
+- `--paginate` - Fetch all pages
+- `--slurp` - Combine pages into array (requires --paginate)
+- `--raw` - Output raw response without formatting
+- `--silent` - Suppress output on success
+- `-i, --include` - Include response headers in output
+
+## Global Flags
+
+Available on all commands:
+
+- `-h, --help` - Help for command
+- `-v, --version` - Version information
+- `--no-color` - Disable colored output
+- `-q, --quiet` - Suppress non-essential output
+- `--verbose` - Show detailed output including debug info
+- `--no-input` - Disable interactive prompts
+- `-w, --web` - Open in browser (on view commands)
+
+## List Output Flags
+
+Available on all list commands (`run list`, `agent list`, `job list`, `pool list`, `project list`, `queue list`, `project vcs list`, `pipeline list`) and on `agent jobs`, `project param list`, `job param list`:
+
+- `--plain` - Tab-separated plain text output for scripting (mutually exclusive with `--json`)
+- `--no-header` - Omit header row (use with `--plain`)

--- a/plugins/teamcity-cli/skills/teamcity-cli/references/output.md
+++ b/plugins/teamcity-cli/skills/teamcity-cli/references/output.md
@@ -1,0 +1,123 @@
+# Output Formats
+
+Most commands support multiple output formats for different use cases.
+
+## Available Formats
+
+| Format          | Flag          | Use Case                       |
+|-----------------|---------------|--------------------------------|
+| Table (default) | none          | Human-readable, colored output |
+| Plain text      | `--plain`     | Scripting, parsing             |
+| JSON            | `--json`      | Programmatic access            |
+| No color        | `--no-color`  | Logs, CI environments          |
+| No header       | `--no-header` | Clean output for piping        |
+
+## JSON Output
+
+__Default JSON (all fields):__
+```bash
+teamcity run list --json
+```
+
+__List available fields:__
+```bash
+teamcity run list --json=
+```
+
+__Select specific fields:__
+```bash
+teamcity run list --json=id,status,webUrl
+```
+
+__Nested fields (dot notation):__
+```bash
+teamcity run list --json=id,buildType.name,triggered.user.username
+```
+
+## Available JSON Fields by Command
+
+| Command        | Example fields                                                                                                                                                                                        |
+|----------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `run list`     | `id`, `number`, `status`, `state`, `branchName`, `buildTypeId`, `buildType.name`, `buildType.projectName`, `triggered.type`, `triggered.user.name`, `agent.name`, `startDate`, `finishDate`, `webUrl` |
+| `job list`     | `id`, `name`, `projectName`, `projectId`, `paused`, `href`, `webUrl`                                                                                                                                  |
+| `project list` | `id`, `name`, `description`, `parentProjectId`, `href`, `webUrl`                                                                                                                                      |
+| `queue list`   | `id`, `buildTypeId`, `state`, `branchName`, `queuedDate`, `buildType.name`, `triggered.user.name`, `webUrl`                                                                                           |
+| `agent list`   | `id`, `name`, `connected`, `enabled`, `authorized`, `pool.name`, `webUrl`                                                                                                                             |
+| `pool list`    | `id`, `name`, `maxAgents`                                                                                                                                                                             |
+| `pipeline list`| `id`, `name`, `webUrl`, `parentProject.id`, `parentProject.name`, `headBuildType.id`, `jobs.count`                                                                                                    |
+
+Run `teamcity <command> --json=` to see all available fields for that command.
+
+## Scripting Examples
+
+__Get build IDs of failed builds:__
+```bash
+teamcity run list --status failure --plain --no-header | awk '{print $2}'
+```
+
+__JSON with jq:__
+```bash
+teamcity run list --json | jq '.[] | {id, status, branch}'
+```
+
+__Get build IDs that failed (JSON):__
+```bash
+teamcity run list --status failure --json=id | jq -r '.[].id'
+```
+
+__Export runs to CSV:__
+```bash
+teamcity run list --json=id,status,branchName | jq -r '.[] | [.id,.status,.branchName] | @csv'
+```
+
+__Filter builds by pattern:__
+```bash
+teamcity run list --json | jq '.[] | select(.branch | contains("feature"))'
+```
+
+__Count builds by status:__
+```bash
+teamcity run list --json | jq 'group_by(.status) | map({status: .[0].status, count: length})'
+```
+
+__Get web URLs for queued builds:__
+```bash
+teamcity queue list --json=webUrl | jq -r '.[].webUrl'
+```
+
+## Environment Variables
+
+For non-interactive use (CI/CD, scripts):
+
+```bash
+export TEAMCITY_URL="https://teamcity.example.com"
+export TEAMCITY_TOKEN="your-api-token"
+
+# Commands will use these automatically
+teamcity run list
+```
+
+Environment variables always take precedence over config file settings.
+
+Other supported variables:
+- `TEAMCITY_GUEST=1` - use guest authentication
+- `TEAMCITY_RO=1` - read-only mode (block write operations)
+- `TEAMCITY_NO_UPDATE=1` - disable automatic update checks
+- `NO_COLOR` or `TEAMCITY_NO_COLOR` - disable colored output
+
+## Combining with Other Tools
+
+__Open in browser:__
+```bash
+teamcity run view <id> -w
+```
+
+__Pipe to less with color:__
+```bash
+teamcity run list | less -R
+```
+
+__Watch and notify:__
+```bash
+teamcity run watch <id> && notify-send "Build complete"
+```

--- a/plugins/teamcity-cli/skills/teamcity-cli/references/workflows.md
+++ b/plugins/teamcity-cli/skills/teamcity-cli/references/workflows.md
@@ -1,0 +1,951 @@
+# Common Workflows
+
+## Contents
+
+- Inspecting a build from a TeamCity URL
+- Investigating a build failure
+- Starting and monitoring builds
+- Personal builds (local changes)
+- Finding jobs and projects
+- Working with build artifacts
+- Build metadata (pin/unpin, tag, comment)
+- Managing the build queue
+- Managing job and project parameters
+- Validating Kotlin DSL locally
+- Project connections (GitHub App, Docker)
+- VCS roots
+- Project settings (export & status)
+- Secure tokens
+- Managing agents
+- Remote agent access (term, exec)
+- Managing agent pools
+- Failure classification
+- Build chain debugging
+- Fixing a build failure
+- Monitoring builds until green
+- Test reliability analysis
+- Working with pipelines
+- Tips
+- Troubleshooting
+
+## Inspecting a Build from a TeamCity URL
+
+When a user provides a TeamCity URL, parse it and map to `teamcity` commands.
+
+__Format 1: Specific build__ - `https://host/buildConfiguration/ConfigId/12345`
+```bash
+# Extract build ID (last numeric path segment): 12345
+teamcity run view 12345
+# If failed:
+teamcity run log 12345 --failed --raw
+teamcity run tests 12345 --failed
+```
+
+__Format 2: Build configuration__ - `https://host/buildConfiguration/ConfigId`
+```bash
+# Extract config ID (last non-numeric path segment): ConfigId
+teamcity run list --job ConfigId
+```
+
+__Format 3: Project__ - `https://host/project/ProjectId`
+```bash
+# Extract project ID: ProjectId
+teamcity job list --project ProjectId
+```
+
+Strip query params (`?mode=builds`) and fragments (`#all-projects`) before parsing.
+
+## Investigating a Build Failure
+
+When a build has __FAILURE__ status, proactively suggest: `teamcity run log <id> --failed` (failure summary), `teamcity run tests <id> --failed` (failed tests), `teamcity run changes <id>` (triggering changes).
+
+For __composite/matrix builds__ (snapshot dependencies, no agent), find failed children with `teamcity run list --status failure` and appropriate filters.
+
+1. __Find the failed build:__
+   ```bash
+   teamcity run list --status failure -n 10
+   ```
+
+2. __View build details:__
+   ```bash
+   teamcity run view <run-id>
+   ```
+
+3. __Check the build log:__
+   ```bash
+   teamcity run log <run-id> --raw
+   ```
+
+   Always use `--raw` to avoid interactive terminal formatting. Dump the output to a temp file to re-read it as needed.
+
+   For failed steps only:
+   ```bash
+   teamcity run log <run-id> --failed
+   ```
+
+4. __View test results:__
+   ```bash
+   teamcity run tests <run-id>
+   ```
+
+   For failed tests only:
+   ```bash
+   teamcity run tests <run-id> --failed
+   ```
+
+5. __See what changes triggered the build:__
+   ```bash
+   teamcity run changes <run-id>
+   ```
+
+## Starting and Monitoring Builds
+
+> __Always use `--watch`__ when starting builds to wait until the build finishes before proceeding.
+> __Always verify the branch name__ - do not guess. Check with `git branch` or `teamcity run list --job <job-id>` to see valid branches.
+
+__Start a build:__
+```bash
+teamcity run start <job-id> --watch
+```
+
+__Start with specific branch:__
+```bash
+teamcity run start <job-id> --branch feature/my-branch --watch
+```
+
+__Start with parameters:__
+```bash
+teamcity run start <job-id> -P "param1=value1" -P "param2=value2"
+```
+
+__Start with env vars and system properties:__
+```bash
+teamcity run start <job-id> -P version=1.0 -S build.number=123 -E CI=true
+```
+
+__Start and watch:__
+```bash
+teamcity run start <job-id> --watch
+teamcity run start <job-id> --watch --timeout 30m
+```
+
+__Start with comment and tags:__
+```bash
+teamcity run start <job-id> --comment "Release build" --tag release --tag v1.0
+```
+
+__Start with clean checkout and rebuild deps:__
+```bash
+teamcity run start <job-id> --clean --rebuild-deps --top
+```
+
+__Dry run (see what would be triggered):__
+```bash
+teamcity run start <job-id> --dry-run
+```
+
+__Watch an existing build:__
+```bash
+teamcity run watch <run-id>
+```
+
+__Stream logs while watching:__
+```bash
+teamcity run watch <run-id> --logs
+```
+
+__Watch with timeout:__
+```bash
+teamcity run watch <run-id> --timeout 30m --quiet
+```
+
+__Wait for completion and get JSON result (for scripting):__
+```bash
+teamcity run start <job-id> --watch --json
+teamcity run watch <run-id> --json
+```
+
+## Personal Builds (Local Changes)
+
+> __Kotlin DSL caveat:__ `--local-changes` does __not__ include changes to Kotlin DSL (`.teamcity/`). Always push Kotlin DSL changes to the remote before running the build.
+
+__Run build with local git changes:__
+```bash
+teamcity run start <job-id> --local-changes
+```
+
+__Run build from a patch file:__
+```bash
+teamcity run start <job-id> --local-changes changes.patch
+```
+
+__Personal build with specific branch:__
+```bash
+teamcity run start <job-id> --personal --branch my-feature --watch
+```
+
+__Skip auto-push:__
+```bash
+teamcity run start <job-id> --local-changes --no-push
+```
+
+## Finding Jobs and Projects
+
+__List all projects:__
+```bash
+teamcity project list
+```
+
+__List sub-projects:__
+```bash
+teamcity project list --parent <project-id>
+```
+
+__Create a project:__
+```bash
+teamcity project create <name>
+teamcity project create <name> --id <id> --parent <parent-id>
+```
+
+__List jobs in a project:__
+```bash
+teamcity job list --project <project-id>
+```
+
+__View job details:__
+```bash
+teamcity job view <job-id>
+```
+
+__Search for a job by name:__
+```bash
+teamcity job list --json | jq '.[] | select(.name | contains("deploy"))'
+```
+
+## Working with Build Artifacts
+
+__List artifacts from a build:__
+```bash
+teamcity run artifacts <run-id>
+```
+
+__List artifacts from latest build of a job:__
+```bash
+teamcity run artifacts --job <job-id>
+```
+
+__Download all artifacts:__
+```bash
+teamcity run download <run-id>
+```
+
+__Download to specific directory:__
+```bash
+teamcity run download <run-id> -o ./artifacts
+```
+
+__Download a subdirectory:__
+```bash
+teamcity run download <run-id> --path build/assets
+```
+
+__Download specific artifact pattern:__
+```bash
+teamcity run download <run-id> --artifact "*.jar"
+```
+
+__Combine path and pattern:__
+```bash
+teamcity run download <run-id> --path build/assets -a "*.js"
+```
+
+## Build Metadata
+
+__Pin a build (prevent cleanup):__
+```bash
+teamcity run pin <run-id> --comment "Release candidate"
+```
+
+__Unpin a build:__
+```bash
+teamcity run unpin <run-id>
+```
+
+__Tag a build:__
+```bash
+teamcity run tag <run-id> deployed production
+```
+
+__Remove tags:__
+```bash
+teamcity run untag <run-id> deployed
+```
+
+__Add a comment:__
+```bash
+teamcity run comment <run-id> "Verified by QA"
+```
+
+__View existing comment:__
+```bash
+teamcity run comment <run-id>
+```
+
+__Delete a comment:__
+```bash
+teamcity run comment <run-id> --delete
+```
+
+## Managing the Build Queue
+
+__View queued builds:__
+```bash
+teamcity queue list
+```
+
+__Filter queue by job:__
+```bash
+teamcity queue list --job <job-id>
+```
+
+__Move a build to top of queue:__
+```bash
+teamcity queue top <run-id>
+```
+
+__Remove from queue:__
+```bash
+teamcity queue remove <run-id>
+```
+
+__Approve a build waiting for approval:__
+```bash
+teamcity queue approve <run-id>
+```
+
+## Managing Job and Project Parameters
+
+__List job parameters:__
+```bash
+teamcity job param list <job-id>
+```
+
+__Set a parameter:__
+```bash
+teamcity job param set <job-id> MY_PARAM "my value"
+```
+
+__Set a secure parameter:__
+```bash
+teamcity job param set <job-id> SECRET_KEY "____" --secure
+```
+
+__Get a parameter:__
+```bash
+teamcity job param get <job-id> MY_PARAM
+```
+
+__Delete a parameter:__
+```bash
+teamcity job param delete <job-id> MY_PARAM
+```
+
+Project parameters work the same way with `teamcity project param`.
+
+## Validating Kotlin DSL Locally
+
+__Always use `teamcity project settings validate`__ to verify Kotlin DSL - never generic `mvn compile`.
+
+Under the hood it runs `mvn teamcity-configs:generate` (or `./mvnw` when available) inside the `.teamcity/` directory, which is the only correct DSL validation step. Generic Maven commands like `mvn compile` do __not__ validate TeamCity DSL and will give misleading results.
+The optional positional argument is only a filesystem path to `.teamcity`; do __not__ pass a TeamCity project ID/name, and do __not__ invent `--dir`.
+
+```bash
+# Preferred - auto-detects .teamcity dir and Maven wrapper
+teamcity project settings validate
+
+# Explicit path
+teamcity project settings validate ./path/to/.teamcity
+
+# Show full Maven output for debugging
+teamcity project settings validate --verbose
+```
+
+If you need the raw Maven command (e.g., in CI without the CLI installed):
+```bash
+./mvnw teamcity-configs:generate -f .teamcity/pom.xml   # prefer wrapper
+mvn teamcity-configs:generate -f .teamcity/pom.xml       # fallback
+```
+
+## Project Connections
+
+Connections give jobs credentials for external services (GitHub, Docker registries, AWS, ...) without storing secrets per-job. Required before creating a VCS root that authenticates via OAuth.
+
+__Inspect existing connections in a project:__
+```bash
+teamcity project connection list --project <project-id>
+```
+
+### Connecting a GitHub repository (GitHub App)
+
+> __Always use this path for GitHub.__ Don't `vcs create --auth password` with a personal access token - PATs tie infrastructure to one human, leak in job logs, and can't be revoked centrally. The four-step flow below produces a non-personal "Refreshable access token" tied to a service-identity App, which is what the TeamCity UI's "Sign in to GitHub App" button creates.
+
+Creates a fresh GitHub App via GitHub's manifest flow - credentials are captured automatically, no PAT involved. Lets jobs clone, post commit statuses, and comment on PRs.
+
+__1. Create the connection__ (one browser click on github.com):
+
+```bash
+teamcity project connection create github-app -p <project-id>
+# prompts: Connection name (default "GitHub App"), GitHub organization (blank for personal)
+# browser auto-redirects to GitHub's "Create GitHub App" page; click Create.
+# CLI captures App ID, client ID, secret, PEM, owner URL.
+```
+
+The output prints `Next steps:` with follow-up commands and the install link. Capture the `PROJECT_EXT_NN` from the success line.
+
+__2. Authorize as the current TeamCity user__ (stores a token for `(connection × user)`):
+
+```bash
+teamcity project connection authorize PROJECT_EXT_NN -p <project-id>
+# browser opens TeamCity's OAuth page -> click Authorize on GitHub -> tab self-closes.
+```
+
+__3. Install the App on a repo__ (one-time, per repo, on github.com):
+
+Open the printed install link `https://github.com/apps/<slug>/installations/new`, pick repos, click Install.
+
+> Steps 2 and 3 are independent - order doesn't matter. Both must complete before step 4: Authorize provides the user token TeamCity uses for API calls; Install grants the App access to the repo. `vcs create` will fail without either.
+
+__4. Create the VCS root using the connection:__
+
+```bash
+teamcity project vcs create -p <project-id> \
+  --auth token \
+  --connection-id PROJECT_EXT_NN \
+  --url https://github.com/<owner>/<repo>.git
+```
+
+TeamCity auto-fills `authMethod=ACCESS_TOKEN`, `username=oauth2`, and the proper `tokenId` from the connection's stored token. No manual property setup needed; the resulting VCS root uses a non-personal "Refreshable access token" - exactly what the UI's "Sign in to GitHub App" produces.
+
+__Non-interactive (agent) variant - bring your own GitHub App credentials:__
+
+```bash
+echo "$GH_APP_CLIENT_SECRET" | teamcity project connection create github-app \
+  -p <project-id> --no-manifest \
+  --name "Backend" \
+  --owner my-org \
+  --app-id 1234567 \
+  --client-id Iv1.abc \
+  --private-key-file /path/to/key.pem \
+  --stdin
+```
+
+Skips the manifest browser flow; use when a human has already registered the App and stored its credentials in a vault.
+
+### Connecting a Docker registry
+
+For pushing images to GHCR, Docker Hub, or a private registry. Uses static credentials - always use a service account / robot user, never a personal password.
+
+```bash
+echo "$REGISTRY_TOKEN" | teamcity project connection create docker \
+  -p <project-id> \
+  --name "GHCR" \
+  --url https://ghcr.io \
+  --username my-org \
+  --stdin
+```
+
+Interactive variant prompts for each field; password is read via a secret prompt (never echoed). The connection is referenced from the Docker Image Builder runner and the `docker-support` build feature via its ID; configure those in the UI or Kotlin DSL.
+
+### Removing a connection
+
+```bash
+teamcity project connection delete PROJECT_EXT_NN -p <project-id>
+teamcity project connection delete PROJECT_EXT_NN -p <project-id> --yes   # skip confirm
+```
+
+VCS roots and build features that reference the deleted connection break - clean those up first.
+
+__Gotchas:__
+- `vcs create --auth token` test connection returns "Malformed request" if the user hasn't authorized yet. The CLI prints a tip pointing at `connection authorize`. Run that, then retry.
+- The App's per-repo install (step 2) is mandatory; without it, clones return 404 even with a valid connection.
+- Connections in a parent project are inherited by sub-projects - don't recreate the same connection in nested projects.
+- For Docker on AWS-managed ECR, prefer an AWS connection with role-based federation over Docker credentials.
+
+## VCS Roots
+
+For questions like "which repository URL and default branch does project `<id>` use", always discover attached VCS roots first, then inspect a concrete root.
+
+__List VCS roots in a project:__
+```bash
+teamcity project vcs list --project <project-id>
+```
+
+__View VCS root details:__
+```bash
+teamcity project vcs view <vcs-root-id>
+```
+
+__Required sequence for project VCS inspection:__
+1. Run `teamcity project vcs list --project <project-id>` to get valid root IDs.
+2. Run `teamcity project vcs view <vcs-root-id>` for URL, default branch, auth method, and other properties.
+3. Do not guess VCS root IDs.
+4. Do not use `teamcity project view` or `teamcity project settings status` as a substitute for VCS root details.
+
+__Create a VCS root:__
+```bash
+# Preferred for GitHub: use a GitHub App connection (see Project Connections above).
+teamcity project vcs create -p <project-id> \
+  --auth token --connection-id <connection-id> \
+  --url https://github.com/<owner>/<repo>.git
+
+# Other auth methods (use only when there is no usable connection).
+teamcity project vcs create -p <project-id> --url <url> --auth anonymous
+teamcity project vcs create -p <project-id> --url <url> --auth password --username U --stdin <<<"$PAT"
+teamcity project vcs create -p <project-id> --url <url> --auth ssh-key --ssh-key-name my-key
+```
+
+> __For GitHub repositories, always prefer the GitHub App connection path__ (`--auth token --connection-id <id>`). Pasting a personal access token via `--auth password` works but is an anti-pattern: PATs are tied to a single human, leak via job logs, and can't be revoked centrally. Use the [Connecting a GitHub repository](#connecting-a-github-repository-github-app) workflow before falling back to PAT auth.
+
+__Delete a VCS root:__
+```bash
+teamcity project vcs delete <vcs-root-id>
+teamcity project vcs delete <vcs-root-id> --yes   # skip confirmation
+```
+
+## Project Settings (Export & Status)
+
+__Check versioned settings sync status (requires server connection):__
+```bash
+teamcity project settings status <project-id>
+```
+
+__Export project settings as Kotlin DSL:__
+```bash
+teamcity project settings export <project-id>
+```
+
+__Export as XML:__
+```bash
+teamcity project settings export <project-id> --xml -o settings.zip
+```
+
+## Secure Tokens
+
+__Store a secret and get a token reference:__
+```bash
+teamcity project token put <project-id> "my-secret-password"
+```
+
+__Store from stdin (for piping):__
+```bash
+echo -n "my-secret" | teamcity project token put <project-id> --stdin
+```
+
+__Retrieve a token value (requires System Admin):__
+```bash
+teamcity project token get <project-id> "credentialsJSON:abc123..."
+```
+
+## Managing Agents
+
+__List all agents:__
+```bash
+teamcity agent list
+```
+
+__List connected agents only:__
+```bash
+teamcity agent list --connected
+```
+
+__Filter agents by pool:__
+```bash
+teamcity agent list --pool Default
+```
+
+__View agent details:__
+```bash
+teamcity agent view <agent-id>
+```
+
+__See what jobs an agent can run:__
+```bash
+teamcity agent jobs <agent-id>
+```
+
+__See why jobs are incompatible with an agent:__
+```bash
+teamcity agent jobs <agent-id> --incompatible
+```
+
+__Enable/disable an agent:__
+```bash
+teamcity agent enable <agent-id>
+teamcity agent disable <agent-id>
+```
+
+__Authorize/deauthorize an agent:__
+```bash
+teamcity agent authorize <agent-id>
+teamcity agent deauthorize <agent-id>
+```
+
+__Move agent to a different pool:__
+```bash
+teamcity agent move <agent-id> <pool-id>
+```
+
+__Reboot an agent:__
+```bash
+teamcity agent reboot <agent-id>
+```
+
+__Reboot after current build finishes:__
+```bash
+teamcity agent reboot <agent-id> --graceful
+```
+
+## Remote Agent Access
+
+__Open interactive shell on an agent:__
+```bash
+teamcity agent term <agent-id>
+```
+
+__Execute a command on an agent:__
+```bash
+teamcity agent exec <agent-id> "ls -la"
+```
+
+__Execute with timeout:__
+```bash
+teamcity agent exec <agent-id> --timeout 10m -- long-running-script.sh
+```
+
+## Managing Agent Pools
+
+__List all pools:__
+```bash
+teamcity pool list
+```
+
+__View pool details:__
+```bash
+teamcity pool view <pool-id>
+```
+
+__Link a project to a pool:__
+```bash
+teamcity pool link <pool-id> <project-id>
+```
+
+__Unlink a project from a pool:__
+```bash
+teamcity pool unlink <pool-id> <project-id>
+```
+
+## Failure Classification
+
+When a build fails, classify the failure before attempting a fix. The classification determines the fix strategy.
+
+__Decision tree:__
+
+1. __Is the build composite (no agent, has snapshot dependencies)?__
+   - Yes -> The composite build itself has no logs. Drill into child builds to find the actual failure. Use `teamcity run list --status failure` filtered to the relevant job tree.
+2. __Is the failure transient or permanent?__
+   - Transient: infrastructure timeouts, agent disconnects, OOM on agent, flaky tests (same code passes on retry). Fix: retry with `teamcity run restart <id>`.
+   - Permanent: compilation errors, test failures correlated with code changes, config errors. Fix: change code or config.
+3. __Is the failure in code, versioned settings, or server config?__
+   - Code: fix in repo, verify with `--local-changes`, push.
+   - Versioned settings (Kotlin DSL): fix in repo, validate with `teamcity project settings validate`, push. Cannot use `--local-changes`.
+   - Pipeline YAML: fix in repo, validate with `teamcity pipeline validate`, push. Cannot use `--local-changes`.
+   - Server config: fix via TeamCity UI or API. Not in repo.
+
+__Default:__ treat unknown failures as permanent until proven otherwise.
+
+__Gotchas:__
+- Composite builds have empty logs - always drill to child failures first.
+- A build can fail with "no compatible agents" - this is server config, not code.
+- `--local-changes` does NOT include Kotlin DSL or pipeline YAML stored in repo.
+
+## Build Chain Debugging
+
+TeamCity's snapshot dependency chains are unique - no competitor has this. When a build in a chain fails, the failure cascades upstream, so multiple builds may show as failed.
+
+__Find the root failure:__
+
+```bash
+# View the dependency tree for a specific build run (shows statuses)
+teamcity run tree <run-id>
+
+# Use --json for programmatic analysis
+teamcity run tree <run-id> --json
+```
+
+`run tree` shows the actual build runs with their statuses, so you can immediately see which dependency failed. Use `job tree` if you need the job-level (build configuration) dependency structure instead.
+
+__Key principle:__ The first failure in the chain (the deepest dependency that failed) is the root cause, not the last. Work bottom-up.
+
+__Steps:__
+1. Start from the build the user reported.
+2. Run `teamcity run tree <run-id>` to see the full dependency tree with statuses.
+3. Find the deepest build in the tree that has a failure status (not just "Snapshot dependency build failed").
+4. That's your root cause. Investigate its logs: `teamcity run log <id> --failed --raw`
+
+__Gotchas:__
+- Builds that fail only because a dependency failed show "Snapshot dependency build failed" - skip these and go deeper.
+- Restarting the top-level build won't help if the root child is still broken.
+- Use `run tree` (shows actual builds with statuses) for debugging failures. Use `job tree` (shows build configuration structure) for understanding the dependency graph.
+
+## Fixing a Build Failure
+
+End-to-end workflow for diagnosing and fixing a CI failure. Equivalent to GitHub's `gh-fix-ci`.
+
+### Step 1: Find and diagnose
+
+```bash
+# Get the failed build details
+teamcity run view <run-id>
+
+# Get the failure log (always use --raw, dump to temp file)
+teamcity run log <run-id> --failed --raw > /tmp/build-failure.log
+
+# Check failed tests
+teamcity run tests <run-id> --failed
+
+# See what changes triggered the build
+teamcity run changes <run-id>
+```
+
+### Step 2: Classify the failure
+
+Use the [Failure Classification](#failure-classification) decision tree above.
+
+### Step 3: Fix
+
+__For code failures:__
+1. Read the relevant source files and understand the error.
+2. Make the fix.
+3. Verify locally if possible (run tests, compile, lint).
+4. Verify on TeamCity without committing:
+   ```bash
+   teamcity run start <job-id> --local-changes --watch
+   ```
+5. Once green, commit and push.
+
+__For versioned settings failures (Kotlin DSL):__
+1. Fix the DSL code in `.teamcity/`.
+2. Validate locally:
+   ```bash
+   teamcity project settings validate
+   ```
+3. Push the fix (cannot use `--local-changes` for DSL).
+
+__For pipeline YAML failures:__
+- __Server-stored pipelines:__ pull -> fix -> validate -> push:
+  ```bash
+  teamcity pipeline pull <pipeline-id> -o /tmp/pipeline.yml
+  # edit /tmp/pipeline.yml
+  teamcity pipeline validate /tmp/pipeline.yml
+  teamcity pipeline push <pipeline-id> /tmp/pipeline.yml
+  ```
+- __VCS-stored pipelines__ (`.teamcity.yml` in repo): edit the file directly, validate, then ask before committing or pushing:
+  ```bash
+  # edit .teamcity.yml
+  teamcity pipeline validate .teamcity.yml
+  # commit and push only after explicit user approval
+  ```
+  (`pull`/`push` commands fail for VCS-backed pipelines - edit the repo file instead.)
+
+__For server config failures:__
+1. Identify the misconfiguration from the logs.
+2. Fix via TeamCity UI or `teamcity api`.
+3. Restart the build: `teamcity run restart <run-id>`
+
+### Guardrails
+
+- Never delete or skip failing tests to make the build green.
+- Never disable linting or static analysis steps.
+- Never force-push to fix a build.
+- If the fix requires changes outside your expertise, document the diagnosis and escalate.
+
+__Gotchas:__
+- Always use `--raw` for logs and dump to a temp file - build logs can be very large and lose formatting without `--raw`.
+- `--local-changes` does NOT include Kotlin DSL or pipeline YAML stored in repo. Always push DSL changes before running.
+- Composite builds have no logs of their own - drill to the child that actually failed.
+- If the build fails with a different error after your fix, that's a new failure - re-diagnose from step 1.
+
+## Monitoring Builds Until Green
+
+Loop workflow for watching a build, fixing failures, and retrying. In Cline, keep this explicit and user-steered: do not run an autonomous background fixer, and ask before build starts/restarts, TeamCity server mutations, commits, or pushes.
+
+### Loop
+
+1. __Start or watch the build:__
+   ```bash
+   teamcity run start <job-id> --branch <branch> --watch
+   # or watch an existing build:
+   teamcity run watch <run-id>
+   ```
+
+2. __If the build succeeds:__ done.
+
+3. __If the build fails:__ run the [Fixing a Build Failure](#fixing-a-build-failure) workflow above.
+
+4. __After pushing the fix:__
+   - If the job has a VCS trigger, a new build starts automatically. Poll until a build with a higher ID than the failed one appears, then watch it:
+     ```bash
+     # Poll for a build on the pushed commit:
+     teamcity run list --job <job-id> --branch <branch> --revision @head -n 1 --json
+     # Repeat until a result appears (or ~30s pass).
+     # If no new build appears, start one manually:
+     teamcity run start <job-id> --branch <branch> --watch
+     ```
+   - If no VCS trigger, start a new build manually:
+     ```bash
+     teamcity run start <job-id> --branch <branch> --watch
+     ```
+
+5. __Repeat__ from step 2.
+
+### Stop conditions
+
+- __Success:__ the build is green.
+- __Max attempts reached:__ stop after 3 fix attempts. Each attempt must make different changes - if you're repeating the same fix, something deeper is wrong.
+- __Unfixable issue:__ server config problem, missing agent, infrastructure failure, or a failure outside the scope of code changes.
+- __Same failure after fix:__ if the exact same error appears after your fix, re-examine the diagnosis - the fix may not have addressed the root cause.
+
+__Gotchas:__
+- A VCS trigger fires only when new commits are pushed to a monitored branch. If the job doesn't have a VCS trigger configured, you must start builds manually with `teamcity run start`.
+- After pushing, wait a few seconds before listing runs - the trigger needs time to pick up the change.
+- Watch for "build already running" - if a build is queued or running for the same branch, watch it instead of starting a new one.
+
+## Test Reliability Analysis
+
+Identify flaky tests by cross-referencing failures across builds. Equivalent to CircleCI's `find_flaky_tests`.
+
+### Identify potentially flaky tests
+
+```bash
+# Get failed tests from the current build
+teamcity run tests <run-id> --failed --json > /tmp/failed-tests.json
+
+# Check if the same tests failed in recent builds
+teamcity run list --job <job-id> --status failure -n 5 --json
+
+# For each recent failed build, get its failed tests
+teamcity run tests <other-run-id> --failed --json
+```
+
+### Cross-reference with code changes
+
+```bash
+# Check what changed between builds
+teamcity run changes <run-id>
+```
+
+__Flaky test indicators:__
+- Test fails intermittently across builds without corresponding code changes.
+- Test passes on retry (restart) without any code change.
+- Test fails on one agent but passes on another (environment-dependent).
+
+### What to do with flaky tests
+
+1. Document the flaky test: name, frequency, suspected cause.
+2. If `teamcity test mute` becomes available, ask before using it and include a tracking issue in the comment.
+3. Otherwise, document the suspected flaky test in the relevant issue or follow-up note.
+4. Never delete, skip, or mute a flaky test without explicit user approval and a tracking issue - it may be catching real intermittent bugs.
+
+__Gotchas:__
+- A test that fails only on certain agents may be environment-dependent, not flaky. Check agent properties with `teamcity agent view <id>`.
+- Some test frameworks report different test names on failure vs success (e.g., parameterized tests). Normalize test names before comparing.
+- Large test suites may need `--json` output piped through `jq` for efficient filtering.
+
+## Working with Pipelines
+
+Pipelines are YAML-first build configurations. Unlike jobs (build configs) that are configured via UI or Kotlin DSL, pipelines are defined in a `.teamcity.yml` file. Each pipeline is a TeamCity project containing multiple jobs.
+
+__List pipelines:__
+```bash
+teamcity pipeline list
+teamcity pipeline list --project <project-id>
+```
+
+__View pipeline details:__
+```bash
+teamcity pipeline view <pipeline-id>
+teamcity pipeline view <pipeline-id> --web   # open in browser
+```
+
+__Create a pipeline from YAML:__
+```bash
+# --vcs-root is required in non-interactive (agent) usage
+teamcity pipeline create my-pipeline --project <project-id> --vcs-root <vcs-root-id>
+
+# From a specific file
+teamcity pipeline create my-pipeline --project <project-id> --vcs-root <vcs-root-id> --file pipeline.yml
+```
+
+__Validate pipeline YAML before pushing:__
+```bash
+# Validates against server schema (cached locally for 24h)
+teamcity pipeline validate
+
+# Validate a specific file
+teamcity pipeline validate my-pipeline.yml
+
+# Force re-fetch schema from server
+teamcity pipeline validate --refresh-schema
+```
+
+__Pull/push pipeline YAML (edit-in-place workflow):__
+```bash
+# Download current YAML
+teamcity pipeline pull <pipeline-id> -o .teamcity.yml
+
+# Edit the file...
+
+# Validate before pushing
+teamcity pipeline validate .teamcity.yml
+
+# Upload changes
+teamcity pipeline push <pipeline-id> .teamcity.yml
+```
+
+__Delete a pipeline:__
+```bash
+teamcity pipeline delete <pipeline-id>
+teamcity pipeline delete <pipeline-id> --yes   # skip confirmation
+```
+
+__Gotchas:__
+- If the pipeline stores YAML in VCS (versioned settings), `pull` and `push` will return an error - edit the YAML directly in the repo instead.
+- `pipeline push` does NOT validate - always run `pipeline validate` first.
+- `pipeline create` requires `--project` and `--vcs-root` in non-interactive mode - pipelines always belong to a parent project and VCS root.
+- The default YAML file is `.teamcity.yml` in the current directory.
+
+## Tips
+
+1. __Use `--json` for programmatic access__ - Parse with `jq` for complex queries
+
+1. __Use `teamcity api` as escape hatch__ - When a specific command doesn't exist, use raw API access
+
+1. __Environment variables__ - If overriding with env vars, set both `TEAMCITY_URL` and `TEAMCITY_TOKEN`; `TEAMCITY_URL` alone bypasses stored auth
+
+1. __Open in browser__ - Most view commands support `-w` to open in web browser
+
+1. __Auto-detection from DSL__ - When working in a project with Kotlin DSL config, the server URL is auto-detected from `.teamcity/pom.xml`
+
+1. __Multiple servers__ - Use `TEAMCITY_URL` env var to switch between servers, or `teamcity auth login --server <url>` to add servers
+
+## Troubleshooting
+
+| Symptom                      | Likely Cause              | Action                                                                                  |
+|------------------------------|---------------------------|-----------------------------------------------------------------------------------------|
+| `401 Unauthorized`           | Invalid or expired token  | Run `teamcity auth status` to check; re-login with `teamcity auth login`                |
+| `403 Forbidden`              | Insufficient permissions  | Build config may require different access rights; check with TeamCity admin             |
+| `404 Not Found`              | Build deleted or wrong ID | Verify the build ID/URL; the build may have been cleaned up                             |
+| Connection refused / timeout | Server unreachable        | Check if TeamCity instance is accessible; verify server URL with `teamcity auth status` |
+| `Not authenticated`          | `TEAMCITY_URL` set without matching token, or no auth configured | Unset `TEAMCITY_URL` to use stored auth from `teamcity auth login`, or set both `TEAMCITY_URL` and `TEAMCITY_TOKEN` |
+| `No server configured`       | Missing auth config       | Run `teamcity auth login -s <url>` or set `TEAMCITY_URL` and `TEAMCITY_TOKEN` env vars  |
+| `Network access blocked by sandbox` | Sandbox proxy blocking outbound requests | Add the server domain to the sandbox `allowedDomains`, or exclude `teamcity` from sandboxing |


### PR DESCRIPTION
## TeamCity CLI

Adds a curated TeamCity CLI plugin for Cline users who already use JetBrains TeamCity for CI/CD. The plugin teaches Cline how to inspect builds, diagnose failed runs, read logs and tests, reason about snapshot dependency chains, validate Kotlin DSL and pipeline YAML, and use the `teamcity` CLI without guessing command names or flags.

## Cline Primitives

- Skill: `teamcity-cli` bundles TeamCity command reference, output-format guidance, and workflows for failure investigation, build chains, pipelines, project connections, agents, queues, artifacts, and flaky-test analysis.
- Rule: `teamcity-cli-safety` makes the workflow read-first and asks for explicit confirmation before server mutations, secrets work, remote agent shell access, artifact downloads outside temp/user-approved paths, commits, pushes, or repeated CI-fix loops.

The plugin intentionally does not register an MCP server or run any install-time setup. It also does not install the TeamCity CLI, start background build-monitoring loops, or mutate TeamCity settings on behalf of the user.

## Requirements

Users need the `teamcity` CLI installed and authenticated before the skill can do useful work:

```bash
teamcity auth status
```

TeamCity credentials, GitHub App/Docker connection credentials, project tokens, and remote agent access remain controlled by the user's local CLI/session. The plugin only bundles guidance and a prompt rule; it does not store credentials or contact TeamCity during installation.

## Trust Boundaries

TeamCity CLI can start/cancel/restart builds, edit projects/jobs/parameters, push pipeline YAML, manage queues and agents, open remote agent shells, and read or write sensitive CI metadata. The bundled rule and skill notes keep those operations explicit, steer Cline toward read-only discovery first, and require user approval before destructive or externally visible actions.
