### PR TITLE
feat: add Vibe Prospecting plugin

### DIFF
--- a/plugins/vibe-prospecting/README.md
+++ b/plugins/vibe-prospecting/README.md
@@ -1,0 +1,14 @@
+# Vibe Prospecting
+
+Vibe Prospecting gives Cline a guided workflow for B2B company and contact research. The bundled skill covers lead-list creation, company and prospect matching, contact enrichment, business events, technology stack filters, market sizing, and CSV export workflows through the `@vibeprospecting/vpai` CLI.
+
+## Cline Primitives
+
+- Skill: `vibe-prospecting` teaches Cline how to use the Vibe Prospecting CLI safely, including schema discovery, controlled-vocabulary autocomplete, session chaining, enrichment, event fetches, and sample-first validation.
+- Rule: `vibe-prospecting:prospecting-safety` keeps CLI execution, authentication, full-scale lead fetches, contact enrichment, and CSV exports behind explicit user intent and approval.
+
+## Requirements
+
+Use requires Node/npm access for `npx @vibeprospecting/vpai@latest` and Vibe Prospecting authentication. Prefer session-scoped `VP_API_KEY`; only run persistent `vpai config --api-key` or browser login after the user approves durable auth. The plugin does not install or run the CLI during plugin installation.
+
+Prospect records, emails, phone numbers, business events, and exports should be treated as sensitive business data. The workflow samples five entities first and waits for explicit approval before running a full export.

--- a/plugins/vibe-prospecting/index.ts
+++ b/plugins/vibe-prospecting/index.ts
@@ -1,0 +1,25 @@
+import type { AgentPlugin } from "@cline/sdk";
+
+const PLUGIN_NAME = "vibe-prospecting";
+
+const plugin: AgentPlugin = {
+	name: PLUGIN_NAME,
+	manifest: {
+		capabilities: ["skills", "rules"],
+	},
+
+	setup(api) {
+		api.registerRule({
+			id: `${PLUGIN_NAME}:prospecting-safety`,
+			source: PLUGIN_NAME,
+			content: [
+				"Vibe Prospecting is available for B2B company/contact research through its bundled skill.",
+				"Do not run `npx @vibeprospecting/vpai@latest`, install third-party packages, authenticate, fetch lead/contact data, enrich prospects, or export CSVs unless the user explicitly asks for Vibe Prospecting work.",
+				"Before any full-scale prospecting run, follow the sample-first workflow in the skill: complete the same workflow on exactly five entities, present it as a sample, then wait for explicit user approval before scaling up.",
+				"Treat prospect/contact records, emails, phone numbers, business events, and exported CSVs as sensitive business data. Do not send, upload, persist outside the workspace, or use for outreach without explicit user approval.",
+			].join("\n"),
+		});
+	},
+};
+
+export default plugin;

--- a/plugins/vibe-prospecting/package.json
+++ b/plugins/vibe-prospecting/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "vibe-prospecting",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "Cline plugin for Vibe Prospecting B2B company and contact research workflows.",
+  "exports": {
+    ".": "./index.ts"
+  },
+  "cline": {
+    "plugins": [
+      {
+        "paths": [
+          "./index.ts"
+        ],
+        "capabilities": [
+          "skills",
+          "rules"
+        ]
+      }
+    ]
+  },
+  "peerDependencies": {
+    "@cline/sdk": "*"
+  },
+  "peerDependenciesMeta": {
+    "@cline/sdk": {
+      "optional": true
+    }
+  }
+}

--- a/plugins/vibe-prospecting/skills/vibe-prospecting/SKILL.md
+++ b/plugins/vibe-prospecting/skills/vibe-prospecting/SKILL.md
@@ -1,0 +1,178 @@
+---
+name: "vibe-prospecting"
+description: "Find company & contact data. Turn your agent into a prospecting platform. Get contact information, roles, tech stack, business events, website changes, intent data. Build lead lists, research prospects, identify talent. 150M+ companies, 800M+ professionals, 50+ data sources."
+compatibility: Run with `npx @vibeprospecting/vpai@latest` after the user has configured Vibe Prospecting auth.
+metadata:
+  version: "0.1.62"
+---
+
+# Vibe Prospecting CLI
+
+Use the CLI: `npx @vibeprospecting/vpai@latest`. Treat every tool response as JSON. Do not run the CLI until the user has asked for prospecting work and Vibe Prospecting auth is configured.
+
+## Hard Rules
+
+1. Sample first, always. Run the COMPLETE workflow on exactly 5 entities (`--number-of-results 5`) before any full run. That cap is a quality gate only: Explorium can match many more rows for the same filters. Never describe those 5 rows as the full dataset, "all results," or "what the database has." Show the sample, state clearly that it is a preview and the index has more, then after explicit approval re-run the same CLI tool(s) you used in the sample chain with full-scale parameters (same `--args`, session, and filters; raise caps such as `--number-of-results` to the user's real target where that flag applies). Run `fetch-entities-statistics` only when all of your discovery `fetch-entities` filters (and any supported scope flags) are valid for statistics too - see rule 8. Never auto-export. "Find 100" still means sample 5 first, then scale up after approval.
+2. `--tool-reasoning '<user wording>'` on every real call. Use the user's request verbatim. Reuse across the whole workflow. Skip ONLY when running `<tool> --all-parameters` with no `--args`.
+3. Chain via session DB, never paste IDs. Each step prints `session_id`, `db_path`, and `table_name`. Pass `--session-id` with the `session_id` from the prior JSON output so the next command uses the same SQLite session store. With `--session-id`, `--table-name` is required for `enrich-business`, `enrich-prospects`, `fetch-businesses-events`, and `fetch-prospects-events` - pass the prior step's `table_name` exactly. For `match-*` only, `--table-name` is optional (CLI can pick the first table with the right ID column when omitted). For `fetch-entities` prospects scoped to earlier companies, use `--businesses-table-name` plus `--session-id`.
+4. `--csv` only on the final step. Intermediate steps emit JSON for chaining. Add `--csv` once, at the end.
+5. `autocomplete` first for: `naics_category`, `linkedin_category`, `company_tech_stack_tech`, `job_title`, `business_intent_topics`, `city_region`. Use returned standardized values, not raw user wording.
+6. Never invent tool parameters. Before the first `--args` execution of each distinct tool in a workflow, run `npx @vibeprospecting/vpai@latest <tool> --all-parameters` for that tool (once per tool per task unless you already printed its schema earlier in the same workflow). That command prints one JSON object to stdout: `name`, `description`, and `inputSchema` (the tool input JSON Schema). Do this even when the planned call matches the examples and you are not uncertain-examples can drift; the printed schema is authoritative. Run `--all-parameters` again if you change tools, filters, or shapes materially, or if anything still feels ambiguous. You may use examples and reference docs as shortcuts only after they align with that live schema. Build `--args` only from fields and shapes confirmed by `inputSchema` from `--all-parameters` (and examples when they match it).
+7. `--session-id` is a CLI flag (not inside `--args`). Use the `session_id` value returned by the MCP in each prior step's JSON. Omit only on the first call in a chain.
+8. `fetch-entities-statistics` only when stats supports the full fetch. Compare your planned `fetch-entities` payload to the input schema from `fetch-entities-statistics --all-parameters`. Call statistics only if every filter key, value shape, `entity_type`, and any scope you rely on (e.g. `--session-id` / `--businesses-table-name`) is accepted by the statistics tool the same way it is for `fetch-entities`. If any part of the discovery query is missing from the stats schema, unsupported, or would require a different shape, skip stats - do not call it with a partial or guessed subset. When you do call it, reuse the same `--args` filter object (and supported flags) as `fetch-entities`, plus `--tool-reasoning`. Prefer running stats before presenting the sample so you can headline 5 of [total] when the response includes a usable count. When you did not run statistics (or stats had no usable total), present Sample preview (5 rows) and tell the user Explorium has much more matching the same filters-do not quote how many remain, do not say statistics failed or a total was unavailable, and never invent a number. Call stats again before a full-scale fetch if filters or scope changed and the full fetch filter set still fits statistics.
+
+## Auth
+
+```bash
+export VP_API_KEY="<tenant-api-key>"
+VP_API_KEY="$VP_API_KEY" npx @vibeprospecting/vpai@latest --help
+```
+
+Prefer session-scoped `VP_API_KEY`. Only run persistent `vpai config --api-key` or browser login after the user approves durable auth. If the user does not have a tenant API key, follow [`login.md`](references/login.md).
+
+## Sample Gate
+
+The sample is the complete workflow on 5 entities, not a fetch preview.
+
+Universe vs sample: The 5 rows are a small fixed preview so the user can validate filters and enrichment before spending quota. The underlying match set is typically much larger (often thousands or more). Do not equate "we returned 5" with "only 5 exist." Ground volume with `fetch-entities-statistics` only when the entire planned `fetch-entities` filter set is valid for stats (rule 8); never guess a total.
+
+1. When the full fetch filter set is supported by statistics, run `fetch-entities-statistics` with the same discovery `entity_type`, `filters`, and supported CLI flags as the upcoming `fetch-entities` (per rule 8). Otherwise skip stats; still tell the user Explorium has much more for the same filters (no numeric total, no mention of statistics gaps).
+2. Fetch exactly 5 (`--number-of-results 5`).
+3. Run every subsequent step (`match-*`, `enrich-*`, `fetch-*-events`) on those 5.
+4. Show the fully enriched final rows as a markdown table with all useful columns.
+5. Stop. Wait for approval in a new message. Then run at full scale.
+
+NEVER stop after the fetch to ask for approval. Complete the full chain on 5 first.
+
+Example - user says "find 100 Israeli companies, get 30 CEOs, find contact info":
+- WRONG: fetch 5 companies → show table → ask "continue?"
+- RIGHT: when the full `fetch-entities` filter set is supported by `fetch-entities-statistics`, run stats first (same `--args` filters) → fetch 5 companies → fetch CEOs at those 5 → enrich CEOs with contacts → show final table (5 of [total] when stats gave a total; otherwise Sample preview (5 rows) plus a short line that much more matches exist for these filters-no count, no stats apology) → ask "run full 100?"
+
+### Presenting the sample
+
+Always frame the table as a sample, not the full population.
+
+- When statistics returned a usable total (you only called stats because every `fetch-entities` filter was valid for `fetch-entities-statistics`): Sample preview (5 of [total] matches) - [total] must come from `fetch-entities-statistics`, never from counting the 5 rows.
+- When you did not use a numeric total (no stats, or no usable total): Sample preview (5 rows) and one plain sentence that Explorium has much more matching these filters-do not say how many more, do not mention statistics or missing totals, never invent [total].
+
+`Results Found: [X] [entity type] from [Y] [companies/sources] [qualifier]` (optional context line)
+
+Headline: Sample preview (5 of [total] matches): only with a stats-backed [total]; otherwise Sample preview (5 rows): then a single framing line that much more records exist for the same filters (qualitative only).
+
+End with an explicit next step, for example: After you confirm, I will re-run the same tool(s) with full-scale limits (e.g. `--number-of-results [user's N]` where you used `fetch-entities`) to pull the real batch.
+
+When the preview is a subset of what the user asked for (more rows or fields available at scale), add:
+
+- With a stats-backed [total]: `More data available: Preview shows [n] of [total]. Confirm before I run the full export.`
+- Without a numeric [total]: say the preview is five rows, much more exists in Explorium for the same filters, and ask to confirm a full export-do not give a remaining count or mention why no total was shown.
+
+Do not mention export when everything the user asked for is already in chat.
+
+### Before the full export, confirm
+
+- Export size (cap on records).
+- Filter narrowing: industry, size, revenue, region, tech.
+- For prospects: title variants, dedupe by company.
+- For contacts: professional emails only or also personal/phones.
+
+## Workflow
+
+```
+0. Auth - see Auth section above (or login.md)
+1. npx @vibeprospecting/vpai@latest --help                    Discover tools
+2. Read references/<tool>.md for workflow + caveats
+3. Before the first real `--args` for each tool: `npx @vibeprospecting/vpai@latest <tool> --all-parameters` (mandatory per tool, not only when uncertain). Prints the tool input schema as JSON. Run again if the planned call diverges from what you already validated.
+4. Build `--args` only from fields confirmed by that printed input schema (examples count only when they match it). If a parameter is not confirmed there, do not use it.
+5. When the entire planned `fetch-entities` filter set (and supported flags) matches `fetch-entities-statistics` input schema per `--all-parameters`: run `fetch-entities-statistics`, then sample (5 entities, full chain) - see Sample Gate
+6. npx @vibeprospecting/vpai@latest <tool> --args '<json>' --tool-reasoning '<user request>'
+7. Chain: --session-id <session_id> [--table-name <table_name>] [--businesses-table-name <name> for prospect fetch from businesses]
+8. Final step only: add --csv
+```
+
+Reference docs:
+
+- [`autocomplete.md`](references/autocomplete.md) - controlled-vocab lookups
+- [`fetch.md`](references/fetch.md) - `fetch-entities`, `fetch-*-events`
+- [`match.md`](references/match.md) - resolve known entities to IDs
+- [`enrich.md`](references/enrich.md) - enrichment after IDs
+- [`fetch-stats.md`](references/fetch-stats.md) - counts and market sizing
+- [`login.md`](references/login.md) - auth fallback flow
+
+## Flags
+
+| Flag | Description |
+|------|-------------|
+| `--help` | List tools |
+| `--all-parameters` | Print `{ name, description, inputSchema }` to stdout (pretty-printed JSON). Run before the first `--args` for each tool in a workflow (and again if the tool or payload changes materially). Routine, not only when uncertain-the `inputSchema` field is authoritative. |
+| `--args '<json>'` | Tool arguments |
+| `--session-id <id>` | Same workflow: pass `session_id` from the previous tool's JSON (opens the shared SQLite DB under `db_path`). |
+| `--table-name <name>` | Required with `--session-id` for `enrich-business`, `enrich-prospects`, `fetch-businesses-events`, and `fetch-prospects-events` (prior step's `table_name`). Optional for `match-*` only (disambiguate when multiple tables). |
+| `--businesses-table-name <name>` | For `fetch-entities` + `entity_type: prospects`: table whose rows supply `business_id` for the filter (with `--session-id`). |
+| `--number-of-results <n>` | For `fetch-entities`: total rows across pages (CLI paginates). Omit for one raw page. |
+| `--file-path <path>` | For `match-business` / `match-prospects`: path to a CSV file to match. Each row becomes one candidate. Requires `--schema`. |
+| `--schema '<json>'` | Required with `--file-path`. JSON dict mapping CSV column headers to API field names. Business fields: `name`, `domain`. Prospect fields: `full_name`, `first_name`, `last_name`, `email`, `phone_number`, `linkedin`, `company_name`, `business_id`. |
+| `--csv` | Also write flattened CSV. Final step only. |
+
+## Filter Pattern
+
+```json
+{ "values": ["v1", "v2"], "negate": false }   // include or exclude
+{ "gte": 6, "lte": 24 }                       // range
+true | false | null                           // boolean (not wrapped)
+```
+
+## Limits
+
+| Tool | Limit |
+|------|-------|
+| `match-business` | 50 per call |
+| `match-prospects` | 40 per call |
+| `enrich-business` | 50 IDs per call |
+| `enrich-prospects` | 50 IDs per call |
+| `fetch-businesses-events` / `fetch-prospects-events` | Up to 20 IDs per MCP request (CLI chunks + merges). Pass `event_types` and `timestamp_from` in `--args`. Do not put `business_ids` / `prospect_ids` in `--args` - IDs come only from `--table-name`. |
+| `fetch-entities` | use `--number-of-results`; CLI paginates. Don't pass `next_cursor` or `page_size` manually |
+
+## Common Workflows
+
+Replace `SESSION_ID` with the `session_id` from the previous step.
+
+### VP Engineering at SaaS in NY
+
+```bash
+npx @vibeprospecting/vpai@latest autocomplete --args '{"field":"linkedin_category","query":"software"}' --tool-reasoning 'find VP Eng at SaaS in NY'
+# When every fetch-entities filter (and flags) is valid for fetch-entities-statistics (--all-parameters):
+npx @vibeprospecting/vpai@latest fetch-entities-statistics --args '{"entity_type":"prospects","filters":{"job_level":{"values":["vice president"]},"job_department":{"values":["engineering"]},"linkedin_category":{"values":["Software Development"]},"company_region_country_code":{"values":["US-NY"]},"has_email":true}}' --tool-reasoning 'find VP Eng at SaaS in NY'
+npx @vibeprospecting/vpai@latest fetch-entities --args '{"entity_type":"prospects","filters":{"job_level":{"values":["vice president"]},"job_department":{"values":["engineering"]},"linkedin_category":{"values":["Software Development"]},"company_region_country_code":{"values":["US-NY"]},"has_email":true}}' --number-of-results 5 --tool-reasoning 'find VP Eng at SaaS in NY'
+npx @vibeprospecting/vpai@latest enrich-prospects --args '{"enrichments":["contacts","profiles"]}' --session-id <session_id> --table-name <fetch_entities_table_from_prior_step> --tool-reasoning 'find VP Eng at SaaS in NY'
+```
+
+### Companies that raised + use Salesforce
+
+```bash
+npx @vibeprospecting/vpai@latest autocomplete --args '{"field":"company_tech_stack_tech","query":"salesforce"}' --tool-reasoning 'companies that raised and use Salesforce'
+# When every fetch-entities filter (and flags) is valid for fetch-entities-statistics (--all-parameters):
+npx @vibeprospecting/vpai@latest fetch-entities-statistics --args '{"entity_type":"businesses","filters":{"company_tech_stack_tech":{"values":["Salesforce"]},"events":{"values":["new_funding_round"],"last_occurrence":60}}}' --tool-reasoning 'companies that raised and use Salesforce'
+npx @vibeprospecting/vpai@latest fetch-entities --args '{"entity_type":"businesses","filters":{"company_tech_stack_tech":{"values":["Salesforce"]},"events":{"values":["new_funding_round"],"last_occurrence":60}}}' --number-of-results 5 --tool-reasoning 'companies that raised and use Salesforce'
+npx @vibeprospecting/vpai@latest fetch-businesses-events --args '{"event_types":["new_funding_round"],"timestamp_from":"2024-10-01"}' --session-id <session_id> --table-name <fetch_entities_table_from_prior_step> --tool-reasoning 'companies that raised and use Salesforce'
+```
+
+### Market sizing
+
+```bash
+npx @vibeprospecting/vpai@latest fetch-entities-statistics --args '{"entity_type":"businesses","filters":{"linkedin_category":{"values":["Hospital & Health Care"]},"company_country_code":{"values":["US"]}}}' --tool-reasoning 'market sizing US healthcare'
+```
+
+## Troubleshooting
+
+| Error | Solution |
+|-------|----------|
+| CLI install fails (`npx` unavailable, sandbox, permission denied) | Tell the user the local environment cannot run the Vibe Prospecting CLI and ask whether they want to install Node/npm support or use Vibe Prospecting outside Cline. |
+| Auth / 401 | Run Auth section above; if there is no tenant API key, follow [`login.md`](references/login.md). |
+| `Not authenticated` | Neither `~/.config/vpai/config.json` nor `VP_API_KEY` is available. Follow [`login.md`](references/login.md). |
+| Missing `session_id` in JSON / CLI refuses to chain | The MCP must return `session_id`; ensure you target production `https://vibeprospecting.explorium.ai/mcp` (embedded in the npm CLI). Pass `--session-id` with that exact string on the next step. |
+| Wrong rows used when chaining | Pass `--table-name` matching the prior step's `table_name`. |
+| `enrich-*` or `fetch-*-events` with `--session-id` but no `--table-name` | `--table-name` is required for `enrich-business`, `enrich-prospects`, `fetch-businesses-events`, and `fetch-prospects-events` whenever you pass `--session-id`. |
+| Empty results | Check filter values; run `autocomplete` for controlled-vocab fields; re-check the relevant live input schema with `<tool> --all-parameters` |
+| `linkedin_category` + `naics_category` together | Mutually exclusive - use one |
+| JSON parse error | Validate JSON; check shell quoting |
+| Timeout on `fetch-entities`, `enrich-*`, `fetch-*-events`, or `match-*` with `--file-path` | Re-run the exact same command with the same `--session-id`, `--table-name`, `--args`, and (for match) `--file-path` / `--schema`. The CLI resumes from the last checkpoint - completed ID batches are skipped, no work is repeated. If the job already completed on a prior run, the stored manifest is returned instantly with no API calls. |

--- a/plugins/vibe-prospecting/skills/vibe-prospecting/references/autocomplete.md
+++ b/plugins/vibe-prospecting/skills/vibe-prospecting/references/autocomplete.md
@@ -1,0 +1,47 @@
+# Autocomplete
+
+Run before any search that uses controlled-vocabulary fields. Returns standardized values to use verbatim in the next `fetch-entities` / `fetch-entities-statistics` call.
+
+Use the examples below when the planned autocomplete call matches them. Before the first real `--args` for `autocomplete`, run `npx @vibeprospecting/vpai@latest autocomplete --all-parameters` once (mandatory, not only when uncertain). That prints `{ name, description, inputSchema }` to stdout; use `inputSchema` for argument shapes. Never invent parameters.
+
+Output may include `session_id` - pass as `--session-id` to the next tool.
+
+## Fields that require autocomplete
+
+- `linkedin_category`
+- `naics_category`
+- `company_tech_stack_tech`
+- `job_title`
+- `business_intent_topics`
+- `city_region`
+
+## Fields that do NOT require autocomplete
+
+- `company_country_code` - ISO Alpha-2 (e.g. `"US"`, `"GB"`)
+- `company_region_country_code` - ISO 3166-2 (e.g. `"US-NY"`)
+- `company_size`, `company_revenue`, `company_age`, `job_level`, `job_department` - fixed buckets (use `--all-parameters` on `fetch-entities` / `fetch-entities-statistics` for exact allowed enum strings)
+- `website_keywords` - free text
+
+## Mutual exclusions
+
+- `linkedin_category` and `naics_category` - use one, not both.
+- `company_region_country_code` and `company_country_code` - use one.
+- `job_title` requires autocomplete; `job_level` and `job_department` do not.
+
+## Picking values
+
+- Autocomplete may return noisy variants (misspellings, spacing, compound titles). Pick the canonical clean value, usually the first clean result.
+- Multiple values broaden matching with OR logic. Don't include near-duplicates unless you want a wider search.
+- For executive title searches, prefer `job_level` plus the cleanest single `job_title` value.
+
+## Examples
+
+```bash
+npx @vibeprospecting/vpai@latest autocomplete --args '{"field":"linkedin_category","query":"software"}' --tool-reasoning '<user request>'
+npx @vibeprospecting/vpai@latest autocomplete --args '{"field":"company_tech_stack_tech","query":"salesforce"}' --tool-reasoning '<user request>'
+npx @vibeprospecting/vpai@latest autocomplete --args '{"field":"job_title","query":"data scientist"}' --tool-reasoning '<user request>'
+npx @vibeprospecting/vpai@latest autocomplete --args '{"field":"business_intent_topics","query":"cloud security"}' --tool-reasoning '<user request>'
+
+# Reuse session_id on the following fetch
+npx @vibeprospecting/vpai@latest fetch-entities --args '{"entity_type":"businesses","filters":{"linkedin_category":{"values":["Software Development"]}}}' --session-id <session_id> --number-of-results 5 --tool-reasoning '<user request>'
+```

--- a/plugins/vibe-prospecting/skills/vibe-prospecting/references/enrich.md
+++ b/plugins/vibe-prospecting/skills/vibe-prospecting/references/enrich.md
@@ -1,0 +1,55 @@
+# Enrich
+
+Run after you have business or prospect IDs.
+
+Use the examples below when the planned enrich call matches them. Before the first real `--args` for that enrich tool, run `npx @vibeprospecting/vpai@latest <tool> --all-parameters` once (mandatory per tool, not only when uncertain). That prints `{ name, description, inputSchema }`; use `inputSchema` for argument shapes. Never invent parameters.
+
+## Rules
+
+- Pass `--session-id` from the previous step. The CLI loads IDs from the session SQLite DB (`db_path` in prior output).
+- `--table-name` is required with `--session-id` for both enrich tools - pass the prior step's `table_name` exactly (no automatic table pick).
+- `--csv` only on the final step. Intermediate enrich steps that feed another tool emit JSON only.
+- Examples use five-row samples by default. After the user approves the sample, repeat the same command chain with the user's target size and add `--csv` on the final step only if the user requested an export.
+- Both tools batch large ID lists automatically (chunks of 50).
+- `business_ids` / `prospect_ids` do not need to appear in `--args` when IDs come from the session DB via `--session-id`.
+
+## `enrich-business`
+
+```bash
+# Full company intelligence
+npx @vibeprospecting/vpai@latest match-business --args '{"businesses_to_match":[{"name":"Stripe","domain":"stripe.com"}]}' --tool-reasoning '<user request>'
+npx @vibeprospecting/vpai@latest enrich-business --args '{"enrichments":["firmographics","technographics","funding-and-acquisitions","workforce-trends"]}' --session-id <session_id> --table-name <match_business_table_name> --tool-reasoning '<user request>'
+
+# Tech stack + keyword check
+npx @vibeprospecting/vpai@latest enrich-business --args '{
+  "enrichments": ["technographics","webstack","website-keywords"],
+  "parameters": {"keywords": ["AI","machine learning","LLM"]}
+}' --session-id <session_id> --table-name <match_business_table_name> --tool-reasoning '<user request>'
+
+# Public company financials
+npx @vibeprospecting/vpai@latest enrich-business --args '{
+  "enrichments": ["financial-metrics","competitive-landscape","strategic-insights"],
+  "parameters": {"date": "2024-01-01T00:00"}
+}' --session-id <session_id> --table-name <match_business_table_name> --tool-reasoning '<user request>'
+```
+
+Enrichment types: `firmographics`, `technographics`, `company-ratings`, `financial-metrics`, `funding-and-acquisitions`, `challenges`, `competitive-landscape`, `strategic-insights`, `workforce-trends`, `linkedin-posts`, `website-changes`, `website-keywords`, `webstack`, `company-hierarchies`.
+
+Caveats:
+- `financial-metrics` requires `parameters.date`.
+- `website-keywords` requires `parameters.keywords`.
+- For finding people at a company, use `fetch-entities` with `entity_type: prospects` + `business_id` filter (or businesses reference flow), not enrichment alone.
+
+## `enrich-prospects`
+
+Combine all needed enrichments in one call.
+
+```bash
+# Profile + contacts
+npx @vibeprospecting/vpai@latest fetch-entities --args '{"entity_type":"prospects","filters":{"job_level":{"values":["director"]},"job_department":{"values":["engineering"]}}}' --number-of-results 5 --tool-reasoning '<user request>'
+npx @vibeprospecting/vpai@latest enrich-prospects --args '{"enrichments":["profiles","contacts"]}' --session-id <session_id> --table-name <fetch_entities_table_name> --tool-reasoning '<user request>'
+```
+
+Enrichment types: `contacts` (emails, phones), `profiles` (name, role, work history, education), `linkedin-posts`.
+
+When `--csv` is used on the final step, output includes `csv_path` alongside `db_path`, `table_name`, and `session_id`.

--- a/plugins/vibe-prospecting/skills/vibe-prospecting/references/fetch-stats.md
+++ b/plugins/vibe-prospecting/skills/vibe-prospecting/references/fetch-stats.md
@@ -1,0 +1,20 @@
+# Fetch Stats
+
+Counts and breakdowns without fetching individual records. `fetch-entities-statistics` covers both business and prospect counts - set `entity_type` accordingly.
+
+Use the examples below when the planned stats call matches them. Before the first real `--args` for `fetch-entities-statistics`, run `npx @vibeprospecting/vpai@latest fetch-entities-statistics --all-parameters` once (mandatory, not only when uncertain). That prints `{ name, description, inputSchema }`; use `inputSchema` for argument shapes. Never invent parameters.
+
+`--session-id` is a CLI flag. Filter shape matches `fetch-entities`.
+
+## Examples
+
+```bash
+# US SaaS, 51-200
+npx @vibeprospecting/vpai@latest fetch-entities-statistics --args '{"entity_type":"businesses","filters":{"company_country_code":{"values":["US"]},"company_size":{"values":["51-200"]},"linkedin_category":{"values":["Software Development"]}}}' --tool-reasoning '<user request>'
+
+# Fintech across Europe
+npx @vibeprospecting/vpai@latest fetch-entities-statistics --args '{"entity_type":"businesses","filters":{"linkedin_category":{"values":["Financial Services"]},"company_country_code":{"values":["GB","DE","FR","NL","SE"]}}}' --tool-reasoning '<user request>'
+
+# Marketing directors in fintech
+npx @vibeprospecting/vpai@latest fetch-entities-statistics --args '{"entity_type":"prospects","filters":{"job_level":{"values":["director"]},"job_department":{"values":["marketing"]},"linkedin_category":{"values":["Financial Services"]}}}' --tool-reasoning '<user request>'
+```

--- a/plugins/vibe-prospecting/skills/vibe-prospecting/references/fetch.md
+++ b/plugins/vibe-prospecting/skills/vibe-prospecting/references/fetch.md
@@ -1,0 +1,123 @@
+# Fetch
+
+Search for businesses or prospects and retrieve event details. `fetch-entities` covers both - set `entity_type` to `businesses` or `prospects`.
+
+Use the examples below when the planned fetch call matches them. Before the first real `--args` for each fetch-related tool, run `npx @vibeprospecting/vpai@latest <tool> --all-parameters` once (mandatory per tool, not only when uncertain). That prints `{ name, description, inputSchema }`; use `inputSchema` for argument shapes. Never invent parameters.
+
+## Rules
+
+- `--session-id` is a CLI flag (not inside `--args`). Pass the `session_id` from the previous tool JSON so the CLI reuses the same session SQLite DB (`db_path`).
+- `--csv` only on the final step. Intermediate steps emit JSON for chaining.
+- Examples use five-row samples by default. After the user approves the sample, repeat the same command chain with the user's target size and add `--csv` on the final step only if the user requested an export.
+- Chain IDs: There is no `--input-file`. After match/fetch, pass `--session-id`; the CLI reads `business_id` or `prospect_id` from tables under that session. Use `--table-name` with the prior step's `table_name` - required for `fetch-businesses-events` / `fetch-prospects-events` (and for `enrich-*`); optional for `match-*` when disambiguating multiple tables.
+- Prospects at prior companies: For `fetch-entities` with `entity_type: prospects` scoped to businesses from an earlier step, pass `--session-id`, `--businesses-table-name` (table containing those `business_id` rows), and optional `--table-name` only if you need to disambiguate.
+- `--number-of-results N` collects N rows across pages automatically. Omit for one raw page.
+
+## `fetch-entities` for businesses
+
+```bash
+# US software, 51-200 employees
+npx @vibeprospecting/vpai@latest fetch-entities --args '{
+  "entity_type": "businesses",
+  "filters": {
+    "company_country_code": {"values": ["US"]},
+    "company_size": {"values": ["51-200"]},
+    "linkedin_category": {"values": ["Software Development"]}
+  }
+}' --number-of-results 5 --tool-reasoning '<user request>'
+
+# Salesforce users, exclude UK
+npx @vibeprospecting/vpai@latest fetch-entities --args '{
+  "entity_type": "businesses",
+  "filters": {
+    "company_tech_stack_tech": {"values": ["Salesforce"]},
+    "company_country_code": {"values": ["GB"], "negate": true}
+  }
+}' --number-of-results 5 --tool-reasoning '<user request>'
+
+# Recently funded private US, 3-6 yrs old
+npx @vibeprospecting/vpai@latest fetch-entities --args '{
+  "entity_type": "businesses",
+  "filters": {
+    "company_country_code": {"values": ["US"]},
+    "company_age": {"values": ["3-6"]},
+    "is_public_company": false,
+    "events": {"values": ["new_funding_round"], "last_occurrence": 60}
+  }
+}' --number-of-results 5 --tool-reasoning '<user request>'
+```
+
+## `fetch-entities` for prospects
+
+```bash
+# C-suite engineering at mid-size
+npx @vibeprospecting/vpai@latest fetch-entities --args '{
+  "entity_type": "prospects",
+  "filters": {
+    "job_level": {"values": ["c-suite"]},
+    "job_department": {"values": ["engineering"]},
+    "company_size": {"values": ["201-500"]}
+  }
+}' --number-of-results 5 --tool-reasoning '<user request>'
+```
+
+## Job filter rules
+
+- `job_title` is substring-match, not exact-match.
+- For executive searches, always combine `job_title` with `job_level` (usually `c-suite`) to remove assistants, advisors, office-of roles.
+
+```bash
+npx @vibeprospecting/vpai@latest fetch-entities --args '{
+  "entity_type": "prospects",
+  "filters": {
+    "job_title": {"values": ["chief executive officer"]},
+    "job_level": {"values": ["c-suite"]}
+  }
+}' --number-of-results 5 --tool-reasoning '<user request>'
+```
+
+## Company size pitfall
+
+`company_size` uses fixed buckets (`1-10`, `11-50`, `51-200`, `201-500`, ...). No exact `>100` cutoff. For "over 100 employees", approximate with adjacent buckets (`51-200` + `201-500`) or enrich with `firmographics` for exact headcount.
+
+## Chaining business IDs into a prospect fetch
+
+Use `--session-id` from the match/fetch-business step, `--businesses-table-name` set to the table that holds `business_id` (from prior JSON `table_name`), and filters for the prospect query inside `--args`.
+
+```bash
+# 1. Resolve companies
+npx @vibeprospecting/vpai@latest match-business --args '{"businesses_to_match":[{"name":"Acme","domain":"acme.com"}]}' --tool-reasoning '<user request>'
+# 2. Leaders at those companies (reuse session; inject business IDs via businesses table)
+npx @vibeprospecting/vpai@latest fetch-entities --args '{"entity_type":"prospects","filters":{"job_level":{"values":["director","vice president","c-suite"]}}}' --session-id <session_id> --businesses-table-name <match_business_table_name> --number-of-results 5 --tool-reasoning '<user request>'
+# 3. Enrich - pass session + fetch table name for prospect rows
+npx @vibeprospecting/vpai@latest enrich-prospects --args '{"enrichments":["contacts"]}' --session-id <session_id> --table-name <fetch_entities_table_name> --tool-reasoning '<user request>'
+```
+
+## `fetch-businesses-events` / `fetch-prospects-events`
+
+Session-based bulk events for companies or prospects you already have in the session DB (from `match-*`, `fetch-entities`, etc.).
+
+### Rules
+
+- `--session-id` and `--table-name` are required together. `--table-name` must be the prior step's `table_name` whose rows include `business_id` (business events) or `prospect_id` (prospect events).
+- Do not put `business_ids` / `prospect_ids` inside `--args`. The CLI reads IDs from the SQLite table only; this avoids oversized requests and enables chunking.
+- The CLI calls MCP with up to 20 IDs per request, runs batches concurrently (bounded), appends Partner `output_events` rows, then pivots into one output row per source entity. Output columns are `event_<event_type>` (for example `event_new_product`, `event_new_funding_round`): each cell is a JSON array string for that type (newest-first, capped per type), or an empty CSV cell when there are no events for that type.
+- `--csv` on this step writes a flattened CSV next to the session DB; the JSON manifest includes `csv_path` and `columns`.
+- Resume: If a run times out, re-run the same command (same `--session-id`, `--table-name`, `--args`). Completed ID batches are skipped until the job finishes.
+
+Before the first real events call, inspect allowed `event_types` and `--args` shape from the input JSON Schema via `fetch-businesses-events --all-parameters` / `fetch-prospects-events --all-parameters` (routine pull, not only when uncertain).
+
+### Examples
+
+```bash
+# Funding + product signals for companies from a prior fetch
+npx @vibeprospecting/vpai@latest fetch-entities --args '{"entity_type":"businesses","filters":{"events":{"values":["new_funding_round"],"last_occurrence":60}}}' --number-of-results 5 --tool-reasoning '<user request>'
+npx @vibeprospecting/vpai@latest fetch-businesses-events --args '{"event_types":["new_funding_round","new_product"],"timestamp_from":"2024-10-01"}' --session-id <session_id> --table-name <fetch_entities_table_name> --tool-reasoning '<user request>'
+
+# Match file → events (same session chain)
+npx @vibeprospecting/vpai@latest match-business --file-path ./companies.csv --schema '{"Company":"name"}' --tool-reasoning '<user request>'
+npx @vibeprospecting/vpai@latest fetch-businesses-events --args '{"event_types":["new_partnership"],"timestamp_from":"2023-01-01"}' --session-id <session_id> --table-name <match_business_table_name> --tool-reasoning '<user request>'
+
+# Prospect-level events
+npx @vibeprospecting/vpai@latest fetch-prospects-events --args '{"event_types":["prospect_changed_role"],"timestamp_from":"2024-07-01"}' --session-id <session_id> --table-name <fetch_entities_table_name> --tool-reasoning '<user request>'
+```

--- a/plugins/vibe-prospecting/skills/vibe-prospecting/references/login.md
+++ b/plugins/vibe-prospecting/skills/vibe-prospecting/references/login.md
@@ -1,0 +1,67 @@
+# vpai CLI - Login & Setup
+
+Authenticate `npx @vibeprospecting/vpai@latest` before running any Vibe Prospecting workflow.
+
+## Fast Path
+
+If the user has a tenant API key, prefer session-scoped auth from an environment variable:
+
+```bash
+export VP_API_KEY="<tenant-api-key>"
+VP_API_KEY="$VP_API_KEY" npx @vibeprospecting/vpai@latest --help
+```
+
+Do not print real keys, paste them into chat, or commit them to the workspace.
+
+Only persist the key to the CLI config after the user explicitly approves durable auth:
+
+```bash
+npx @vibeprospecting/vpai@latest config --api-key "$VP_API_KEY"
+```
+
+## Browser Login
+
+If the user does not have an API key and approves browser-based durable auth, use the CLI login flow:
+
+```bash
+npx @vibeprospecting/vpai@latest login
+```
+
+The CLI prints a browser URL and may print a user code. Ask the user to open the URL and approve the sign-in. Then poll for completion:
+
+```bash
+npx @vibeprospecting/vpai@latest login --poll
+```
+
+Repeat the poll until sign-in completes or until roughly two minutes have passed. If it does not complete, ask the user to verify the browser approval and retry the poll.
+
+## Where Auth Lives
+
+- The CLI stores durable auth in `~/.config/vpai/config.json` only after `config --api-key` or browser login.
+- `VP_API_KEY` can be used for session-scoped auth without writing a key file.
+- Keep exports, CSVs, and logs out of `~/.config/vpai/`; that directory is for CLI configuration only.
+
+## Verify
+
+```bash
+npx @vibeprospecting/vpai@latest --help
+```
+
+If the tool list prints, the CLI is ready.
+
+## Sign Out / Switch Account
+
+```bash
+npx @vibeprospecting/vpai@latest logout
+```
+
+Then repeat the API key or browser login flow.
+
+## Troubleshooting
+
+| Problem | Fix |
+|---|---|
+| `npx ... vpai` will not run | Verify Node.js and npm/npx are available, then retry. |
+| `Not authenticated` | Provide `VP_API_KEY` for the command, or ask the user to approve persistent config/browser login. |
+| Need to switch tenants | Run `npx @vibeprospecting/vpai@latest logout`, then authenticate again. |
+| `--csv` write fails (`EACCES`) | Choose a workspace-writable output path or set `TMPDIR` to a writable temp directory. |

--- a/plugins/vibe-prospecting/skills/vibe-prospecting/references/match.md
+++ b/plugins/vibe-prospecting/skills/vibe-prospecting/references/match.md
@@ -1,0 +1,62 @@
+# Match
+
+Resolve known entities to canonical IDs for follow-up enrichment or events.
+
+Use the examples below when the planned match call matches them. Before the first real `--args` for that match tool, run `npx @vibeprospecting/vpai@latest <tool> --all-parameters` once (mandatory per tool, not only when uncertain). That prints `{ name, description, inputSchema }`; use `inputSchema` for argument shapes. Never invent parameters.
+
+## Rules
+
+- `--session-id` is a CLI flag. Omit on first call; pass the `session_id` returned in JSON from each prior step.
+- `--csv` only on the final step. Intermediate steps emit JSON.
+- Chain IDs: Pass `--session-id` so the CLI reads from the session SQLite DB. Use `--table-name` when multiple tables exist. Do not paste raw IDs into `--args`.
+- Limits: `match-business` 50/call, `match-prospects` 40/call.
+
+Skip match if you already ran `fetch-entities` - those results include IDs.
+
+## CSV Upload (`--file-path` + `--schema`)
+
+Use when the user provides a CSV file of companies or people to resolve to Explorium IDs.
+
+- `--file-path <path>` - path to the CSV file.
+- `--schema '<json>'` - required. JSON dict mapping CSV column headers to API field names. Build this by inspecting the CSV headers, then map each to the correct API field below.
+
+Business API fields: `name`, `domain`
+
+Prospect API fields: `full_name`, `first_name`, `last_name` (combined into `full_name`), `email`, `phone_number`, `linkedin`, `company_name`, `business_id`
+
+The output merges all original CSV columns with the matched ID. Chain into enrich with the returned `session_id` and `table_name`.
+
+## `match-business`
+
+```bash
+# Name + domain (most accurate)
+npx @vibeprospecting/vpai@latest match-business --args '{"businesses_to_match":[{"name":"Salesforce","domain":"salesforce.com"}]}' --tool-reasoning '<user request>'
+
+# Multiple
+npx @vibeprospecting/vpai@latest match-business --args '{"businesses_to_match":[{"domain":"stripe.com"},{"name":"OpenAI"},{"name":"HubSpot","domain":"hubspot.com"}]}' --tool-reasoning '<user request>'
+
+# From CSV (user provides a file)
+npx @vibeprospecting/vpai@latest match-business --file-path /path/to/companies.csv --schema '{"Company Name":"name","Website":"domain"}' --tool-reasoning '<user request>'
+
+# Chain into enrich (same session + table from match output)
+npx @vibeprospecting/vpai@latest enrich-business --args '{"enrichments":["firmographics"]}' --session-id <session_id> --table-name <match_business_table_name> --tool-reasoning '<user request>'
+```
+
+## `match-prospects`
+
+```bash
+# By email (most reliable)
+npx @vibeprospecting/vpai@latest match-prospects --args '{"prospects_to_match":[{"email":"jane.smith@acme.com"}]}' --tool-reasoning '<user request>'
+
+# By LinkedIn
+npx @vibeprospecting/vpai@latest match-prospects --args '{"prospects_to_match":[{"linkedin":"https://linkedin.com/in/janesmith"}]}' --tool-reasoning '<user request>'
+
+# By name + company
+npx @vibeprospecting/vpai@latest match-prospects --args '{"prospects_to_match":[{"full_name":"Jane Smith","company_name":"Acme Corp"}]}' --tool-reasoning '<user request>'
+
+# From CSV (user provides a file)
+npx @vibeprospecting/vpai@latest match-prospects --file-path /path/to/people.csv --schema '{"First Name":"first_name","Last Name":"last_name","Email":"email","Company":"company_name"}' --tool-reasoning '<user request>'
+
+# Chain into enrich
+npx @vibeprospecting/vpai@latest enrich-prospects --args '{"enrichments":["contacts"]}' --session-id <session_id> --table-name <match_prospects_table_name> --tool-reasoning '<user request>'
+```


### PR DESCRIPTION
## Vibe Prospecting

Adds a Vibe Prospecting plugin for B2B company and contact research. The plugin gives Cline a guided workflow for building lead lists, matching companies and prospects, enriching contact/profile data, checking business events, using technology-stack and intent filters, and exporting results through the `@vibeprospecting/vpai` CLI.

The port keeps installation inert: installing the plugin does not run `npx`, install the CLI, authenticate, contact Vibe Prospecting, or write MCP settings. Cline only uses the CLI workflow when the user asks for prospecting work.

## Cline Primitives

- Skill: `vibe-prospecting` provides the operational workflow for the Vibe Prospecting CLI, including schema discovery with `--all-parameters`, controlled-vocabulary autocomplete, session chaining via `session_id` and `table_name`, match/enrich/fetch/event workflows, market sizing, and CSV export handling.
- Rule: `vibe-prospecting:prospecting-safety` keeps CLI execution, authentication, lead/contact fetches, enrichment, and CSV exports behind explicit user intent and approval.

## Requirements

Users need Node/npm access for `npx @vibeprospecting/vpai@latest` and Vibe Prospecting auth. The skill prefers session-scoped `VP_API_KEY`; persistent `vpai config --api-key` and browser login are documented as opt-in durable auth paths.

Prospect records, emails, phone numbers, business events, and CSV exports are treated as sensitive business data. The workflow samples exactly five entities first, presents the result as a preview, and waits for explicit approval before scaling to a larger run or export.

## Safety Shape

The examples are sample-safe by default: five-row fetches and no automatic CSV export. Full-size runs reuse the same command chain only after the user approves the sample, and exports are only added on the final step when the user requested an export.
