### PR TITLE
feat: add Windsor.ai plugin

### DIFF
--- a/plugins/windsor-ai/LICENSE.windsor-ai
+++ b/plugins/windsor-ai/LICENSE.windsor-ai
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Windsor.ai
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/plugins/windsor-ai/README.md
+++ b/plugins/windsor-ai/README.md
@@ -1,0 +1,16 @@
+# Windsor.ai
+
+Windsor.ai gives Cline access to connected business data sources for marketing analytics, CRM, ecommerce, finance, sales, reporting, dashboards, and data-integration work. It can help inspect available connectors, query campaign and revenue data, generate TypeScript types from live schemas, and shape data for apps or reports.
+
+## Cline Primitives
+
+- MCP: registers the remote `windsor-ai` Streamable HTTP MCP server at `https://mcp.windsor.ai`, exposing connector discovery, field/schema inspection, and data query tools.
+- Skill: `business-data` guides Cline through Windsor.ai workflows: discover sources, inspect options and fields, query data, join connector results, and integrate results into code with explicit write approval.
+- Commands: `/campaign-report`, `/windsor-sources`, and `/windsor-types` provide quick entry points for common reporting, source-discovery, and TypeScript schema workflows.
+- Rule: `windsor-ai:business-data-safety` treats connected account metadata, business metrics, CRM records, ecommerce orders, finance data, and exports as sensitive business data.
+
+## Requirements
+
+Users need a Windsor.ai account with connectors already configured. The remote MCP server may require authorization before tools are available in Cline.
+
+The plugin does not run local setup, install dependencies, or query Windsor.ai during installation. Broad queries, all-source exploration, large date ranges, and file writes are intentionally gated behind user intent and approval.

--- a/plugins/windsor-ai/index.ts
+++ b/plugins/windsor-ai/index.ts
@@ -1,0 +1,103 @@
+import type { AgentPlugin } from "@cline/sdk";
+
+const PLUGIN_NAME = "windsor-ai";
+
+function commandPrompt(title: string, body: string): string {
+	return [`Windsor.ai ${title}`, "", body].join("\n");
+}
+
+const plugin: AgentPlugin = {
+	name: PLUGIN_NAME,
+	manifest: {
+		capabilities: ["mcp", "skills", "commands", "rules"],
+	},
+
+	setup(api) {
+		api.registerMcpServer({
+			name: "windsor-ai",
+			transport: {
+				type: "streamableHttp",
+				url: "https://mcp.windsor.ai",
+			},
+			metadata: {
+				description:
+					"Query Windsor.ai business data from marketing, sales, CRM, ecommerce, finance, and analytics connectors.",
+			},
+		});
+
+		api.registerCommand({
+			name: "campaign-report",
+			description:
+				"Generate a 30-day campaign performance report from a connected Windsor.ai source.",
+			handler() {
+				return {
+					submitPrompt: commandPrompt(
+						"campaign report",
+						[
+							"Use the Windsor.ai MCP tools to generate a campaign performance report.",
+							"Call `get_connectors` first, ask which connector/account to use unless only one obvious account exists, then inspect available fields with `get_options` if needed.",
+							"Query the last 30 days with campaign/date/spend/clicks/impressions/conversions/revenue when those fields exist, then present the top 25 campaigns sorted by spend descending plus totals for spend, clicks, and conversions.",
+							"Ask before expanding beyond the top 25 or pulling row-level/customer/contact data.",
+							"Do not write files or export data unless the user explicitly asks.",
+						].join("\n"),
+					),
+				};
+			},
+		});
+
+		api.registerCommand({
+			name: "windsor-sources",
+			description:
+				"Show connected Windsor.ai data sources and the fields available from each.",
+			handler() {
+				return {
+					submitPrompt: commandPrompt(
+						"source overview",
+						[
+							"Use the Windsor.ai MCP tools to summarize connected data sources.",
+							"Call `get_connectors`, then for connectors with accounts call `get_options` to inspect available fields.",
+							"Present a concise overview with platform name, account IDs/names when available, approximate dimensions versus metrics, and a few representative fields.",
+							"Keep the output scannable and avoid dumping full schemas unless the user asks.",
+						].join("\n"),
+					),
+				};
+			},
+		});
+
+		api.registerCommand({
+			name: "windsor-types",
+			description:
+				"Generate TypeScript type definitions for a Windsor.ai connector schema.",
+			handler(input) {
+				const requestedConnector = input.trim();
+				return {
+					submitPrompt: commandPrompt(
+						"TypeScript types",
+						[
+							requestedConnector
+								? `Generate TypeScript types for the Windsor.ai connector: ${requestedConnector}.`
+								: "Generate TypeScript types for a Windsor.ai connector. Ask which connector to use if the user has not already specified one.",
+							"Use `get_connectors` first. Ask which account to use unless only one obvious account exists, because schema discovery requires account IDs.",
+							"Use `get_options` and `get_fields` to inspect the schema for the selected connector/account.",
+							"Generate a clear exported interface with JSDoc comments from field descriptions and TypeScript types mapped from Windsor field types.",
+							"Before writing the file, propose the destination path such as `src/types/windsor-{connector}.ts` and wait for user approval.",
+						].join("\n"),
+					),
+				};
+			},
+		});
+
+		api.registerRule({
+			id: `${PLUGIN_NAME}:business-data-safety`,
+			source: PLUGIN_NAME,
+			content: [
+				"Windsor.ai exposes connected business data through the plugin-owned MCP server. Treat account IDs, marketing metrics, CRM records, ecommerce orders, finance data, and analytics exports as sensitive business data.",
+				"Do not query Windsor.ai, pull large datasets, write exports, create fixtures from real records, or generate files from live data unless the user explicitly asked for that Windsor.ai workflow.",
+				"Prefer aggregate, non-PII previews and schema inspection before broad queries. Ask before querying all sources, using large date ranges, joining multiple connectors, retrieving customer/contact/order-level rows, or writing any data-derived file to the workspace.",
+				"Prefer synthetic or anonymized fixtures. If real records are required, get explicit approval and keep generated export/fixture files out of commits by default.",
+			].join("\n"),
+		});
+	},
+};
+
+export default plugin;

--- a/plugins/windsor-ai/package.json
+++ b/plugins/windsor-ai/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "windsor-ai",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "description": "Cline plugin for Windsor.ai business data connectors and reporting workflows.",
+  "exports": {
+    ".": "./index.ts"
+  },
+  "cline": {
+    "plugins": [
+      {
+        "paths": [
+          "./index.ts"
+        ],
+        "capabilities": [
+          "mcp",
+          "skills",
+          "commands",
+          "rules"
+        ]
+      }
+    ]
+  },
+  "peerDependencies": {
+    "@cline/sdk": "*"
+  },
+  "peerDependenciesMeta": {
+    "@cline/sdk": {
+      "optional": true
+    }
+  }
+}

--- a/plugins/windsor-ai/skills/business-data/SKILL.md
+++ b/plugins/windsor-ai/skills/business-data/SKILL.md
@@ -1,0 +1,81 @@
+---
+name: "business-data"
+description: "Use Windsor.ai business data connectors for marketing analytics, CRM, sales, ecommerce, finance, and dashboard/reporting workflows."
+disable-model-invocation: false
+---
+
+# Windsor.ai Business Data Skill
+
+Use this skill when the user explicitly asks to use Windsor.ai, asks about connected Windsor.ai sources, or asks to query data from accounts already connected through Windsor.ai. Do not infer Windsor.ai usage from a generic dashboard, report, CRM, ecommerce, finance, or analytics request without first asking whether the user wants to use Windsor.ai.
+
+Do not query connected accounts, pull data, write files, generate fixtures from real data, or persist exports unless the user has explicitly asked for that Windsor.ai workflow. Treat returned business metrics, CRM records, ecommerce transactions, financial data, and account IDs as sensitive business data.
+
+## When to Use
+
+- User asks to use Windsor.ai for a dashboard, report, data visualization, integration, or data export
+- User asks about ad spend, campaign performance, ROAS, CTR, CPC, or conversion metrics from Windsor.ai-connected accounts
+- User asks to inspect Windsor.ai connectors, accounts, fields, or available data sources
+- User asks to build code against Windsor.ai connector schemas
+- User asks to create fixtures or seed data from Windsor.ai; prefer synthetic or anonymized fixtures, and use real records only after explicit approval
+
+## Available Tools
+
+Windsor.ai provides 4 MCP tools through the plugin-owned `windsor-ai` MCP server:
+
+### `get_connectors`
+Lists all connected platforms and their account IDs. Always call this first if you don't know what accounts are available.
+
+### `get_options`
+Returns available fields, date filters, and options for a specific connector. Use this to discover what data can be queried before calling `get_data`.
+
+Parameters:
+- `connector` (required): Platform ID like `"google_ads"`, `"facebook"`, `"tiktok"`, `"linkedin"`, `"googleanalytics4"`, `"hubspot"`, `"salesforce"`, `"searchconsole"`, `"instagram"`, `"youtube"`, `"google_my_business"`, `"shopify"`, `"stripe"`, `"quickbooks"`, and 300+ more
+- `accounts` (required): List of account IDs from `get_connectors`
+
+### `get_fields`
+Returns detailed metadata about specific fields - data types, descriptions, available values. Use this when you need to understand the schema before writing code that processes the data.
+
+Parameters:
+- `connector` (required): Platform ID
+- `fields` (required): List of field IDs like `["campaign", "spend", "clicks"]`
+
+### `get_data`
+Retrieves actual data. This is the main query tool.
+
+Parameters:
+- `connector` (required): Platform ID
+- `accounts` (required): List of account IDs
+- `fields` (required): Fields to retrieve, e.g. `["campaign", "date", "spend", "clicks", "impressions"]`
+- `date_from` / `date_to`: Date range as `"YYYY-MM-DD"`
+- `date_preset`: Shorthand like `"last_7d"`, `"last_30d"`, `"this_month"`, `"last_3m"`
+- `filters`: Conditions like `[["spend", "gt", 100], "and", ["campaign", "contains", "Sale"]]`
+- `options`: Connector-specific options like `{"attribution_window": "7d_view,1d_click"}`
+
+## Workflow Pattern
+
+1. Discover: Call `get_connectors` to see what's connected.
+2. Explore: Call `get_options` to see available fields for a connector.
+3. Understand: Call `get_fields` for field metadata if building typed interfaces.
+4. Query: Call `get_data` only after the connector, account, fields, date range, and intended output are clear. Default to aggregate metrics and non-PII fields.
+5. Confirm writes: Before saving queried data, generated fixtures, seed files, dashboard payloads, or TypeScript types into the workspace, summarize the destination path and get user approval.
+6. Protect outputs: Prefer synthetic/anonymized fixtures. If real records are required, ask first, keep files out of commits by default, and suggest adding export/fixture paths to `.gitignore`.
+
+## Common Field Patterns
+
+Fields vary by connector type. Here are some common examples:
+
+Marketing/Ads connectors: `campaign`, `adgroup`, `ad`, `date`, `device`, `country`, `spend`, `clicks`, `impressions`, `conversions`, `revenue`, `ctr`, `cpc`, `cpm`, `roas`
+
+CRM connectors: `deal`, `contact`, `company`, `stage`, `owner`, `amount`, `close_date`
+
+Ecommerce connectors: `order_id`, `product`, `quantity`, `price`, `status`. Treat customer/contact/order-level rows as sensitive row-level data; fetch them only when the user explicitly asks for that level of detail.
+
+Always check `get_options` first since available fields vary by connector.
+
+## Tips
+
+- When building dashboards or charts, pull small aggregate previews with `get_data`, show the preview, and ask before writing local JSON/CSV files the app can read
+- For TypeScript projects, use `get_fields` to generate accurate type definitions
+- Use `date_preset` for quick queries: `"last_7d"`, `"last_30d"`, `"this_month"`
+- Combine filters for focused queries: `[["spend", "gt", 0], "and", ["campaign", "ncontains", "test"]]`
+- You can join data from different connectors (e.g. ad spend + CRM revenue) by pulling from each and merging in code


### PR DESCRIPTION
## Windsor.ai

Adds a Windsor.ai plugin for querying connected business data sources from Cline. The plugin is shaped around marketing analytics, CRM, ecommerce, finance, sales, reporting, dashboard, and data-integration workflows where the user already has Windsor.ai connectors configured.

The plugin stays inert on install: it does not run local setup, install dependencies, query Windsor.ai, or fetch account data during installation. It registers a plugin-owned remote MCP server and leaves authorization to Cline's MCP flow.

## Cline Primitives

- MCP: registers the remote `windsor-ai` Streamable HTTP MCP server at `https://mcp.windsor.ai`, exposing connector discovery, field/schema inspection, and data query tools.
- Skill: `business-data` guides Cline through Windsor.ai workflows: discover connected sources, inspect connector options and fields, query data, join connector results, and integrate results into code with explicit approval before writes.
- Commands: `/campaign-report`, `/windsor-sources`, and `/windsor-types` provide quick entry points for campaign reporting, source discovery, and TypeScript schema generation.
- Rule: `windsor-ai:business-data-safety` treats connected account metadata, business metrics, CRM records, ecommerce orders, finance data, and exports as sensitive business data.

## Requirements

Users need a Windsor.ai account with connectors already configured. The remote MCP server may require authorization before its tools are available in Cline.

The skill is intentionally scoped to explicit Windsor.ai or Windsor-connected-source requests. For generic dashboard, report, CRM, ecommerce, finance, or analytics requests, Cline should ask before assuming Windsor.ai is the right data source.

## Safety Shape

The plugin defaults to aggregate, non-PII previews and schema inspection before broad queries. It asks before querying all sources, using large date ranges, joining multiple connectors, retrieving customer/contact/order-level rows, or writing data-derived files.

Fixture and seed-data guidance prefers synthetic or anonymized data. If real records are required, the workflow requires explicit approval and keeps generated exports or fixtures out of commits by default.
