### PR TITLE
feat: add terraform plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Each plugin lives in `plugins/<slug>`. The directory name is the install keyword
 | `mac-notify` | macOS notifications when a Cline run completes. |
 | `nanobanana` | Image generation through OpenRouter and Gemini image models. |
 | `speak` | Speaks completed Cline replies with ElevenLabs text to speech. |
+| `terraform` | Terraform MCP server for Infrastructure as Code workflows. |
 | `typescript-lsp` | TypeScript language service `goto_definition` support. |
 | `weather-metrics` | Demo weather tool plus runtime metrics hooks. |
 | `web-search` | Exa-backed web search as a Cline tool. |

--- a/plugins/terraform/README.md
+++ b/plugins/terraform/README.md
@@ -1,0 +1,31 @@
+# Terraform
+
+Register the HashiCorp Terraform MCP server for Cline.
+
+## What It Does
+
+This plugin adds a local stdio MCP server named `terraform` using Docker and the pinned `hashicorp/terraform-mcp-server:0.4.0` image. The server gives Cline Terraform ecosystem context for Infrastructure as Code workflows.
+
+The plugin also adds a Terraform safety rule so Cline starts with read-only discovery/planning, treats state and tokens as sensitive, and asks before infrastructure-changing actions.
+
+## Install
+
+```bash
+cline plugin install terraform
+```
+
+For local development from this repository:
+
+```bash
+cline plugin install ./plugins/terraform --cwd .
+```
+
+## Requirements
+
+- Docker available on the machine running Cline.
+- Network access to pull `hashicorp/terraform-mcp-server:0.4.0` the first time the MCP server starts.
+- `TFE_TOKEN` in the environment when Terraform Cloud or Terraform Enterprise access is needed.
+
+## Security Notes
+
+Terraform plans, state, variables, and Terraform Cloud tokens can expose infrastructure details and secrets. Review MCP tool calls before changing infrastructure, and do not commit or print sensitive values.

--- a/plugins/terraform/index.ts
+++ b/plugins/terraform/index.ts
@@ -1,0 +1,40 @@
+import type { AgentPlugin } from "@cline/sdk"
+
+const terraformRule = [
+	"Terraform MCP tools can inspect infrastructure metadata and may help generate or change Terraform configuration.",
+	"Prefer read-only discovery and planning first. Do not run or recommend apply, destroy, import, state mutation, workspace deletion, or credential changes without explicit user approval.",
+	"Treat Terraform state, plan output, variables, provider credentials, and TFE_TOKEN as sensitive. Do not print, commit, or persist secrets.",
+	"Before making infrastructure changes, identify the target workspace/project, provider account, environment, and blast radius.",
+].join("\n")
+
+const plugin: AgentPlugin = {
+	name: "terraform",
+	manifest: {
+		capabilities: ["mcp", "rules"],
+	},
+	setup(api) {
+		api.registerMcpServer({
+			name: "terraform",
+			transport: {
+				type: "stdio",
+				command: "docker",
+				args: [
+					"run",
+					"-i",
+					"--rm",
+					"-e",
+					"TFE_TOKEN",
+					"hashicorp/terraform-mcp-server:0.4.0",
+				],
+			},
+		})
+
+		api.registerRule({
+			id: "terraform-safety",
+			source: "terraform",
+			content: terraformRule,
+		})
+	},
+}
+
+export default plugin


### PR DESCRIPTION
# Terraform

Adds a Cline plugin for Terraform infrastructure workflows. The plugin registers HashiCorp's Terraform MCP server as a local stdio server named `terraform`, using Docker to run the pinned `hashicorp/terraform-mcp-server:0.4.0` image.

The Docker command forwards `TFE_TOKEN` from the user's environment with `-e TFE_TOKEN`, so Terraform Cloud or Terraform Enterprise credentials stay outside the plugin source and are only available when the user has explicitly set them in the Cline process environment.

## Cline Primitives

- MCP server: exposes Terraform ecosystem context and Terraform Cloud / Enterprise integration through the Terraform MCP server.
- Rule: adds Terraform-specific safety guidance so Cline prefers read-only discovery and planning first, treats state/plans/variables/tokens as sensitive, and asks before infrastructure-changing operations.

## Requirements

- Docker must be available on the machine running Cline.
- The Docker image is pulled the first time the MCP server starts; install itself does not start Docker or perform network setup.
- `TFE_TOKEN` is required only for Terraform Cloud or Terraform Enterprise access.

## Trust Boundaries

Terraform plans, state, variables, provider credentials, and Terraform Cloud tokens can expose infrastructure details and secrets. The plugin keeps credential setup external to the plugin and adds guardrails around apply/destroy/import/state/workspace-changing actions.
